### PR TITLE
Add support to parse a asciidoc document

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,19 @@
+ARG RUBY_IMAGE=ruby:3.1.2-slim
+
+FROM ${RUBY_IMAGE}
+
+RUN apt-get update \
+    && apt-get install -y build-essential git \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# install latest bundler
+RUN gem install bundler
+
+# Create app directory
+WORKDIR /workspace
+
+# Set bundle path
+ENV BUNDLE_PATH /bundle
+
+# Default to console
+CMD ["bin/console"]

--- a/.docker/Makefile
+++ b/.docker/Makefile
@@ -1,0 +1,35 @@
+export SPEC ?= spec
+SPEC_FILE = $(subst ../,, $(SPEC))
+export RUBY_IMAGE ?= ruby:3.1.2-slim
+
+.PHONY: up
+up:
+	docker-compose up
+
+.PHONY: down
+down:
+	docker-compose down
+
+.PHONY: test
+test: rspec
+
+.PHONY: ssh
+ssh:
+	docker-compose run lib bash
+
+.PHONY: install
+install:
+	docker-compose run lib bin/setup
+
+.PHONY: console
+console:
+	docker-compose run lib bin/console
+
+.PHONY: rspec
+rspec:
+	docker-compose run lib bin/rspec ${SPEC_FILE}
+
+.PHONY: setup
+setup:
+	docker-compose build --build-arg RUBY_IMAGE=${RUBY_IMAGE}
+	docker-compose run lib bin/setup

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+  lib:
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile
+
+    volumes:
+      - .:/workspace
+      - bundle:/bundle
+
+volumes:
+  bundle:

--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -1,0 +1,61 @@
+## Docker
+
+This directory is only meant to be used for development, and contains some
+necessary setup to spin up docker containers with multiple ruby environment.
+
+### Setup
+
+Before doing anything, you might want to create a symlink to the docker file and
+Makefile. This would allow you to avoid some of the unnecessary work related to
+the file paths To do that run the following from the root of the project.
+
+```
+ln -sf .docker/Makefile .
+ln -sf .docker/docker-compose.yml .
+```
+
+By default it usages the most recent ruby version for docker environment, but if
+you want to run it in any specific version then you can set it up by exporting
+`RUBY_IMAGE` environment variable in your shell:
+
+```sh
+export RUBY_IMAGE=ruby:3.0-buster
+```
+
+Once everything is set then you would need to build the development images for
+the first time and you can do that using:
+
+```sh
+make setup
+```
+
+The setup process will install all dependencies and it will also setup a volume
+to speed up the repeated gem installation.
+
+### Playground
+
+The `Makefile` contains two target for tests, and you can run the tests using
+any of the following commands:
+
+```sh
+make test
+
+# or
+make rspec
+```
+
+If you need more control, and you want to do some development on the go then you
+can get into the container using:
+
+```sh
+make ssh
+```
+
+### Cleanup
+
+Once you are done with your experiment then you can cleanup the docker
+environment using the following command.
+
+```sh
+make down
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+/.tmp.xml
+/test.*
+/a.*
+/spec/assets/test*
+/spec/assets/test/
+/spec/assets/extract/
+
+# rspec failure tracking
+.rspec_status
+.rubocop-https---raw-githubusercontent-com-riboseinc-oss-guides-master-ci-rubocop-yml
+Gemfile.lock
+relaton/
+.vscode/
+
+.rubocop-https--*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,13 @@ PATH
   remote: .
   specs:
     coradoc (0.1.0)
+      asciidoctor
       pry
 
 GEM
   remote: https://rubygems.org/
   specs:
+    asciidoctor (2.0.18)
     ast (2.4.2)
     coderay (1.1.3)
     diff-lcs (1.5.0)
@@ -51,6 +53,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+.docker/Makefile

--- a/README.md
+++ b/README.md
@@ -1,4 +1,55 @@
 # Coradoc
 
-Coming Soon!
+Ignore it for now!
 
+## Parsing a document
+
+```ruby
+file = "sample.adoc"
+document = Coradoc::Parser.parse(file)
+```
+
+Here are the attributes it should contains
+
+**Standard Doc**
+
+```yml
+- bibdata
+- boilerplate
+- preface
+- sections
+- annex: AnnexA
+- annex: AnnexB
+- annex: AnnexC
+- annex: AnnexD
+- annex: _extraneous_information
+- bibliography
+
+# Additional
+- extension
+- preface
+- indexsect:
+- type
+- version
+```
+
+**Bibdata**
+
+```yml
+- title: []
+- docidentifier: []
+- docnumber
+- contributor:
+    - role: []
+    - organization.name
+    - organization.abbreviation
+
+- edition
+- version
+- language
+- script
+- status
+- copyright
+- ext
+
+```

--- a/coradoc.gemspec
+++ b/coradoc.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "asciidoctor"
   spec.add_runtime_dependency "pry"
 
   # Uncomment to register a new dependency of your gem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,1 @@
+.docker/docker-compose.yml

--- a/lib/coradoc.rb
+++ b/lib/coradoc.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
-require_relative "coradoc/version"
+require "asciidoctor"
+require "coradoc/version"
+require "coradoc/document/base"
+require "coradoc/parser"
 
 module Coradoc
   class Error < StandardError; end
-  # Your code goes here...
+
+  def self.root
+    File.dirname(__dir__)
+  end
+
+  def self.root_path
+    Pathname.new(Coradoc.root)
+  end
 end

--- a/lib/coradoc/document/base.rb
+++ b/lib/coradoc/document/base.rb
@@ -1,0 +1,19 @@
+require "coradoc/document/bib_data"
+
+module Coradoc
+  module Document
+    class Base
+      attr_reader :bibdata
+
+      def initialize(asciidoc)
+        @bibdata = extract_bibdata(asciidoc)
+      end
+
+      private
+
+      def extract_bibdata(asciidoc)
+        @bibdata ||= BibData.new(asciidoc.attributes)
+      end
+    end
+  end
+end

--- a/lib/coradoc/document/bib_data.rb
+++ b/lib/coradoc/document/bib_data.rb
@@ -1,0 +1,54 @@
+module Coradoc
+  module Document
+    class BibData
+      ATTRIBUTES = [
+        :docnumber,
+        :tc_docnumber,
+        :partnumber,
+        :edition,
+        :revdate,
+        :copyright_year,
+        :language,
+        :title_intro_en,
+        :title_main_en,
+        :title_part_en,
+        :title_intro_fr,
+        :title_main_fr,
+        :title_part_fr,
+        :doctype,
+        :docstage,
+        :docsubstage,
+        :draft,
+        :technical_committee_number,
+        :secretariat,
+        :technical_committee,
+        :subcommittee_number,
+        :subcommittee,
+        :workgroup_type,
+        :workgroup_number,
+        :workgroup,
+        :library_ics,
+        :mn_document_class,
+        :mn_output_extensions,
+        :local_cache_only,
+      ]
+
+      attr_reader *ATTRIBUTES
+
+      def initialize(attributes)
+        slice_bibdata_attributes(attributes)
+      end
+
+      private
+
+      attr_writer *ATTRIBUTES
+
+      def slice_bibdata_attributes(attributes)
+        ATTRIBUTES.each do |attr|
+          value = attributes[attr.to_s] || attributes[attr.to_s.gsub("_", "-")]
+          self.send("#{attr}=", value)
+        end
+      end
+    end
+  end
+end

--- a/lib/coradoc/parser.rb
+++ b/lib/coradoc/parser.rb
@@ -1,0 +1,16 @@
+module Coradoc
+  class Parser
+    def initialize(filename)
+      @filename = filename
+    end
+
+    def self.parse(filename)
+      new(filename).parse
+    end
+
+    def parse
+      asciidoc = Asciidoctor.load_file(@filename, safe: :safe)
+      Coradoc::Document::Base.new(asciidoc)
+    end
+  end
+end

--- a/spec/coradoc/parser_spec.rb
+++ b/spec/coradoc/parser_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Parser do
+  describe ".parse" do
+    it "parses the document to metanorma document" do
+      sample_file = Coradoc.root_path.join(
+        "spec", "fixtures", "iso-sample", "rice-en.cd.sections.adoc",
+      )
+
+      document = Coradoc::Parser.parse(sample_file.to_s)
+
+      expect(document.class).to be(Coradoc::Document::Base)
+      expect(document.bibdata.class).to be(Coradoc::Document::BibData)
+      expect(document.bibdata.docnumber).to eq("173012")
+    end
+  end
+end

--- a/spec/fixtures/iso-sample/rice-en.cd.sections.adoc
+++ b/spec/fixtures/iso-sample/rice-en.cd.sections.adoc
@@ -1,0 +1,65 @@
+= Rice model
+:docnumber: 173012
+:tc-docnumber: 17301
+:partnumber: 1
+:edition: 2
+:revdate: 2016-05-01
+:copyright-year: 2016
+:language: en
+:title-intro-en: Cereals and pulses
+:title-main-en: Specifications and test methods
+:title-part-en: Rice (CD)
+:title-intro-fr: Céréales et légumineuses
+:title-main-fr: Spécification et méthodes d'essai
+:title-part-fr: Riz (CD)
+:doctype: international-standard
+:docstage: 30
+:docsubstage: 00
+:draft:
+:technical-committee-number: 34
+:secretariat: SAC
+:technical-committee: Food products
+:subcommittee-number: 4
+:subcommittee: Cereals and pulses
+:workgroup-type: WG
+:workgroup-number: 4
+:workgroup: Amylose in rice
+:library-ics: 67.060
+:mn-document-class: iso
+:mn-output-extensions: xml
+// :mn-output-extensions: xml,html,doc,html_alt,pdf,rxl
+:local-cache-only:
+
+// include::sections-en/00-foreword.adoc[]
+
+// include::sections-en/00-introduction.adoc[]
+//
+// include::sections-en/01-scope.adoc[]
+//
+// include::sections-en/02-normref.adoc[]
+//
+// include::sections-en/03-termdef.adoc[]
+//
+// include::sections-en/04-specifications.adoc[]
+//
+// include::sections-en/05-sampling.adoc[]
+//
+// include::sections-en/06-testmethods.adoc[]
+//
+// include::sections-en/07-testreport.adoc[]
+//
+// include::sections-en/08-packaging.adoc[]
+//
+// include::sections-en/09-marking.adoc[]
+//
+// include::sections-en/aa-annex-a.adoc[]
+//
+// include::sections-en/ab-annex-b.adoc[]
+//
+// include::sections-en/ac-annex-c.adoc[]
+//
+// include::sections-en/ad-annex-d.adoc[]
+//
+// include::sections-en/ae-annex-e.adoc[]
+//
+// include::sections-en/b0-bibliography.adoc[]

--- a/spec/fixtures/iso-sample/rice-en.cd.sections.xml
+++ b/spec/fixtures/iso-sample/rice-en.cd.sections.xml
@@ -1,0 +1,3000 @@
+<iso-standard
+  xmlns="https://www.metanorma.org/ns/iso" type="semantic" version="2.3.3">
+<bibdata type="standard">
+  <title language="en" format="text/plain" type="main">Cereals and pulses — Specifications and test methods — Rice (CD)</title>
+  <title language="en" format="text/plain" type="title-intro">Cereals and pulses</title>
+  <title language="en" format="text/plain" type="title-main">Specifications and test methods</title>
+  <title language="en" format="text/plain" type="title-part">Rice (CD)</title>
+  <title language="fr" format="text/plain" type="main">Céréales et légumineuses — Spécification et méthodes d’essai — Riz (CD)</title>
+  <title language="fr" format="text/plain" type="title-intro">Céréales et légumineuses</title>
+  <title language="fr" format="text/plain" type="title-main">Spécification et méthodes d’essai</title>
+  <title language="fr" format="text/plain" type="title-part">Riz (CD)</title>
+  <docidentifier type="ISO">ISO/CD 17301-1</docidentifier>
+  <docidentifier type="iso-undated">ISO/CD 17301-1</docidentifier>
+  <docidentifier type="iso-with-lang">ISO/CD 17301-1(E)</docidentifier>
+  <docidentifier type="iso-reference">ISO/CD 17301-1:2016(E)</docidentifier>
+  <docidentifier type="iso-tc">17301</docidentifier>
+  <docnumber>17301</docnumber>
+  <contributor>
+    <role type="author"/>
+    <organization>
+      <name>International Organization for Standardization</name>
+      <abbreviation>ISO</abbreviation>
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      <name>International Organization for Standardization</name>
+      <abbreviation>ISO</abbreviation>
+    </organization>
+  </contributor>
+  <edition>2</edition>
+  <version>
+    <revision-date>2016-05-01</revision-date>
+  </version>
+  <language>en</language>
+  <script>Latn</script>
+  <status>
+    <stage abbreviation="CD">30</stage>
+    <substage>00</substage>
+  </status>
+  <copyright>
+    <from>2016</from>
+    <owner>
+      <organization>
+        <name>International Organization for Standardization</name>
+        <abbreviation>ISO</abbreviation>
+      </organization>
+    </owner>
+  </copyright>
+  <ext>
+    <doctype>international-standard</doctype>
+    <editorialgroup>
+      <agency>ISO</agency>
+      <technical-committee number="34" type="TC">Food products</technical-committee>
+      <subcommittee number="4" type="SC">Cereals and pulses</subcommittee>
+      <workgroup number="4" type="WG">Amylose in rice</workgroup>
+      <secretariat>SAC</secretariat>
+    </editorialgroup>
+    <approvalgroup>
+      <agency>ISO</agency>
+      <technical-committee number="34" type="TC">Food products</technical-committee>
+      <subcommittee number="4" type="SC">Cereals and pulses</subcommittee>
+      <workgroup number="4" type="WG">Amylose in rice</workgroup>
+    </approvalgroup>
+    <ics>
+      <code>67.060</code>
+      <text>Cereals, pulses and derived products</text>
+    </ics>
+    <structuredidentifier>
+      <project-number part="1">ISO 17301</project-number>
+    </structuredidentifier>
+    <stagename>Committee draft</stagename>
+  </ext>
+</bibdata>
+<boilerplate>
+  <copyright-statement>
+    <clause>
+      <p id="boilerplate-year">© 
+      <span class="std_publisher">ISO</span>
+      <span class="std_docNumber">2016</span>
+    </p>
+    <p id="boilerplate-message">
+      All rights
+      reserved. Unless otherwise specified, or required in the context of its implementation,
+      no part of this publication may be
+      reproduced or utilized otherwise in any form or by any means, electronic or
+      mechanical, including photocopying, or posting on the internet or an intranet,
+      without prior written permission. Permission can be requested from either ISO
+      at the address below or ISO’s member body in the country of the requester.
+    </p>
+    <p id="boilerplate-address" align="left">
+      ISO copyright office
+      <br/>
+      CP 401 • Ch. de Blandonnet 8
+      <br/>
+      CH-1214 Vernier, Geneva
+      <br/>
+      Phone: +41 22 749 01 11
+      <br/>
+      Email: copyright@iso.org
+      <br/>
+      Website: www.iso.org
+
+    </p>
+    <p id="boilerplate-place">
+      Published in Switzerland
+    </p>
+  </clause>
+</copyright-statement>
+<license-statement>
+  <clause>
+    <title>Warning for WDs and CDs</title>
+    <p id="_0840af1c-9f34-b7d7-503e-b3ec992d2499">This
+    document is not an ISO International Standard. It is distributed for review and
+    comment. It is subject to change without notice and may not be referred to as
+      an International Standard.</p>
+    <p id="_8dc371d2-fa89-5e4f-69d2-5e8555da3afa">Recipients
+    of this draft are invited to submit, with their comments, notification of any
+    relevant patent rights of which they are aware and to provide supporting
+      documentation.</p>
+  </clause>
+</license-statement>
+  </boilerplate>
+  <preface>
+    <foreword id="_bd9d4d9f-9bc9-c561-06df-b51e4ddc6ab6" obligation="informative">
+      <title>Foreword</title>
+      <p id="_9c8ab905-d2d9-3934-0dfa-9764a6352dcf">ISO (the International Organization for Standardization)
+        is a worldwide federation of national standards bodies (ISO member bodies). The work of preparing International Standards is normally carried out through ISO technical committees. Each member body interested in a subject for which a technical committee has been established has the right to be represented on that committee. International organizations, governmental and non-governmental, in liaison with ISO, also take part in the work. ISO collaborates closely with the International Electrotechnical Commission (IEC) on all matters of electrotechnical standardization.</p>
+      <p id="_f1083fe6-457b-ed9f-a5a1-091fed6f8b06">The procedures used to develop this document and those intended for its further maintenance are described in the ISO/IEC Directives, Part 1. In particular the different approval criteria needed for the different types of ISO documents should be noted. This document was drafted in accordance with the editorial rules of the ISO/IEC Directives, Part 2 (see www.iso.org/directives).</p>
+      <p id="_9e049049-8b46-3d3e-97b9-eebd6fb12fcb">Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. ISO shall not be held responsible for identifying any or all such patent rights. Details of any patent rights identified during the development of the document will be in the Introduction and/or on the ISO list of patent declarations received (see www.iso.org/patents).</p>
+      <p id="_3ab973f1-2a74-b4ca-84d1-ea4900a47843">Any trade name used in this document is information given for the convenience of users and does not constitute an endorsement.</p>
+      <p id="_de7c4d87-54d1-49a0-0f1e-4d3fa697e2c0">For an explanation on the voluntary nature of standards, the meaning of ISO specific terms and expressions related to conformity assessment, as well as information about ISO’s adherence to the World Trade Organization (WTO) principles in the Technical Barriers to Trade (TBT) see the following URL: www.iso.org/iso/foreword.html.</p>
+      <p id="_cf8a2eec-abdb-514a-e600-961f73801c3e">This document was prepared by Technical Committee ISO/TC 34, 
+      <em>Food products</em>, Subcommittee SC 4, 
+      <em>Cereals and pulses</em>.
+    </p>
+    <p id="_93c384ca-f032-8bab-d056-8131047c2173">This second edition cancels and replaces the first edition (ISO 17301-1:2009), which has been technically revised.</p>
+    <p id="_12198271-eb42-170b-472f-d5d0af329b45">The main changes compared to the previous edition are:</p>
+    <ul id="_ca3422d5-3221-19bb-b747-467e6479cacd">
+      <li>
+        <p id="_69589d82-6bb9-5702-4198-137c2aef51bd">updated normative references;</p>
+      </li>
+      <li>
+        <p id="_da371c9d-d5fb-2da0-00fd-1aa1edc48f1a">deletion of 4.3.</p>
+      </li>
+    </ul>
+    <p id="_f2323128-b17e-c010-8c1b-8edbd098b394">A list of all parts in the ISO 17301 series can be found on the ISO website.</p>
+    <review id="_e761ef6b-8203-d5a1-e38a-57a1cb66e1d1" reviewer="ISO" date="2017-01-01T00:00:00Z" from="foreword" to="foreword">
+      <p id="_97c18e3e-ba89-4f93-cc8b-0aba13f4c192">A Foreword shall appear in each document. The generic text is shown here. It does not contain requirements, recommendations or permissions.</p>
+      <p id="_5ee8dd10-43c3-ce10-9abd-20153a287d78">For further information on the Foreword, see 
+      <strong>ISO/IEC Directives, Part 2, 2016, Clause 12.</strong>
+    </p>
+  </review>
+</foreword>
+<introduction id="_introduction" obligation="informative">
+  <title>Introduction</title>
+  <p id="_a0dbb31c-ed48-4522-e73c-45e28d886ecc">This document was developed in response to worldwide demand for minimum specifications for rice traded internationally, since most commercial bulks of grain, which have not been screened or aspirated, contain a proportion of other grains, weed seeds, chaff, straw, stones, sand, etc. The vegetable materials can have physical and biological properties which differ from those of the main constituent and can therefore affect the storage behaviour.</p>
+  <p id="_5d7da9c1-e0f3-2ac4-cf7b-e7e352fb8c4c">Rice is a permanent host to a considerable microflora; most of these microorganisms are cosmopolitan, the majority are innocuous, but some produce harmful by-products. Microflora communities present on freshly harvested rice include many types of bacteria, moulds and yeasts. While the rice is ripening and its moisture content is falling, the number of field microorganisms, mainly bacteria, diminishes. When the rice is harvested, it is invaded by storage microorganisms and the field microflora gradually dies out. If the mass fraction of moisture (formerly expressed as moisture content) is less than 18 %, the microflora does not multiply, whereas above 18 % it does so rapidly. Thus, at harvest, the qualitative and the quantitative composition of the microflora depends more upon ecological factors than upon the variety of the rice. During transport and storage, additions to the microfloral population occur. Microorganisms on the rice at harvest tend to die out during storage and are replaced by microorganisms adapted to storage conditions.</p>
+  <p id="_74ded5a0-4f56-c294-bc3f-bdce186a2a9d">Storage losses have been estimated as being an average of 5 %, and as much as 30 %, especially in countries with climates favourable to the rapid development of agents of deterioration and where storage techniques are poorly developed, such as developing countries in the damp tropics. The magnitude of these figures highlights the need to promote throughout the world a rapid improvement in techniques of conservation.</p>
+  <p id="_92bc22e4-4539-9196-e15c-b5a7883898de">The International Organization for Standardization (ISO) draws attention to the fact that it is claimed that compliance with this document may involve the use of a patent concerning sample dividers given in 
+  <xref target="AnnexA" style="short"/> and shown in 
+  <xref target="figureA-1" style="short"/>.
+</p>
+<p id="_03e2c7fd-3354-38e7-630e-301e22d5e2de">ISO takes no position concerning the evidence, validity and scope of this patent right.</p>
+<p id="_b25b2395-d689-b045-5df5-29af5049999e">The holder of this patent right has assured ISO that he/she is willing to negotiate licences under reasonable and non-discriminatory terms and conditions with applicants throughout the world. In this respect, the statement of the holder of this patent right is registered with ISO. Information may be obtained from:</p>
+<p id="_b9101aa2-532b-0c63-c7e4-6cfbc11872bf" align="left">Vache Equipment
+<br/>
+Fictitious
+<br/>
+World
+<br/>
+<link target="mailto:gehf@vacheequipment.fic"/>
+      </p>
+      <p id="_6ccfce7d-3835-b4d2-e7f9-bc8f124d4fdf">Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights other than those identified above. ISO shall not be held responsible for identifying any or all such patent rights.</p>
+    </introduction>
+  </preface>
+  <sections>
+    <clause id="_scope" type="scope" inline-header="false" obligation="normative">
+      <title>Scope</title>
+      <p id="_3ecdfb39-1816-d2bd-9ef5-7676eac61e6c">This document specifies minimum requirements and test methods for rice (
+      <em>Oryza sativa L.</em>).
+    </p>
+    <p id="_3303b9a8-234a-b9f0-1baa-d8cd027a378f">It is applicable to husked rice, husked parboiled rice, milled rice and milled parboiled rice, suitable for human consumption, directly or after reconditioning.</p>
+    <p id="_61c9ac36-f12b-c822-f863-23e521b5e323">It is not applicable to cooked rice products.</p>
+  </clause>
+  <terms id="_terms_and_definitions" obligation="normative">
+    <title>Terms and definitions</title>
+    <p id="_fcf8a560-80b7-050c-5b7c-a0fa533bb966">For the purposes of this document,
+      the following terms and definitions apply.</p>
+    <p id="_ad8b7c56-0577-cbbd-8b29-1a9a010ee6c9">ISO and IEC maintain terminology databases for use in
+      standardization at the following addresses:</p>
+    <ul id="_5c30f860-dfd7-0b61-ce12-f1f3bfd48683">
+      <li>
+        <p id="_9f56356a-3a58-64c4-e59e-a23ca3da7e88">ISO Online browsing platform: available at
+
+        <link target="https://www.iso.org/obp"/>
+      </p>
+    </li>
+    <li>
+      <p id="_e32e7234-859e-9fdd-bd49-6e9d7b1a65ff">IEC Electropedia: available at
+
+      <link target="https://www.electropedia.org"/>
+    </p>
+  </li>
+</ul>
+<term id="term-paddy">
+  <preferred>
+    <expression>
+      <name>paddy</name>
+    </expression>
+  </preferred>
+  <admitted>
+    <expression>
+      <name>paddy rice</name>
+    </expression>
+  </admitted>
+  <admitted>
+    <expression>
+      <name>rough rice</name>
+    </expression>
+  </admitted>
+  <definition>
+    <verbal-definition>
+      <p id="_e1574058-8cb3-3866-9f3e-2118889b9f7f">rice retaining its husk after threshing</p>
+    </verbal-definition>
+  </definition>
+  <termsource status="identical" type="authoritative">
+    <origin bibitemid="ISO7301" type="inline" citeas="ISO&amp;#xa0;7301:2011">
+      <localityStack>
+        <locality type="clause">
+          <referenceFrom>3.1</referenceFrom>
+        </locality>
+      </localityStack>
+    </origin>
+  </termsource>
+</term>
+<term id="term-husked-rice">
+  <preferred>
+    <expression>
+      <name>husked rice</name>
+    </expression>
+  </preferred>
+  <deprecates>
+    <expression>
+      <name>cargo rice</name>
+    </expression>
+  </deprecates>
+  <definition>
+    <verbal-definition>
+      <p id="_22b2b44a-2066-78d3-9916-b66401fc9014">
+        <concept>
+          <refterm>paddy</refterm>
+          <renderterm>paddy</renderterm>
+          <xref target="term-paddy"/>
+          </concept> from which the husk only has been removed
+        </p>
+      </verbal-definition>
+    </definition>
+    <termsource status="modified" type="authoritative">
+      <origin bibitemid="ISO7301" type="inline" citeas="ISO&amp;#xa0;7301:2011">
+        <localityStack>
+          <locality type="clause">
+            <referenceFrom>3.2</referenceFrom>
+          </locality>
+        </localityStack>
+      </origin>
+      <modification>
+        <p id="_3e647472-2532-04e1-5525-1fdc6d2eb844">The term “cargo rice” is shown as deprecated, and Note 1 to entry is not included here</p>
+      </modification>
+    </termsource>
+  </term>
+  <term id="term-milled-rice">
+    <preferred>
+      <expression>
+        <name>milled rice</name>
+      </expression>
+    </preferred>
+    <admitted>
+      <expression>
+        <name>white rice</name>
+      </expression>
+    </admitted>
+    <definition>
+      <verbal-definition>
+        <p id="_93c4b7be-1f3d-107c-2fd3-5e458e731ac8">
+          <concept>
+            <refterm>husked rice</refterm>
+            <renderterm>husked rice</renderterm>
+            <xref target="term-husked-rice"/>
+            </concept> from which almost all of the bran and embryo have been removed by milling
+          </p>
+        </verbal-definition>
+      </definition>
+      <termsource status="identical" type="authoritative">
+        <origin bibitemid="ISO7301" type="inline" citeas="ISO&amp;#xa0;7301:2011">
+          <localityStack>
+            <locality type="clause">
+              <referenceFrom>3.3</referenceFrom>
+            </locality>
+          </localityStack>
+        </origin>
+      </termsource>
+    </term>
+    <term id="term-parboiled-rice">
+      <preferred>
+        <expression>
+          <name>parboiled rice</name>
+        </expression>
+      </preferred>
+      <definition>
+        <verbal-definition>
+          <p id="_77760029-ab22-355b-ecc6-4737f60e10c8">rice whose starch has been fully gelatinized by soaking 
+          <concept>
+            <refterm>paddy</refterm>
+            <renderterm>paddy</renderterm>
+            <xref target="term-paddy"/>
+            </concept> in water followed by a heat treatment and a drying process
+          </p>
+        </verbal-definition>
+      </definition>
+    </term>
+    <term id="term-waxy-rice">
+      <preferred>
+        <expression>
+          <name>waxy rice</name>
+        </expression>
+      </preferred>
+      <definition>
+        <verbal-definition>
+          <p id="_60750349-2f02-e9e6-812a-afcff9596bb1">variety of rice whose kernels have a white and opaque appearance</p>
+        </verbal-definition>
+      </definition>
+      <termnote id="_e8de9229-ac2f-641c-445b-b78d2a987268">
+        <p id="_d25b5f1c-f61d-2478-f256-1c5388b05586">The starch of waxy rice consists almost entirely of amylopectin. The kernels have a tendency to stick together after cooking.</p>
+      </termnote>
+    </term>
+    <term id="term-extraneous-matter">
+      <preferred>
+        <expression>
+          <name>extraneous matter</name>
+        </expression>
+      </preferred>
+      <admitted>
+        <expression>
+          <name>EM</name>
+        </expression>
+      </admitted>
+      <domain>rice</domain>
+      <definition>
+        <verbal-definition>
+          <p id="_d186b0df-9142-b9b9-4f4a-e9b71f886d27">organic and inorganic components other than whole or broken kernels</p>
+        </verbal-definition>
+      </definition>
+      <termexample id="_952d3194-222e-c5ad-ee56-c84fc6ca4c23">
+        <p id="_20f8cb53-500e-71a4-ff4b-f363cd408bf3">Foreign seeds, husks, bran, sand, dust.</p>
+      </termexample>
+    </term>
+    <term id="term-HDK">
+      <preferred>
+        <expression>
+          <name>HDK</name>
+        </expression>
+      </preferred>
+      <admitted>
+        <expression>
+          <name>heat-damaged kernel</name>
+        </expression>
+      </admitted>
+      <definition>
+        <verbal-definition>
+          <p id="_8e4d67ad-21df-cfbb-621e-a93ac7b58c24">kernel, whole or broken, which has changed its normal colour as a result of heating</p>
+        </verbal-definition>
+      </definition>
+      <termnote id="_c9008be8-1e45-abcb-1167-f47fe78f548d">
+        <p id="_a06e8d73-dca3-9d1c-b869-56c454ba6c5e">This category includes whole or broken kernels that are yellow due to alteration. Parboiled rice in a batch of non-parboiled rice is also included in this category.</p>
+      </termnote>
+    </term>
+    <term id="term-damaged-kernel">
+      <preferred>
+        <expression>
+          <name>damaged kernel</name>
+        </expression>
+      </preferred>
+      <definition>
+        <verbal-definition>
+          <p id="_0542d5a5-f0b9-fafc-4dc2-4f089edadc22">kernel, whole or broken, showing obvious deterioration due to moisture, pests, disease or other causes, but excluding 
+          <concept>
+            <refterm>HDK</refterm>
+            <renderterm>HDK</renderterm>
+            <xref target="term-HDK"/>
+          </concept>
+        </p>
+      </verbal-definition>
+    </definition>
+  </term>
+  <term id="term-immature-kernel">
+    <preferred>
+      <expression>
+        <name>immature kernel</name>
+      </expression>
+    </preferred>
+    <admitted>
+      <expression>
+        <name>unripe kernel</name>
+      </expression>
+    </admitted>
+    <definition>
+      <verbal-definition>
+        <p id="_fe4dd579-20d0-2da7-008a-dabb846fa9ef">kernel, whole or broken, which is unripe and/or underdeveloped</p>
+      </verbal-definition>
+    </definition>
+  </term>
+  <term id="term-husked-rice-yield">
+    <preferred>
+      <expression>
+        <name>husked rice yield</name>
+      </expression>
+    </preferred>
+    <definition>
+      <verbal-definition>
+        <p id="_21e6986c-cb50-7495-0b5b-16cb12dd593f">amount of husked rice obtained from paddy</p>
+      </verbal-definition>
+    </definition>
+    <termsource status="identical" type="authoritative">
+      <origin bibitemid="ISO6646" type="inline" citeas="ISO&amp;#xa0;6646">
+        <localityStack>
+          <locality type="clause">
+            <referenceFrom>3.1</referenceFrom>
+          </locality>
+        </localityStack>
+      </origin>
+    </termsource>
+  </term>
+  <term id="term-nitrogen-content">
+    <preferred>
+      <expression>
+        <name>nitrogen content</name>
+      </expression>
+    </preferred>
+    <definition>
+      <verbal-definition>
+        <p id="_4762acb2-0b4f-e78d-6687-29395691975f">quantity of nitrogen determined after application of the procedure described</p>
+      </verbal-definition>
+    </definition>
+    <termnote id="_79578a0c-1335-637c-5de0-be2c2ae6321f">
+      <p id="_1c59e60e-c385-acdd-abb5-f9d204b735a1">It is expressed as a mass fraction of dry product, as a percentage.</p>
+    </termnote>
+    <termsource status="identical" type="authoritative">
+      <origin bibitemid="ISO20483" type="inline" citeas="ISO&amp;#xa0;20483:2013">
+        <localityStack>
+          <locality type="clause">
+            <referenceFrom>3.1</referenceFrom>
+          </locality>
+        </localityStack>
+      </origin>
+    </termsource>
+  </term>
+  <term id="term-crude-protein-content">
+    <preferred>
+      <expression>
+        <name>crude protein content</name>
+      </expression>
+    </preferred>
+    <definition>
+      <verbal-definition>
+        <p id="_28c387d1-5ef2-d616-08d3-b0a9cc6b15dc">quantity of crude protein obtained from the nitrogen content as determined by applying the specified method, calculated by multiplying this content by an appropriate factor depending on the type of cereal or pulse</p>
+      </verbal-definition>
+    </definition>
+    <termnote id="_58988b29-47b5-ca30-b81a-b65c62db04d1">
+      <p id="_df20a68c-bd9a-62e3-20c4-cd6d22e11146">It is expressed as a mass fraction of dry product, as a percentage.</p>
+    </termnote>
+    <termsource status="identical" type="authoritative">
+      <origin bibitemid="ISO20483" type="inline" citeas="ISO&amp;#xa0;20483:2013">
+        <localityStack>
+          <locality type="clause">
+            <referenceFrom>3.2</referenceFrom>
+          </locality>
+        </localityStack>
+      </origin>
+    </termsource>
+  </term>
+  <term id="term-gelatinization">
+    <preferred>
+      <expression>
+        <name>gelatinization</name>
+      </expression>
+    </preferred>
+    <definition>
+      <verbal-definition>
+        <p id="_85a65c0a-7800-c8ad-288d-beb92f3ab0d6">hydration process conferring the jelly-like state typical of the coagulated colloids, which are named “gels”, on kernels</p>
+      </verbal-definition>
+    </definition>
+    <termnote id="_4170c091-fd54-e8c9-8794-3126e18fdd57">
+      <p id="_0dccb2d5-c9ff-0779-c843-c5dfd40ef9c9">See 
+      <xref target="figureC-1" style="short"/>.
+    </p>
+  </termnote>
+  <termsource status="identical" type="authoritative">
+    <origin bibitemid="ISO14864" type="inline" citeas="ISO&amp;#xa0;14864:1998">
+      <localityStack>
+        <locality type="clause">
+          <referenceFrom>3.1</referenceFrom>
+        </locality>
+      </localityStack>
+    </origin>
+  </termsource>
+</term>
+<term id="term-gel-state">
+  <preferred>
+    <expression>
+      <name>gel state</name>
+    </expression>
+  </preferred>
+  <definition>
+    <verbal-definition>
+      <p id="_acf8b215-f9eb-5db9-7c65-222e78cd8dc7">condition reached as a consequence of 
+      <concept>
+        <refterm>gelatinization</refterm>
+        <renderterm>gelatinization</renderterm>
+        <xref target="term-gelatinization"/>
+        </concept>, when the kernel is fully transparent and absolutely free from whitish and opaque granules after being pressed between two glass sheets
+      </p>
+    </verbal-definition>
+  </definition>
+  <termsource status="identical" type="authoritative">
+    <origin bibitemid="ISO14864" type="inline" citeas="ISO&amp;#xa0;14864:1998">
+      <localityStack>
+        <locality type="clause">
+          <referenceFrom>3.2</referenceFrom>
+        </locality>
+      </localityStack>
+    </origin>
+  </termsource>
+</term>
+<term id="term-gelatinization-time">
+  <preferred>
+    <expression>
+      <name>gelatinization time</name>
+    </expression>
+  </preferred>
+  <admitted>
+    <letter-symbol>
+      <name>
+        <stem type="MathML">
+          <math
+            xmlns="http://www.w3.org/1998/Math/MathML">
+          <msub>
+            <mrow>
+              <mi>t</mi>
+            </mrow>
+            <mrow>
+              <mn>90</mn>
+            </mrow>
+          </msub>
+        </math>
+        <asciimath>t_90</asciimath>
+      </stem>
+    </name>
+  </letter-symbol>
+</admitted>
+<definition>
+  <verbal-definition>
+    <p id="_068a1864-1e76-8a50-d103-3060e9abef97">time necessary for 90 % of the kernels to pass from their natural state to the 
+    <concept>
+      <refterm>gel state</refterm>
+      <renderterm>gel state</renderterm>
+      <xref target="term-gel-state"/>
+    </concept>
+  </p>
+</verbal-definition>
+        </definition>
+        <termsource status="identical" type="authoritative">
+          <origin bibitemid="ISO14864" type="inline" citeas="ISO&amp;#xa0;14864:1998">
+            <localityStack>
+              <locality type="clause">
+                <referenceFrom>3.3</referenceFrom>
+              </locality>
+            </localityStack>
+          </origin>
+        </termsource>
+      </term>
+    </terms>
+    <clause id="_specifications" inline-header="false" obligation="normative">
+      <title>Specifications</title>
+      <clause id="_general_organoleptic_and_health_characteristics" inline-header="false" obligation="normative">
+        <title>General, organoleptic and health characteristics</title>
+        <p id="_30d09ddc-8f0f-6b8b-cd69-95367e7fa14e">Kernels of rice, whether parboiled, husked or milled, and whether whole or broken, shall be sound, clean and free from foreign odours or odour which indicates deterioration.</p>
+        <p id="_a2cd6bf3-eb1e-a3b8-ebea-349f96866fcc">The levels of additives and pesticide residues and other contaminants shall not exceed the maximum limits permitted in the country of destination.</p>
+        <p id="_7038352c-2378-e05f-3be1-f4afd4d73a78">The presence of living insects which are visible to the naked eye is not permitted. This should be determined before separating the bulk sample into test samples.</p>
+      </clause>
+      <clause id="_physical_and_chemical_characteristics" inline-header="false" obligation="normative">
+        <title>Physical and chemical characteristics</title>
+        <clause id="_718f57f1-7f06-1126-a288-ac30ff2f1342" inline-header="false" obligation="normative">
+          <p id="_ebe0f2b9-1827-b968-7c45-0e630e78afa9">The mass fraction of moisture, determined in accordance with 
+          <eref type="inline" style="short" bibitemid="ISO712" citeas="ISO 712"/>, using an oven complying with the requirements of 
+          <eref type="inline" style="short" bibitemid="IEC61010-2" citeas="IEC 61010-2:1998"/>, shall not be greater than 15 %.
+          <fn reference="1">
+            <p id="_b4098baa-da0f-fc53-12bf-26bc1527983a">Formerly denoted as 15 % (m/m).</p>
+          </fn>
+        </p>
+        <p id="_83b93e1d-af8c-b196-0aba-7090526be9ad">The mass fraction of extraneous matter and defective kernels in husked and milled rice, whether or not parboiled, determined in accordance with 
+        <xref target="AnnexA" style="short"/>, shall not be greater than the values specified in 
+        <xref target="table1" style="short"/>.
+      </p>
+      <note id="_f1e96394-8e9d-a7ce-3188-961e94452ed3">
+        <p id="_00ffc012-9fa2-7d03-a90e-4fe8dd55c529">Lower mass fractions of moisture are sometimes needed for certain destinations depending on the climate, duration of transport and storage. For further details, see 
+        <eref type="inline" style="short" bibitemid="ISO6322-1" citeas="ISO 6322-1"/>, 
+        <eref type="inline" style="short" bibitemid="ISO6322-2" citeas="ISO 6322-2"/> and 
+        <eref type="inline" style="short" bibitemid="ISO6322-3" citeas="ISO 6322-3"/>.
+      </p>
+    </note>
+  </clause>
+  <clause id="_2" inline-header="false" obligation="normative">
+    <p id="_0c4d50df-a2c0-c434-7183-6272ebb64a22">The defect tolerance for the categories considered, and determined in accordance with the method given in 
+    <xref target="AnnexA" style="short"/>, shall not exceed the limits given in 
+    <xref target="table1" style="short"/>.
+  </p>
+  <table id="table1">
+    <name>Maximum permissible mass fraction of defects</name>
+    <thead>
+      <tr>
+        <th valign="top" rowspan="2" align="center">Defect</th>
+        <th colspan="4" valign="top" align="center">Maximum permissible mass fraction of defects in husked rice
+        <br/>
+        <stem type="MathML">
+          <math
+            xmlns="http://www.w3.org/1998/Math/MathML">
+          <msub>
+            <mrow>
+              <mi>w</mi>
+            </mrow>
+            <mrow>
+              <mo>max</mo>
+            </mrow>
+          </msub>
+        </math>
+        <asciimath>w_max</asciimath>
+      </stem>
+      <br/>
+      %
+    </th>
+  </tr>
+  <tr>
+    <th valign="top" align="left">in husked rice</th>
+    <th valign="top" align="center">in milled rice (non-glutinous)</th>
+    <th valign="top" align="center">in husked parboiled rice</th>
+    <th valign="top" align="center">in milled parboiled rice</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td valign="top" align="left">Extraneous matter: organic
+    <fn reference="a">
+      <p id="_86ef40d3-4f02-2e00-da2d-910da0efb08c">Organic extraneous matter includes foreign seeds, husks, bran, parts of straw, etc.</p>
+    </fn>
+  </td>
+  <td valign="top" align="center">1,0</td>
+  <td valign="top" align="center">0,5</td>
+  <td valign="top" align="center">1,0</td>
+  <td valign="top" align="center">0,5</td>
+</tr>
+<tr>
+  <td valign="top" align="left">Extraneous matter: inorganic
+  <fn reference="b">
+    <p id="_de140715-0163-a7a5-2c25-6330bb6b041e">Inorganic extraneous matter includes stones, sand, dust, etc.</p>
+  </fn>
+</td>
+<td valign="top" align="center">0,5</td>
+<td valign="top" align="center">0,5</td>
+<td valign="top" align="center">0,5</td>
+<td valign="top" align="center">0,5</td>
+              </tr>
+              <tr>
+                <td valign="top" align="left">Paddy</td>
+                <td valign="top" align="center">2,5</td>
+                <td valign="top" align="center">0,3</td>
+                <td valign="top" align="center">2,5</td>
+                <td valign="top" align="center">0,3</td>
+              </tr>
+              <tr>
+                <td valign="top" align="left">Husked rice, non-parboiled</td>
+                <td valign="top" align="center">Not applicable</td>
+                <td valign="top" align="center">1,0</td>
+                <td valign="top" align="center">1,0</td>
+                <td valign="top" align="center">1,0</td>
+              </tr>
+              <tr>
+                <td valign="top" align="left">Milled rice, non-parboiled</td>
+                <td valign="top" align="center">1,0</td>
+                <td valign="top" align="center">Not applicable</td>
+                <td valign="top" align="center">1,0</td>
+                <td valign="top" align="center">1,0</td>
+              </tr>
+              <tr>
+                <td valign="top" align="left">Husked rice, parboiled</td>
+                <td valign="top" align="center">1,0</td>
+                <td valign="top" align="center">1,0</td>
+                <td valign="top" align="center">Not applicable</td>
+                <td valign="top" align="center">1,0</td>
+              </tr>
+              <tr>
+                <td valign="top" align="left">Milled rice, parboiled</td>
+                <td valign="top" align="center">1,0</td>
+                <td valign="top" align="center">1,0</td>
+                <td valign="top" align="center">1,0</td>
+                <td valign="top" align="center">Not applicable</td>
+              </tr>
+              <tr>
+                <td valign="top" align="left">Chips</td>
+                <td valign="top" align="center">0,1</td>
+                <td valign="top" align="center">0,1</td>
+                <td valign="top" align="center">0,1</td>
+                <td valign="top" align="center">0,1</td>
+              </tr>
+              <tr>
+                <td valign="top" align="left">HDK</td>
+                <td valign="top" align="center">2,0
+                <fn reference="c">
+                  <p id="_06644722-25e2-d75b-41df-7ed0b3a5fb84">The maximum permissible mass fraction of defects shall be determined with respect to the mass fraction obtained after milling.</p>
+                </fn>
+              </td>
+              <td valign="top" align="center">2,0</td>
+              <td valign="top" align="center">2,0
+              <fn reference="c">
+                <p id="_b24a6f8a-6a7a-20c3-8cf1-cee37a023d54">The maximum permissible mass fraction of defects shall be determined with respect to the mass fraction obtained after milling.</p>
+              </fn>
+            </td>
+            <td valign="top" align="center">2,0</td>
+          </tr>
+          <tr>
+            <td valign="top" align="left">Damaged kernels</td>
+            <td valign="top" align="center">4,0</td>
+            <td valign="top" align="center">3,0</td>
+            <td valign="top" align="center">4,0</td>
+            <td valign="top" align="center">3,0</td>
+          </tr>
+          <tr>
+            <td valign="top" align="left">Immature and/or malformed kernels</td>
+            <td valign="top" align="center">8,0</td>
+            <td valign="top" align="center">2,0</td>
+            <td valign="top" align="center">8,0</td>
+            <td valign="top" align="center">2,0</td>
+          </tr>
+          <tr>
+            <td valign="top" align="left">Chalky kernels</td>
+            <td valign="top" align="center">5,0
+            <fn reference="c">
+              <p id="_8d112c05-6fc2-add1-36a1-7b1e5ea94afa">The maximum permissible mass fraction of defects shall be determined with respect to the mass fraction obtained after milling.</p>
+            </fn>
+          </td>
+          <td valign="top" align="center">5,0</td>
+          <td valign="top" align="center">Not applicable</td>
+          <td valign="top" align="center">Not applicable</td>
+        </tr>
+        <tr>
+          <td valign="top" align="left">Red kernels and red-streaked kernels</td>
+          <td valign="top" align="center">12,0</td>
+          <td valign="top" align="center">12,0</td>
+          <td valign="top" align="center">12,0
+          <fn reference="c">
+            <p id="_cc55ad89-1d2d-9149-76a9-90bd80530f53">The maximum permissible mass fraction of defects shall be determined with respect to the mass fraction obtained after milling.</p>
+          </fn>
+        </td>
+        <td valign="top" align="center">12,0</td>
+      </tr>
+      <tr>
+        <td valign="top" align="left">Partly gelatinized kernels</td>
+        <td valign="top" align="center">Not applicable</td>
+        <td valign="top" align="center">Not applicable</td>
+        <td valign="top" align="center">11,0
+        <fn reference="c">
+          <p id="_2222a7c8-e05a-2081-c8a3-fea88d5c49fd">The maximum permissible mass fraction of defects shall be determined with respect to the mass fraction obtained after milling.</p>
+        </fn>
+      </td>
+      <td valign="top" align="center">11,0</td>
+    </tr>
+    <tr>
+      <td valign="top" align="left">Pecks</td>
+      <td valign="top" align="center">Not applicable</td>
+      <td valign="top" align="center">Not applicable</td>
+      <td valign="top" align="center">4,0</td>
+      <td valign="top" align="center">2,0</td>
+    </tr>
+    <tr>
+      <td valign="top" align="left">Waxy rice</td>
+      <td valign="top" align="center">1,0
+      <fn reference="c">
+        <p id="_3fbccca2-d56a-946b-b0fc-acdf73093e90">The maximum permissible mass fraction of defects shall be determined with respect to the mass fraction obtained after milling.</p>
+      </fn>
+    </td>
+    <td valign="top" align="center">1,0</td>
+    <td valign="top" align="center">1,0
+    <fn reference="c">
+      <p id="_1f1fb4dc-85b1-7143-8d31-cc05487209be">The maximum permissible mass fraction of defects shall be determined with respect to the mass fraction obtained after milling.</p>
+    </fn>
+  </td>
+  <td valign="top" align="center">1,0</td>
+</tr>
+            </tbody>
+            <tfoot>
+              <tr>
+                <td colspan="5" valign="top" align="left">
+                  <p id="_2e80c795-c60e-bbda-c227-86750c6557ee">Live insects shall not be present. Dead insects shall be included in extraneous matter.</p>
+                </td>
+              </tr>
+            </tfoot>
+            <note id="_61c8670b-2c17-b33a-4e5f-7eb3ebaa8018">
+              <p id="_c68b15fe-a9c1-4d7e-b35d-09915e32c5ef">This table is based on 
+              <eref type="inline" style="short" bibitemid="ISO7301" citeas="ISO 7301:2011">
+                <localityStack>
+                  <locality type="table">
+                    <referenceFrom>1</referenceFrom>
+                  </locality>
+                </localityStack>
+              </eref>
+              <fn reference="d">
+                <p id="_9ffcb1e6-34d6-cb36-20b2-87ecd980b6eb">Cancelled and replaced by ISO 7301:2021.</p>
+                </fn>.
+              </p>
+            </note>
+            <note id="_08c1063a-8991-024c-9ec2-b5ee1ffa5754">
+              <p id="_4573a47a-b566-f82f-b0b9-d2a99a4b55be">Some commercial contracts require information in addition to that provided in this table.</p>
+            </note>
+            <note id="_4f7b87f0-809b-14dc-7590-997ac9adfa9f">
+              <p id="_199f6dbd-d2c9-3ecf-2f10-e1e7116728c3">Only full red husked (cargo) rice is considered in this table.</p>
+            </note>
+          </table>
+        </clause>
+      </clause>
+    </clause>
+    <clause id="clause5" inline-header="false" obligation="normative">
+      <title>Sampling</title>
+      <p id="_23e03a70-49b8-0f99-7c48-a44e86a0d86c">Sampling shall be carried out in accordance with 
+      <eref type="inline" style="short" bibitemid="ISO24333" citeas="ISO 24333:2009">ISO 24333:2009, Clause 5</eref>.
+    </p>
+  </clause>
+  <clause id="_test_methods" inline-header="false" obligation="normative">
+    <title>Test methods</title>
+    <clause id="_moisture_content" inline-header="false" obligation="normative">
+      <title>Moisture content</title>
+      <p id="_7c699e47-d8c7-4d89-4388-63799ae33f99">Determine the mass fraction of moisture in accordance with the method specified in 
+      <eref type="inline" style="short" bibitemid="ISO712" citeas="ISO 712"/>.
+    </p>
+  </clause>
+  <clause id="_waxy_rice_content" inline-header="false" obligation="normative">
+    <title>Waxy rice content</title>
+    <p id="_d60c4a47-92e6-1c50-b118-07ff753a093a">Determine the mass fraction of waxy rice. 
+    <xref target="AnnexB" style="short"/> gives an example of a suitable method.
+  </p>
+</clause>
+<clause id="_nitrogen_content_and_crude_protein_content" inline-header="false" obligation="normative">
+  <title>Nitrogen content and crude protein content</title>
+  <p id="_3d1d3043-177e-14c8-2c71-feb440fa631d">Determine the nitrogen content and crude protein content in accordance with either 
+  <eref type="inline" style="short" bibitemid="ISO16634" citeas="ISO 16634:--">
+    <localityStack>
+      <locality type="clause">
+        <referenceFrom>9</referenceFrom>
+      </locality>
+    </localityStack>
+  </eref>
+  <fn reference="2">
+    <p id="_9dfdf5bc-f527-63ca-e39c-d7a093b95868">Under preparation. (Stage at the time of publication ISO/DIS 16634)</p>
+    </fn>, or 
+    <eref type="inline" style="short" bibitemid="ISO20483" citeas="ISO 20483:2013"/>. For details on the determination of protein content using the Kjeldahl method, see Reference 
+    <eref type="inline" style="short" bibitemid="ref12" citeas="[10]"/> in the Bibliography. For details concerning the use of the Dumas method, see References 
+    <eref type="inline" style="short" bibitemid="ref10" citeas="[15]"/> and 
+    <eref type="inline" style="short" bibitemid="ref16" citeas="[16]"/>.
+  </p>
+  <p id="_b7375224-0f06-09b5-97b7-445a3d79467e">Calculate the crude protein content of the dry product by multiplying the value of the nitrogen content by the conversion factor specified in 
+  <eref type="inline" style="short" bibitemid="ISO20483" citeas="ISO 20483:2013">
+    <localityStack>
+      <locality type="annex">
+        <referenceFrom>C</referenceFrom>
+      </locality>
+    </localityStack>
+    </eref> and Table C.1, that is adapted to the type of cereals or pulses 
+    <eref type="footnote" style="short" bibitemid="ref13" citeas="[11]"/>
+    <eref type="footnote" style="short" bibitemid="ref14" citeas="[12]"/> and to their use.
+  </p>
+</clause>
+<clause id="_gelatinization_time_2" inline-header="false" obligation="normative">
+  <title>Gelatinization time</title>
+  <p id="_a623c79b-9b53-8f17-8e9d-49985d1504a9">Determine the gelatinization time, 
+  <stem type="MathML">
+    <math
+      xmlns="http://www.w3.org/1998/Math/MathML">
+    <msub>
+      <mrow>
+        <mi>t</mi>
+      </mrow>
+      <mrow>
+        <mn>90</mn>
+      </mrow>
+    </msub>
+  </math>
+  <asciimath>t_90</asciimath>
+  </stem>, for rice kernels during cooking. An example of a typical curve is given in 
+  <xref target="figureC-1" style="short"/>. Three typical stages of gelatinization are shown in 
+  <xref target="figureC-2" style="short"/>.
+</p>
+<p id="_af7be79a-8a7c-33c1-fbea-3641a15183cd">Report the results as specified in 
+<xref target="clause7" style="short"/>.
+        </p>
+      </clause>
+      <clause id="_husked_rice_yield_2" inline-header="false" obligation="normative">
+        <title>Husked rice yield</title>
+        <clause id="_determination" inline-header="false" obligation="normative">
+          <title>Determination</title>
+          <admonition id="_20eea713-ae22-2930-fe59-05a579804016" type="caution">
+            <p id="_9b14ad37-da05-ad91-cc00-68955fc7099f">Only use paddy or parboiled rice for the determination of husked rice yield.</p>
+          </admonition>
+          <p id="_2fb2e7c1-06fe-a067-53f5-16bcf84647e0">Determine the husked rice yield in accordance with 
+          <eref type="inline" style="short" bibitemid="ISO6646" citeas="ISO 6646"/>.
+        </p>
+      </clause>
+      <clause id="_precision" inline-header="false" obligation="normative">
+        <title>Precision</title>
+        <clause id="_interlaboratory_test" inline-header="false" obligation="normative">
+          <title>Interlaboratory test</title>
+          <p id="_b26e22ca-f536-c0d0-d1bd-396a2a644d7c">The results of an interlaboratory test are given in 
+          <xref target="AnnexD" style="short"/> for information
+        </p>
+      </clause>
+      <clause id="_repeatability" inline-header="false" obligation="normative">
+        <title>Repeatability</title>
+        <p id="_c1336200-3744-5a14-bf9a-5f30100d8c17">The absolute difference between two independent single test results, obtained using the same method on identical test material in the same laboratory by the same operator using the same equipment within a short interval of time, shall not exceed the arithmetic mean of the values for 
+        <stem type="MathML">
+          <math
+            xmlns="http://www.w3.org/1998/Math/MathML">
+          <mi>r</mi>
+        </math>
+        <asciimath>r</asciimath>
+        </stem> obtained from the interlaboratory study for husked rice in more than 5 % of cases:
+      </p>
+      <formula id="_95f4f29a-15f7-e2ac-70e0-3d239e54f196" unnumbered="true">
+        <stem type="MathML">
+          <math
+            xmlns="http://www.w3.org/1998/Math/MathML">
+          <mi>r</mi>
+          <mo>=</mo>
+          <mn>1</mn>
+          <mo>%</mo>
+        </math>
+        <asciimath>r = 1 %</asciimath>
+      </stem>
+      <dl id="_78806191-fc99-7d0c-9472-ece28fbc2c5c" key="true">
+        <dt>
+          <stem type="MathML">
+            <math
+              xmlns="http://www.w3.org/1998/Math/MathML">
+            <mi>r</mi>
+          </math>
+          <asciimath>r</asciimath>
+        </stem>
+      </dt>
+      <dd>
+        <p id="_4c9b7cfc-2a8d-6d7e-df48-d53a012621e4">is the repeatability limit.</p>
+      </dd>
+    </dl>
+  </formula>
+</clause>
+<clause id="_reproducibility" inline-header="false" obligation="normative">
+  <title>Reproducibility</title>
+  <p id="_a6be0851-f0b3-2289-6bde-8c4ffde2a932">The absolute difference between two single test results, obtained using the same method on identical test material in different laboratories by different operators using different equipment, shall not exceed the arithmetic mean of the values for 
+  <stem type="MathML">
+    <math
+      xmlns="http://www.w3.org/1998/Math/MathML">
+    <mi>R</mi>
+  </math>
+  <asciimath>R</asciimath>
+  </stem> obtained from the interlaboratory study in more than 5 % of cases:
+</p>
+<formula id="_859c0383-1e8d-50fd-9d2c-1cbafee3bdcc" unnumbered="true">
+  <stem type="MathML">
+    <math
+      xmlns="http://www.w3.org/1998/Math/MathML">
+    <mi>R</mi>
+    <mo>=</mo>
+    <mn>3</mn>
+    <mo>%</mo>
+  </math>
+  <asciimath>R = 3 %</asciimath>
+</stem>
+<dl id="_9d5ef39c-9873-26f4-b9b2-3b728ff67ed9" key="true">
+  <dt>
+    <stem type="MathML">
+      <math
+        xmlns="http://www.w3.org/1998/Math/MathML">
+      <mi>R</mi>
+    </math>
+    <asciimath>R</asciimath>
+  </stem>
+</dt>
+<dd>
+  <p id="_76289b30-a1c1-c8d2-7142-8d57a0380803">is the reproducibility limit.</p>
+</dd>
+              </dl>
+            </formula>
+          </clause>
+        </clause>
+      </clause>
+    </clause>
+    <clause id="clause7" inline-header="false" obligation="normative">
+      <title>Test report</title>
+      <p id="_f74cbbb7-a18c-baa5-2e81-8d5d51abaf72">For each test method, the test report shall specify the following:</p>
+      <ol id="_0203967c-aae2-1eac-d40d-b026d2a54520">
+        <li>
+          <p id="_d1d2571a-450e-f343-a084-7c83e2e5cac4">all information necessary for the complete identification of the sample;</p>
+        </li>
+        <li>
+          <p id="_32abafc3-62e4-840d-62cc-eb442ddf726e">a reference to this document (i.e. ISO 17301-1);</p>
+        </li>
+        <li>
+          <p id="_f44faef2-fbb8-7e1c-e8f1-5f71567a1895">the sampling method used;</p>
+        </li>
+        <li>
+          <p id="_e72f4e3e-f167-9dff-13bd-072a9c06fe8f">the test method used;</p>
+        </li>
+        <li>
+          <p id="_27a92111-847c-0ce0-a65e-e84fd9c13568">the test result(s) obtained or, if the repeatability has been checked, the final quoted result obtained;</p>
+        </li>
+        <li>
+          <p id="_00046492-66ad-561f-a90b-e0a6e20b2983">all operating details not specified in this document, or regarded as optional, together with details of any incidents which may have influenced the test result(s);</p>
+        </li>
+        <li>
+          <p id="_08d14069-a48b-19b0-72e1-d521fce004ce">any unusual features (anomalies) observed during the test;</p>
+        </li>
+        <li>
+          <p id="_522170b2-90f8-5aa8-dd66-65ef44a21a58">the date of the test.</p>
+        </li>
+      </ol>
+    </clause>
+    <clause id="_packaging" inline-header="false" obligation="normative">
+      <title>Packaging</title>
+      <p id="_5389de98-740c-83d8-dfed-9581b691aad9">The packaging shall not transmit any odour or flavour to the product and shall not contain substances which may damage the product or constitute a health risk.</p>
+      <p id="_7a025fbd-7f4b-529b-4a52-ad5605b3a9e4">If bags are used, they shall comply with the requirements of 
+      <eref type="inline" style="short" bibitemid="ISO8351-1" citeas="ISO 8351-1:1994">
+        <localityStack>
+          <locality type="clause">
+            <referenceFrom>9</referenceFrom>
+          </locality>
+        </localityStack>
+        </eref>, or 
+        <eref type="inline" style="short" bibitemid="ISO8351-2" citeas="ISO 8351-2"/>, as appropriate.
+      </p>
+    </clause>
+    <clause id="_marking" inline-header="false" obligation="normative">
+      <title>Marking</title>
+      <p id="_eec970d9-1814-471a-ca8d-23929876b7ed">The packages shall be marked or labelled as required by the country of destination.</p>
+    </clause>
+  </sections>
+  <annex id="AnnexA" inline-header="false" obligation="normative">
+    <title>Determination of defects</title>
+    <clause id="_principle" inline-header="false" obligation="normative">
+      <title>Principle</title>
+      <p id="_cc328623-9a78-01b7-64aa-b2bda8d37b44">Extraneous matter, broken kernels, damaged kernels and other kinds of rice are separated manually according to the following types: husked rice, milled rice, husked parboiled rice and milled parboiled rice. Each type is then weighed.</p>
+    </clause>
+    <clause id="_apparatus" inline-header="false" obligation="normative">
+      <title>Apparatus</title>
+      <p id="_df61ff98-0ab8-806f-efa0-caf47d4e3a88">The usual laboratory apparatus and, in particular, the following.</p>
+      <clause id="AnnexA-2-1" inline-header="true" obligation="normative">
+        <title>Sample divider,</title>
+        <p id="_684887dc-7ec1-99d4-295c-e201a8832580">consisting of a conical sample divider or multiple-slot sample divider with a distribution system, e.g. “Split-it-right” sample divider, such as that shown in 
+        <xref target="figureA-1" style="short"/>.
+      </p>
+    </clause>
+    <clause id="_sieve" inline-header="true" obligation="normative">
+      <title>Sieve,</title>
+      <p id="_9b932abc-a7d8-fec9-a288-2864206912c9">with round perforations of diameter 1,4 mm.</p>
+    </clause>
+    <clause id="_tweezers" inline-header="true" obligation="normative">
+      <title>Tweezers.</title>
+    </clause>
+    <clause id="_scalpel" inline-header="true" obligation="normative">
+      <title>Scalpel.</title>
+    </clause>
+    <clause id="_paintbrush" inline-header="true" obligation="normative">
+      <title>Paintbrush.</title>
+    </clause>
+    <clause id="AnnexA-2-6" inline-header="true" obligation="normative">
+      <title>Steel bowls,</title>
+      <p id="_53470274-9ee3-30de-8774-b2b5ce5009c8">of diameter 100 mm ± 5 mm; seven per test sample.</p>
+    </clause>
+    <clause id="_balance" inline-header="true" obligation="normative">
+      <title>Balance,</title>
+      <p id="_892c7ec8-2d9a-3407-36b6-049af6ad444a">which can be read to the nearest 0,01 g.</p>
+    </clause>
+  </clause>
+  <clause id="_sampling" inline-header="false" obligation="normative">
+    <title>Sampling</title>
+    <p id="_92444cbb-a21e-fea8-c3a7-670d60cac742">See 
+    <xref target="clause5" style="short"/>.
+  </p>
+</clause>
+<clause id="_procedure" inline-header="false" obligation="normative">
+  <title>Procedure</title>
+  <clause id="AnnexA-4-1" inline-header="false" obligation="normative">
+    <title>Preparation of test sample</title>
+    <p id="_201310e9-e86f-0718-62f1-67fac594b891">Carefully mix the laboratory sample to make it as uniform as possible, then proceed to reduce it, using a divider (
+    <xref target="AnnexA-2-1" style="short"/>), until a quantity of about 30 g is obtained.
+  </p>
+  <p id="_a4fc1949-efa4-2552-608c-edb58d8666a3">All parts of kernels which get stuck in the perforations of a sieve should be considered to be retained by the sieve.</p>
+  <figure id="figureA-1">
+    <name>Split-it-right sample divider</name>
+    <image src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPMAAAC4CAYAAAA2adqQAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4nOydB1zM/x/HX/bem4j87E2SzMxKJCsSqWyKUGRk7y1KNCSyR8gmlXZGRPbee2/u/3i/uftf972rS0Xl+3w8PFzf+3zn3efe7897ZpFIJBAREcn4ZP91B+KMFhHJ2DTIKn6AIiKZgz86md+/fy/YJiIikjpk/5PPMV++fIJtIn+OjRvW43xsLPTbtselixdQp149tGnbTvwEMgmimv2P4O2xBmdPn8a8hYtRvFgxDBwyFDOnTcXqVSv+9UeTaRAncyYn5MQJtGjaBPfu3Uf1GjX5dV9zM/Qz741ly13w9es39OnVA0ePHP7XH1WGR+qaEq3ZmYwtmzdhz65d0NFtgpevX+H1i5fo3tMMzVu0QEjQCVy4eIE/9fCwUDRo2AhlypTFoYP70ax5C9gMGvyvP76MSAPQZJaIZBouxp2XNNXRlsydOUNy7uxZSZ+ePSRnT50S3J6NZT/J16/f+HXwiUDJyKFDeNyh/fsl/fr0lty7c0ewj0i6pr6oZmciaP1r0sUYrVu1xqFDBxETHYnXb1+jXsOGgpusXbcewkND+HWLVq1hZz8GrfSbY8eO7Vi+0hXN9JrgwL59gv1E0i/iZM4E3L97F3VrVofrKld4r1uPMmXLoqOBIRzHO6B40eJor98K0RERCW60k3FnnAwJlv1dpWpV3L7zEN+/fYO760oEnjiJ8Y7jsHDe3H/98WYYsk2bNo2uddq//iAyIl4eHljn5YE3b98if4H8KFq0KAoULIQtm/1gYGiEKpWr4OatG6hTty5cXJbjcnw84uMvonbtOjzhQ4ODUaVKVeQvUIDvPnfu3OjS1RQFCxZCRHgY8ubPhxIlS+LalcvYuX0b3r57h2rVqv/rjz294i6umTMgN65dl1gP6C8ZbGPNFz98yGCJ28rlshsx79VD9nrxwgX8d1R4uMSgfVuJk4ODpHVzPcm7d+94Td1cVyfRB2DR20zy5MkTft3FyFDiv2uXYIxIuqC+aM3OQJw7exZ+Gzfg2dOnaNuuPSSSHzhw4ABMTbuhW8+eshvpa9YTG7ds49dfv37Fpg2+OHL4MLJkyYIfP37wv5w5c6JDx45wc10Fff22mDFnjtIH8eDePYx3GIeChQpBT08P9+7dw5s3b2Bi0hU6TZsKxov8NcTY7IxATFQkZs+agd27dqJ0mTL4+PEjHj95jMJFikIi+Y4PH1WHyebIkQP9razhu2kzrAYOImck8uXPi5y5cmDnjh0oVaYUVqxaxiq4MspqaPC+q1a78/nOnDmNdu3b4+69u7AdPhSPHz5UspfI30CUzOmYq5cvY5rzZNSsWQstW7dmqfzg/gP0NjdH7ly5sNHXF630W6NI0WII2LeXJefAwcMw0Kq/TDIrIyYyEvPmzkGp0qXx8sULZMuWDV++fEEnY2P0NOuDPHnzKNnrJyTpF82fi6NHjsBxvBMCA4/jUnw85i9chGo1agjGi/wxRMmcXgnY44+BNlZYvGwFypYrixHDhqJduw4IOnkC67w8sXjRQkyfNRv58+dHQMBerF7rya+7d+2Mx48fJ3pX2k2aYPtuf1aXs2QB2rRtg+8/vuPBgwfQb9kMV69cEewjhSS902Rn7N1/CDu2b0WrVq2xe18AJk2cwCGjn798Eewj8mcQJXM6gqTewf0BiImKxtdvX1CjZi1cjItDqTJl0KePOf/vsnwZ3r19C5OuXbF582YULVIEHz58wOtXL1G1eg38+P4dsedi0bqVPrQqa6Feg4YseVVx7MgRhIWH4uXz54iMikRjbR1cvXoF5uYW+K9qFdStVx958iiX1HQdtOamdXX9Bg3x4P49ZM+RA+U0NFCnbj22oov8McQIsPTA12/f2MpcqGAeibenh2T/3r2SUiWKSK5cvqz06ubOminZvnWL7G/ah6zSsadPS/bu3iVpp99K8uH9B8nokSMkVpYWgv2V8fHjR76GBnVqSaZOmijp3bM7W8jV3T86MoKvX2phd540ke9D5I8hRoClB7Zt3ozbt29i08atOH7sGB49eoASxUrg3bu3Sq8uf/58iJQLArGwHABrGxt0NGiH8+fPoXfvPjA27IBhI21Ru1Yd2NuOxKNHjwTHkYd8zHMWLIDjhAmIiIxAFmTB9BnTkSNbDt7/9evXgn3k0dZpglevP7CWQNZ0Y+MuGDFiKAesvHzxUjBeJPUR1ey/SOzp03CeMhl6zZqhVq1aCAgIwKtXL5E9W3a2WH/58hn6+voYOsIugVHq4YOHWLp4IabPnC0wVvl4eSIiPBxt27XF/v0HoFmhAtq0awdvLy8YGBiiV58+Sd7whfPnMWfWDPyQSJA7V26+jqxZs6FUqVKYPntOonnp37//QNjJYPj6+MB21GhW+728PNG3r4XoykpbGogRYH+B4KAgjB1jhx/ff2Dy1GkIDDyG3LnzQE+vGb59/44nTx4BWX4am27fvoPNfhuxP2APGus0QaFChVCgQAHkzpMbhw7sR+MmTRLcAK1dGzZqyOtpslDXq9cACxfMg46uLooVL46hg2xQtGgxVE/E8lyyVCl079kLRQoXwdVrV5E7dy68fvMKHz98xK6d2/H65WvUrF0b2bMLa1tkzZoFmhUrol2Hjti6ZTO2bd2CnmZmOHX6FDzXrIZmxUooXbq0YD+RFOMuSuY/BAVq7N+7B3v27IFu06YoV7Yc9uzxh5aWFnr17oPyFSqwFfnxo4do3rIVS1/XlStw+dIllCtXDu/ev2f7RtasWTFmnAP+q1oVVhZ9sXj5CpQsWVLpTXx4/4Et31evXGaL+J07d1CunAZq166NbVu3oq9FP3QwNBTsJ8+nT5+wwccbF+Iu4OHDh8iVOzfu3rnNPwjajRtjwqTJgn0U2brJD4cPH0aLFi0g+SHhid3LzAzajZsINAuR30Y0gP0pyEilqVGGQzFH2Y7g1y9fvhKcPSToRIK/58yczoYlMkZ1aKPPRqUmjRpIzHqaSny8PJMMxyTIMFanRjXJoYMHEoRzUngm/S0N10yKyLAwSZXKmhLXFcv5msaPG8P3oa6hi843Z+YMfga0H/2j6xBJFcRwzrSEXDeBx4/j/r17uHLtMkoUK47SZcriwP796Gpqipq1arFaLIWiqcgtRJJZHpLYFBRCQSRnz51Fvbr18PLlS3z5/AVhEaE4cOAI6itJc5SHJKzLsqWcYBF79ix/5LVr18OD+3fx6u0b6DTW4cIEFGGWGCHBQTh+5Ai+fvuKc7GxyJEjJ+7ev4v+/QegsY4Oatepq3JNTa639eu88fnjJ5QuWxafPr7H69dvUKJUKWhrN0bFSpUE+4iojSiZ04pL8fEsDUkKHT10UFKhXGn+mxIeBttYcfLDgrmzJaVLFpUEHj8uuwpFyawIScF2rVtKBlkPYKlMxzHv1VPitdZdMFYVMZGRfC0njh3jY9E1xJ45w8fqbNiR3VTqsGzxIt6HXGVdjAz4/2ZNGqslqem5kOvMdaWL5NWrVxIby/5cUEHkt6kvTuY0gNTa6lW0JI8ePJCsWr6UJ8vcWTNYpaVJFBx0Qqbu0lj9Fs34IkjdTWoyS35NBMqUIp8uHYf8ylK1VVlVEWWQX7iKliafk65hQD9zHuW7zlvSq4epkj2EfPnyReYft+pvwf9PHO/I1+E8eZJgvDLIj03HIL84nZeWFSK/hahmpxakIm/Y4IsyZcogX/787HYqV16D46ob6zbF969f0bO7KUdWFS1WFE+fPEFQ0AnUq1effcDPnz3jiKnPXz5j9JhxSV7V9+/fcTomhv3KVGSgUkUtxMdfwJs3b9nAVq9BA3TuYiLYTx66hsjICLx5/RohQUFoqK2Np48fI3vOHNDUrIQzp2PQvqMBZ2glBqnwBw/sx8W48zh8+BCMDI0RFnYS+m3a4OHDRxg2ciQ0NSsqPQJZ3M+cPoWbN27geOAxWA2wxs2bN3H69GksWrJUMF5EJaKanRqQisgGIcdxrEbT6wVz5wiOTOpkpQrlOOJL8kvdJam9/Je6Sq9HDB3M0ptyjdXl5vXrvC/t5zDGXtJOvyVfU8O6tVVGkSlCqj5dt+ea1ZJxo0dJRo0YziNI9U1OJBcZyehaHMfaS4oXLciqt0G7NvxcVEGaRpuWzSVHDh+SPHzwgJ9F7epVVYwWUYEomVPC9WvXMH7cWFhaWqKCZkXs3LkdN67fQPnyFTiia4TtKOg1b57gDCuXL0XLVvqoW7++bJunuzv7cylraef27fjw8SP/yBYvXgwzZs9D9uyqY6vlIW1g+fJl+PzpEydRkCGqUOHCaNasGbqYdkfhwoUE+8hDfuR1nmsRGRnJWkLg8WNo174DsmXLikMHD6JxYx1MdJ7K/u+koHsKDQvlsRQV9vXLFxQpUgTjHMejcpUqsr0njBuD12/eYvIUZ+zauQMX4uIwdNhwXLt+jX3dImojSubfhdZ5FD997+5dXruSVGvV4ucamAxTfc168VqW1syKbPRdL9hG0o/Wmtu2buFja2lqSFatWM7ranVdR1LI/UP7kVQ0MmjPko6uj6SeOpA0p/PTeefOmSWrYkLr6e6mndW+Duk9OU9y+mU3mMmuLdI66DnRezu2beOx5LZyW7VStq987LmIWoiSWV1oXUgJ/NevX8fdu3dw9sxpNG2qB3p8FPboNNEBq9082B1VolRJ7NqxA1WrVsXJkBD+38S0G2rUrMmuH7eVLtxRQpmEc3VZgarVquP8uVjEX7qI4sWKs3uro4EBS3SqcV2kaBHBfops37YVcbGxXMTgzes3+K/KfxyI0q1HD+TNmw+6enpcbUQVVy5fwtZtW1GscBHs2r0ThQoWgs3AQbw+pzjun9Fohfk4SeG2ciUKFiwAd3c3NNNrjmPHj6Hyf5XRsnkraFQoj7CwUDRsqM2RYlJ2bNsqSubkIUpmdaDABsomkgZYjBw+hKXK48ePZXuT5JNfn5IUpDFUk5rcP9aW/fhvWte6u7rysRKDrLsk2ck6LZVik8aP5/Msmj9P8uL5i0T2/j/yFmdjg458HFrPSzOr1EEqYUkDWb/Om58FrXOl2Vr0OilIKpO0p2dEr+l6EgsaESVzshFdU+rQt3dP9olKMTboINhLcTJLfrl/SBWnL7tZD1OelHScEUMH8Rf50+fPguPIQ8ejcVI1t1PH9nwMmkzJUXcJMkDRfdCxfv4wjeNifcmhu0kXnszj7Eez2hx2MkT2Q3Hr5k2VR5o1YzqPp+dA7rpyZUrwfckXHlREnMzJRlSzVeHpsQY5smVHvvwFWLWsU6cuqlSrihPHj0NDQwPZsmfH7Vu32JBl0tUUhQvlRXT0Wa4/Lc+LFy8QGR6OJ08ew9vbE0119bjcbc4cOdnIVKBgQQwcNFhW7lYRaoMbGRGOVy9fIiY6CvHx8ejY0RCX4i+yCt21qynef/gAa6rvlQTXrl7FudizbGQKDw/j+PCLFy/A0MgIZcuWg5l5X5XRW+D4cglOBgfhxfPn2L9/Hyda1K9fDxcuUvneuqhUSQtRUZHo0KEDvv/4gaDjx1G7bl1On7xwIQ6NtRsjZ67caN6yJYYOtOZjqipvJKrZyUZUsxUh9xFJjFUuK/gdStInKUISVuqiIYlGEpLoZNhBFj+dlBtIGiNNhi065hQnJ5aUnTsZCMYqg1RSuraObfUlIUFBsmsbO3oUb0+Oocxl+TI+Dp2frr3Pr2OpG3Qi+aWx0P70zChyjO5PGnet36o5j6FraqmnK1DFf0auiZI5FRElszzbt27F9q1bYNSpE3LkzAUvjzXobzkA3Xr2Qk9TE07fo4yhwUOGcolbcgFRCqO7myt81nvDZeVq9OyVuDShGlmTxzsgW/YcHKt8+VI8ymmUx5s3r7kgn/WgIYlKRyI0JBi7dmzn4BQdnSbYsX07cuTMyRlV2bNlw7xFi9XqhX34wAGs8/biskIfPn5A8eIl8PTpEzRv3gJ29mOTdImR1kBtYU/FRKNLly6IiopG4SJFMGasAz59+oiFC+ZzMMyq1auhUb5Cgn2pgAFEyZyaNPjnJzNZqSlN8HRMNNp26IhHDx/i+rUraKKrh779+svG2dvZYvhIW1ajp06exF9+KrBHrVA1ypeHkVEnHDx4AE+ePUH9uvXRqXMXtvqqgiLGVixfihzZc+DmrZucQ5w9W1Z8+vQZHQ2M0LpNm0T3x6862hv9NiBn9hzIVyA/4i9c4FxnmpB6zVqgR89eXI8rKehaFi9awBOPumPky5uPLfR169fjiLWy5coleoSTwcFwWbEMXj6+OHvqFDp1NkDr1m2wect2lfcgTuZU59+ezJOdxuP58xeoWbMGtm7ZAot+lrwWPXr0CDy9fTihXwoFiDTT08G5uEuy/GGvte6Ijo6GlZUNdu7cgaxZsmDKtBk4duQQ1vv4sCuno5GR4LyKuLu64uzZM1wMgNxetH6msMrOJiawtLYRjFfk3t07cHJ0xLfv33i9euTIEa4QQpKfcqFJUqvDzes34LrKhcM83717x4X8KA+b3GLKSvBSHW8P99Vo374DKlbSwubNfrz2rlr1P7x8/QYTnCapPKs4mVOdf3PNLA3s2LLJj/8mKy39XaNqZdm6uJmujiAEkSy3ivnDRw8f5vU0HfPY0SOy/F6yVKsKGlGG1P1Dbhv6n9bD9na2bDlODhR8QRZnWseTBTm5OccE7c9BHCuX87qa7pnW1QcDAmRj6Dq7mRjza2nrGyl0Lgo2SQxxzZzq/HuuqcuX4vmLSV9Qit6iLzr9Tf9o8tH/9CWjnkr0mvzEUmjC0jZF3+g+/928fZWLC08AOuZkpwnshiHfKn3x1aVNqxY8GSiCa+ZUZ/4/OcYtKnhAUVZ03ZQWSRFgUvcRpTmqC/mUpcY12p+uiTLByN0mdU2RwU96bHquUsTJ/Ff4NwxgVM95tZsb8ufLy4aY02dO4evnLzAy7oLatWrh+LGjbPyhOtFUHZNqSb96/YpjmcuUKYvq1WvgxcuXGDhwEBeYf/rsqSCTiNbetIaNiojApcuXULhwYTRs2Ajh4aHQ0qrMBqnTZ06jRYuW6Nqtu8pa1pTBFBd3Hrdv3YbfRl/Url0LkZFRyJkrJ1q2aIW8+fLBcoB1olFgXz5/5giyW7duITgoEOU1NHm/o0cPo41+Wzx9/hQOjhNUusPwyw319MljdmVNcpoAZM0Cgw4GiImJRqvW+rh3/x67mnSb6qG8pmaC2trU1zn2fKyoZv9Z/g01u0a1yjIJO9pupMytJGXjeh+BGkoqJLmRSDJOcBgrWb1qhUxq7965U3AORWg/cv+QS4ak2IplS1m60jG3qSl1pEEjdL0k8cldJq1tTaqwOkg1EbpuCt6QZnRpN6yrVgQYRbJJo7W4oIDdCD4/uaNUIUrmv0Lmr5v9/PlzfPv2jfN1z8fGoqJmRRw5chiBR49yWVgpefPmTbDf+o2b0cfcnOOXDx86hLNnYrF8qQt3alixbCkbixLjwNHjuHfnDjzWumOT31aWxK4rlsPD0xunoqNhbdmf/08MspwfCwzGtm1bERkRxQErL1+9RGt9fa7wOWWiE9+T/H0oQnHeV67e4ubqb9+8wcJ5C3HlyhXUqF6Te1J5uLvxMUgSy/Pp82d+RnNnz8LePfu5+bqvjzeySLJAu7EOVwkVSV9k+slMaX2Ojk6wHjQYe/b649q1qzDt3oPdQWNGjZT1VVIsPUtqMfVUOnQsEMNtbXHl6hVs37YNx44dhYGREbzWeaB71y4cVaUMauxGVuSJU5xx5uwZREVGot8AK+6e+PnzZwwfMYITDOrWqs7qtCoq//cfZs6ZC2/fDTDoZIR7d+/i5fOXXCD/5csXXOBg6CDrRLsxkvXdvF9/THaeimw5cuLjhw8w7myC7NlzcOKIm6sLpk6ZyH5j4kDAPtj078fPqGXLVlgwbx78/Xdh8LDhWLLChfcXSX9k+jXzkydPeP01bMRI/vv61asYZTsC2bJlh+2oURxwQWvJcePGYchwW8H+8sdZ6+bKbquCBQvh+/dvMO5sjIjwSFSrXg2jxzgIXDfykLvHefIk3L93F6PHjGVp//rVK87dpXXo1atX0bx5cxh17sLBH4mxwWcdr+0/f/7ExekLFMiPt2/f8eQeYG2NHr16J7I38O3bd8yc5oy3b9+gUSNtnD9/nkNTKTzz3LlYDB9hi7JlSmPJksUcqjp6bMLKJ/369OY2r6oQ18x/hczfBTJnzlx4K9fmhRLj9x08jPV+m7DKZQW6dDHB0WNBWLVyFexHqZ7MJN0mUcH6kFDkzZ8XVapURXBQCBuRqNNDmTLF4OPtJdhPSomSJeG2Zi02b9uJac5TUK1aVThOmIgF8+ciOjoKQ4YOxya/jVi6eJFgX0WoHY3Xel9W+Y8eP8IqcWzsWYwYaYew0FA4T3QS7CMPRXZRB8khw0ZgnMMYjmqjypx0rLUeXvyD4+/vj9379gsmskj6JdN3tHh4/wEuXYqHXrOEFT8oMonWfvsC9uLK5XhWO799+4qzp06zKl6yZClukaoMavPy7NkzfHj/Hvfv38OjR4/Ro0cvXDh/jtfoFy9cRN48eVC0WDHB3jly5uAgDKrmQZbvBo0a8XnI8lynXj08evgAEWGh3F6V8oULJrI2pYSFfhb9cfvWTRQuXAR+mzaiQP4CrIKTjYCSPEiVLl6ihGBfqiF25/YtNGrUmKUxlcmtVrUapkyZCANDI8yYPUdl9BaFklJetCquUTH/J4/RvEVLFSOAndt/SmRV0jf+4gUuRSyiNu6Z3ppNFtukLKuSXwkB7fVbyRIClCUHKEPqSyYrs0knI7bk0rHImn0i8JiSPYTnNTfrIbOwmxj/DNagXOma1f5LVuKDtCqotAoKXb80GUIR2i7t2EjX0MPUhF9Tza+kEkaSSp0Urdl/hcwfNEJfaKrNrA6HDx1kNxJ9GQ8EBAiCRlRBE06aKSQNSKGSuepmIVEwB+1HkzAq4mdBQArMOH0qRhZdpi5UUI/2kRYAcHX5v0uNChUQVNyAAmQoSk0a9BH8q8SvOJkzLP9GS9f3H94LtimjfYeOOBEUyjm+IcEncOTQcYSePAmL3mZcckcV9Ro2xOXrtzDQZjDq1KzDlvBlixdj4MDB2LhxAxuMgk4EqtgbnBN95nQc9JrpYZ23Nw7sP4wmTXSwfMkSLJi/iF1p/cz7IOxkiGBfRajTYmTUaVaxdRvrcgncXj16o2rVahg1cgSMDTqgvIYG+vXrj4GW/fmcly5dRwuFLhoiGQ9hG79MCGUBqUu16tX5H7mcli9bwhbj8RMnYtJER/at1qlTD5ZW1oIIrlw5c8K8Xz+YdOuGg/sDsG3LFty8eQNPHj/hlqr79vjj6LEj6Gbanet4KVKpshb/a9q8BZYtW4wzMac4lZDawcRER6O+dkMcOXwIU52nYJyDI5o2a46CBQsKjkNQF8YFi5dwX+RZM6bi3Llz3NOZfOlmfcxx4OABtG3fPlGLtIg4mdMl6uT2KvJflSpwWeWG+3fvYsrkiahTuzYMjbsgKiIcs6ZPRbfuPdlgpQidi4w6Xbv1gO86LwQHByMoMBDFihZDA01NeK1di0pax2Bu0U9pX6dixYph5sw57B+fN2cWu6/mzJvPRq3dO3fC0nIAzpw+jT3+/pz/3KN3H/4hUYQCSc7HnmXXlfPUaSheoiTGjLKFh9ca3Lr9MMmyuyIZj39CzU4J5cqX5zzdMuXKQVe3EQ4dPIAOHQ3Q2dgQfXqptuhSrekBNgPh5bMe+fLlxau3rxAeFgZfv/Vsea5evTL7i1VBPmtyH1lZ2/C5DI06wM5+DFvKqe8xda24c+c2SpUozPnE8lDwR7vWLTBzxjT2aU+cMB5t9Ftg0mRnHiVO5MzJPyGZU4Pe5hbQ12+LgIB9CD0ZipWuq7kr4/w5s7mtC7m+VGkAFBgRsHcPJz9UrvwfYmKiMGvmXOzatRP37t3lzonGKlrJ0Hr8wqWriAgL4yIKpA1QkMrly5dQXqM8RtvZw99/J7uXaF385u0bnD4Vw4UJKHlkvc86WNkMhGm3Hnj27Kng+CKZB3EyJ4NSZcrICudFR0Rg1vRpWLRkGb59/Yr/tCpgotNk2I62V3pAqjxC/wijju1RoYIm+7L9Nm6E5YAcGDTIGqPs7DFughOX/pGHfiRojUv/qDieSSdDfPr8Cbv3BLA6Pma0HYYPt8Ozp09Qu04dvHz+nMsBbdvlD7PS5rIjiZM5cyOq2b9JY11d7Nl/EDZWllwb7OHj52x1PnfmTJIH9F63HqtXu3KM9vwFi+C/ezcOHTzK27Zu8hOMl4eMcIeOn4DdKHs0a6qDt29eY4yDAxo0rI1dO3di1/ZtWO3uisPHTqB06dKC/UUyL6JkTgEU4hkRfYrzobds3sjrWCo7G3chDvEXL6JHLzPUk+spJYUk/K27D9iYFhMTg1q1a7P6PmCAFY4dPcLdJLJmy8YleMuWE9bw+vDuPfeQohpkgUGBqFunHow6dsLHzx8QERGB0PDoRLtVJIaqpYJI+keczCmkSNGispBEavrmtsoF5n37wn6cAzq218fYsQ683laGjm5T/nfrxg00bdoYtWvWRqVKldi3Tcfo3tUEfpu3sctKCqVeWvYzh1blyli+0hVhISFYumQR9gQc4BEL58357YlMFCteXLBNJGMgTuZUhOKVK2tpYdMmPwwdaAOf9X7Ysmkj2rZqgRmzZqOZiljlilparKaHBJ3A+nXruIrJkcNHOKPJYcxolChVCk2bNuWUySxZsmLZipWcIUXBLLq6uvDx/b9qriqeWl3u3L6Nxk10U3QMkb+DOJlTGbI+0z+SoE2baiM8PAZjHMajn3lveFavgRJKkh6ktGjVGqXLlEXjxvVh2NEIxYsXx/MXzzFs2HB06dIJq93XwsCoE3p0NeGmcjGnzyWadqlIwUTKBIlkfMTJnEaQahwUHMaJ/zVq1uJi+rNnTkeF8hW4bhaFXQYJQi4AACAASURBVCparfGrusj9B0/h7enB6Yzk8lq6dDF69+6DS5cuYcvmTejeoxdat9VXOpE/fvwk2CaFDG5JQcUQRDImojU7DaGw0AWLl7Kfl4obUJkg8vfGnT+P4kULICo8XOnJr1+5wuvgvhb90LJFS+zy34nVa9y4aJ73+g3oY9GXCw0qI08e1Wo2ddNICvnCfCIZC3Ey/yEGDRnKJ9LTa4wuXbti08atsLS0ELiyKJqrZetmGDtmLEvljgbteHvhgoXZ6CUiogpRzf5DUGP1kPBInDl9Cj7rvFC+fAWMGmWPdeu9oXH0COrWq88tbyh6y9tzPb7/+I6x9nZceM+okzG3xgk7eTJFF6tuEb4vX5JWxxODYs6pbJDIn0WczH8YypiSZk0tXjAfXl4e2LxpO9p16MDbqFld6VIlMXSEHZYsXoiwyBjZBVJt7pRA0WPqkNKCfY8SKS4oknaIk/kvMtZxPPLly4OFC+ahUePGWLpwIRo0aMQTeZ//brTvYJCqF5dUAzgphQqrLrAvkn4RJ/NfhiZukaLFuSaWSTdTrvxpbzsSDbUbw3na9AQXlyVLliQvNjGL9YP79wXblPHixXMlW9WH0kdFNfvPI07mv8zTp0+5Comr+1q+kMEDrTB77gKl/uhfZZETJVeuXIm9rRbZkij1mxSqaomLpC2iNfsvQhFfbVo2x2j7sXwRpFrr6OgqncjgiZp0mObLl68E25KzP/HqlXpr65RCpYJFUg9RMv9FqCj+8eCTPHmpKHzAwQAOGFGFOpK5SJHCgm1ScuVUT2q/fq36ByE1ofxukdRDlMx/gX1792CQlSXmzl/IE5nqgzXQ1saFC1cSzVoqXCRlhilqnP4nKJzID4o8uXKpDnARST6ZXjLnK6C8kP3fgtxD1H1irbcPXwFJZA1NTc5rTg3ev1ftVkqq7Y0U8nmnhP+qVkNQcFCSRyhdWlgDTeT3yfSS+f3bd4Jtf5MeXbugRfOf2VOxp0+zak0leVMLqjemijdv36p4JyHUkzklPLx3L109838Fcc38hwgLPYnoqCg4THBCzdq1MXnSBNSqWQc3b95PtHF6alJAzawpVQY4dfmupjqfv4DqJYVI8hEn8x+CygEtW+nKJxvvOA6tW7aGobHxH72GpL3UPyF3WUpQNwKMAmREUo9/oAtkDsG2Pwm5eboYGXAdbfz6olerUu23JjI1e0sJ6qrZKaWcmpFmVGBBJPXI9JJZorY8Sn0uXriA6VOnwG2NB7d0tR0xDM+fPcUaT9X1shNDsYtGclFXzS6UwrraefKqXrfLc+PGdcE2kd8n00/mLJDg3bs/bwSj3lT2drbYsmMXF53fuH49OnboCGOTroKx6pJSyfxWXcksSdkPoLoRYMWLC1veivw+mV7N/vLlq8o+y2nJjGnOWOm2micyuaNCQ0NSNJGRCpJZXdSJAU8MddXsO7dFq3dqIgaNpAHeHmvw4vlzLgFE1T0oZNO8b78Mc/2vXr0UbEsOmlpaao2uUlUsUZSaiNbsVORCXBwC9uzBf1WrwmejH04EBuLY4UPYs28/96z6V8iePTtioqMSvVvKzRZLFKUu4mRORY4fOQLHiRP5gCSR7UYOQ2T0GaWF9zIzHz58QFzc+UTvkEoCFyok5k2nJqKanQqQ+4kaqhcuWlR2MJv+/biedUacyIUKqRdbrYqL589zWSRqlZNcuIXuRCesWb2aiyCKqI84mVPI8+fPMdh6AJynz0A/S0vs2LYVLfSaIG++vEpL6aaEjx8//pF7SmnWFCWEtGjVCtOmOSMmKlLwviqWLl6IMfZ2aK3fBh7e69BcTwePxRJEaiNO5hTw/t17jBg6GEuXr2BjFxUZuHrlCg4fPYEVrqu5hldq8qeynpKiYBKFAXPlzo2cOXLCy8sHXbt2VuoSk9Yju3vnDtdC62xogHr1G2DL9l3c7bJ8hQoYMngY9Jrq4FMi1VNE/o84mVPAzOlTMdJ2lMy4dfjgAUyYNJlV69y5ciE07GSqqoo0QdIDb5IoDCjtV9VIRweTJ01G7JnTgjFUKXSDrw/6W5hzHbS9Bw6iTdt2CcZQjTSzXn0QHhIi2F9EiDiZf4NbN29ioqMDipcogeYtW+LIoUMYPXI4OhgY8cG+fv0KV5cV6NHT7LfWjapQRzKnNK5aHZKq333r+g3Za6pxduvWLcGYT58+49CRQ5gxaw6PUcWkqVNx6NBBFe+KyCNO5t9gnZcH5ixYiHGO43mNvHPHdk6iaNW6NU+mKlqaqFChAubMnY8NvutT7by5ciddKSSlGU/qkJRLSbGp+6lTMYIxU6dNx7fv39CwUeLJFlSsgWqOJ2ft/a8iTuZkQmu9CpoVZTutXeOOqdNn8Ot3b9+ibu3qGDp0OEd7UXeK8xfPY6vfxlQ597dv3wTb/gbK1sCJQUXxFZ9B3QYN0MmgEy7HX0xkz5907twFJ4JOCLaLJESczGpi0ccMs2fN4IAIE9NusLGyhJuLCw4eOcZrRHqPDF7UmtXK2gaDrAegRq1aePX6A/z9d2O126oUX8PbN38m6ykw8JhgmzwkKRNDUdqOnzART548hefaNQm2b9yyjQ1gSUFN9ooUKYJD+/cnMfLfJtNP5mtXrwi2JRfniU6wsxuNSZOdWe1bsXQJhgweimG2tnj54iV6mnaFnq4eHCdMZH+z04TxmDFrLooVKwZry/7QbdoUL54+S/F15FSjuuaL5ylPK6TItcQMd+8Skczfv//AksWLBDnNI0ePxuGDB9meIE/cxQtccSUpLK1s+EdRJBGo4qMkE+I8eZJEU6OMZON6H4mPt9dv32CDOrUk796949dPnjzhY16Oj+e/P7z/IGmq00g2drXrqgT7Nm+qw2OIZUsX8/4p4UBAQJJ7r1i6WLBNypXLlyWFCuYRbJdn7+5dko2+6yVDBw0UvCdl7qyZgm2PHjyQNNfV4edFbN+6RTDm7KlTksmTnRJso2dL10TvJQVdm9vK5UmM+mepn6kk8xr31ZjgMBb+u3ehevXq3BL10MEDgnHq4OuzDgvnzoX3el9WK50cxmGv/27s238QFbW0MG/ObLitcsHO3Xuwxc8PdsOHou6vOtBkFJswbizc13pxJc5hgweicKHCMOlkyG1df5csWZPOZvr4QXVgibr5zFRIX1NTE1OnTBa8R9y8eZP/Jwm9aOEC2I+yRWjoSSxaugyRp352taxZqzZGDh+aYD9qQv/+zTvcuX1bto00nbCwKKxcuUJwHkXatO+A4OBgHBat28rJLJJ5+JDBklEjhsv+7mJkyL/iN65d/y3JPHb0KNlrl+XLWMJLWbhgvsS8Vw/+i6SdVBoRtJ0kDZ13gsNYSevmepJXr17xe3Q9dWpUE5xLXf6UZCap+vjxYx5LElcR6b07OTpInBwcZPenCN3r/r17E2yNjoyQrF3tKhg7ftxYyYvnLwTblTHKdoSSrf88GV8yU1eIHiZdULlyZYweMw4THMahRdMmcBg/PlH/pSporUfr3r79fqYsUqJ9aEgwzMwtZHs8f/KEjTffvn2HjbUlevUy4+1BgceRNWs27r28YN4c5MyZC/sPHZW1UqXrIdfRn/AFp5SSJUtivMMEbNi4QXCka9eucSmkggUKYs6CBSpbxc6dNx8jRw5LsE7W1mmCsDBhk3lTU1Ps8d8l2K6MShUrKdkqkqEns+NYe8yYNhUrV7tDv21bdDftglatWnMf5OYtWwnGJwWpjXq6jWHe14Lbrn54/4FVZG/fjciWLSu7pdrrt4J+u5+RSs6TnNDVxFR21CVLFuHRo4ewtrFEh44dMX3WbEGiBZUQSomqneQ9JFJVpXjx5PmgnSY74/uXL4LtNDkXLV2OCZOVq+FSOnUxgW4TXVy6mND9RD9oB/btS7CtiV4zBB5P3IouReMfSidNDhluMj9+9AiuK10wb/ZM1KhZC6PGjIXfBl/s2rkDRwODExTKu3LpErw916J+g4aC4yhCVmk67npfPz4GlcYdNmQgFixawul6tC626m+BDgaGKFOmLObOmslr0M4mXRERGYGmOo24QseEiZNx7cYdmPboKTjH7Vu3cPnSJcTEJJ7rmxJy5lRt8f6dAnp16gn7QdE9rlntplYZozVe63D+fMJ0yMFDhsJpgiNCFArlV9DUxHU1Sg7Vq18f4+xHCyzj/zwZac1M6y9d7Yayvzu01ResyaTQuk+6dk2Kly9f8Vh5C6z8mpm2T5s8Sfb31MkTZa/JGktr5qQs1Xv8d/M5yBJMa77fsWyrs2aWrmeVQetfddfMUo4dPaLUgtyudUvJ0cOHBduVMWXiBMHW2NOn+VqkngLJr+uz6G0mGKsMuk9ar4vIqJ9hJvPqVSv4w6cvNE0E+jCXLVFt7Bk5fIjKia4ITVT5SUCvd2zbJvtbu2FdyUM5Q9CmjRsEx0gM+kHRaVifr5uMRaVLFv2tL6I6k1nelaaI1A2UGIqT+dbNm+yOU8Rrrbtk6eJFgu3KmDzJSamRjFxZdHx5OnVsLxinDPps6V6+fPmi5N1/kvRtAKN0wkXz52HDeh9UrlwVE8ZP4s6BsWfOYOr0mbAdNVqwD7mFrAf0g3nf/knWpg4JDmZjV9PmzdmgFXv2LFYuW4ZBQ4bBxNQU3p4enECx0W8Lrly+zGM91rjDuHMXwbEUIbV94gRHTriIioxA8xYt2VgXeOwoYk7F4sPH9whSc42YHGrWqoXZM6Yr3eOLGqmEjx49StCwnVRfp4mTUbtGVV4mSOlvNVDtIsbW1gPR2bCjIJDkwOGjXGpJninO09CsqU6SudsdDI2wedM2nEiDZ5hhSY+SmX5tSXLRL+/lS/Es0Uji0DZVUocIPhHI+6grkbt37ZJA3Z0/e7bsNblxSIJKgz7IxaSuaiy9Xv9du2TXtHnjRsG40SOT52JRRzJPd54isR7QX3bd8iTlmpI+c0eHsUrfU3R7UXCJupAkV+Y2c3d1EWwjia3OvRJ+G5KnJWVi0p9kJgPRjKlTUKZsacSevYg9u3djiLU1XFa5shtEVctTkoTenp44czouSYlM9bn8fNejd29ztqxStRAKu9SoUEE2hgxnZ87Gcdqhw5jRWLR4aZIZSadPnUI/8z4YY2eLcQ6OOBUThZ3bt/M1mZmbC8a/e/8eN+XSBVMD6s/c1bQbtm3ZpPbR6Bocx9gjW/ZsuHL1Fl4+f85hmfJMmTYdp08lDLskLcCqn4XgeMow7z8AJ0NOCt558eo1zscm7NO8w38vzsWq17v5+tUr+Po1fSSg/HXSi2SOjAiX9O3dSzJr5nTJhbg4yWi7ERz4celSvGCsIhRs0Fa/hVpBBzeuXeM1IJ3n+/fvLK1MOxvz/0RIUBCHYdI4kg7Ghh0lR48cERxHHjJutdNvJZnmPFniuXYNX7tZj26S+/fuCsbKQ/dZqkQRyds3bwTvKSM5QSMD+llIPn78mOA9RcnstmqVpE7Nahxi+ezpU9n2Y0cOS/x37hAc29tjrSQqIiLBNrrveUrCO5XhscZdsmPb1gTvXIqP52fwUCE4xcfLU8kREkL3o6NdX7J1k59a58/k/H0DGEUaTXaawConWZUpOmiwjRVvVwcyLtGkVzSkqMJxzGiZCrp71y7+ckeGhfHfp0/FSKz692M1uV8fM45KSuw66D2z7t0kSxbM4+uYON6RJ5M6FnQpc2ZOlyxaMF+wXRnqTOYFc38uFfbs3JEgIk4iN5mjIyIk3U26SLZt2STYn/j67Ru/r8i7t+8kg2wGJNhKz5KWFM+fPxeMFxz36zdJX7Negu37/HdLbIcPS7CNfiBVxWtfunhR0qRRA44fnzpposTbY02S5/4H+HuTmaQRWY1pXUprXJKq9KUg142iRFFF3LnYBJMxMT59/sznW+WyQjbKbviwBO4rq/4WfH7aRhNbFXR9tAasVKEcXwPtQ/exZ/duFXskzsTx6lm2kxvOSdd37+7/tQN6TfdGa9KktJgZU535HhWh9Tj96MoTFR6u9hqX1uOKUpjobNhR8uXz/y3T9+7c4WcqbwX/8uUrP+s2LZvLnnlP066So4cOqnXuTM7fm8yLFy5gowpJQfpykPtn1fKlgnGJQS4PdY1ds6ZNZfVa+kNB5929c6dsMtNEL1akAPtPkzJ0TXAcx8ciybF4wfxkGceUoah6qkKdCTPI2kr2mr7wpPbLQ9d9PIllg+SXMVGZS4qOp0wFVpYlpQzyTZP7SxH6fBR/QOn88i68KU5OvM15khNPZPJ/d+tirPZ3IJPzZw1glC1DIZiUpF6jRg1ky5kds6ZPxa4d27F12y4MtxO6mhKjeNFiarVGXbxwPjQrVsLVG7fZPULuJsqA6mhoyO/3NTeDVtUq2LhxM44EBik1dO3d48/ZQRR5VqmiFsz6mHN2Vt169XD4+Aml+6hLsWLFU60sTuHC/695PXrsOLx+lbBs7oVLV7FJjconLVq1huN4J6xYtjTBdov+ltgfEMAGR3kuqVExhGjdpg0OKCkyYDvaHju2JayXFhF1CufPn+PnPn3KZISFncSAAVbsIrv74AnHulN0XmzsWbXOnen5U5I58OhRjt4iFYtUJ5sB/VL8i+q5RqgGKkJSYPnSJbKtpBHIQxI56PhxwX7ykIHHok9vvm76R9IgOevipHj69ClLmqRQRzJTJpM8ygJcHMeOkRn8ksLbw0MwguwaijnN8+bOTjT6TB6yEyhT4UcOHypQ4el5kz2lbq3qkpjISN7m5bFW9j6dk5YTtIb+xyV02ktmCrI36WSEHTu2Y9PW7Zgzayb6mvVELzPz32o4nhzWe3thg68vhtvacYbT7OnTuHWKPBQs0lJfX3BUivvd57+bM7IKFCwIk64m6GpshP7mfTheu1Jl9ZqjqUPx4sXRqEEj9OnVI8XHevYsYUWTchoacHNJmCs8eOgwbNu2RbCvMqh+lyJ9+w3AmjWrEwSBWFpa4VjgMUSGhQrGK2IzeCjsx44WVBjpYtIVnmtWJ9hGGVmkbfToZcale4nSpcsgKvxn5lWuXLmh26Qp3Nd4ICjoBGtdieV0Z2rSSjJTcAeF+5GFl15HRYRL+vTqwf+nFolJ5kUL5rH7iQJQPn/+LDHtYsx/f/36VTBWEYoRNjfryeNpXWxh3luydNHCRANWUgqtuclFQ5ZaVSQlmUnayq+ZiQ8fPvBxw0NPJtjeq3tXte7nyKGDkhOBxwTbydi3aGFCKzw9N9thQwVjlUEBNcrccsYGHQXXtXzxIsmkieNlf9M+WpoafL5hg2zY3tLdtDOv5y9eiONj0N+3bqnn4cgkpJ1kDg4MxLTpU/Dh/XtcOHcOT5885RKtGuU1BWNTG/rV1qxQkWt2UX7x0IHWsB8zlv+mgnyquBB3Hha9zTBujD3697fEvTt3sWzpEkybNoPXn6oCVlLKpg0bODBmtJ09zp1TL1hCnsjwMNZ2Zkx1FtTnomd+6OBRWPa3wBe5dMZR9mPhorAeVkYT3aboa96bu1nK09nEBN8+J0yPLFWmDPLnLyAI21RGl65dsXKlK07FJEwHtbUbBWODDvj65f8ZUaRNUddIKfkLFMDkyVO428XDhw/RXK8FCuQryO2AXF1cMMV5KtzXesPddRV3y5CvbJKpSSvJLA2EJ3cIWSB79+zO7hD6RU2tbBdlklla6UPqeiErqTqVRsgyqqfbmF+TlGypp5uq62Jl0PHp2chXzli9ShjeKEWZZKbrNjE2lP1NvnFlEpfWnWdPn06wjdw66kDnoGeqGCKqaCknyE1Iri912bvHXzCS9qfgHSlU5WXunFlKx7XXb8Xrd+kanrwV9Ezpesk+Q9lZpAGom+GVgUn7NTOt2ciC2r6DAVa7rsTs2XPxHT8wY5ozIiPCBVZRdSBr5tHDh3H9+jXZaArMnznNGRqamoiOPou487FYtngRXr56CXML5Y3Ob926iXVenpg51RlPn7/A4MFD4bZyJWbPnI41Xt6pui6WJ+xkCOdOUw2xxUuW8Rpcyrv3HxIkNCjjcnw8du/cgbGj7fi6qeCBFCqsQPekiPP0mbhyJWGlUqoaqphTrAyyGpv37svF/+UhS77t8KEJpCbVw86ZOxd/Pqp49vQp10ZbtGA+Hty/Lxjl5eOLiIifa2L6frx790Yw5uaNG3yvlEMuD1m3b919gKNHArkBQdyFOGzdvB3Hjh3BRl9fBJ84IdBeMg1pLZkV2bTRl7fv3L5N5vhXtMAmxl5/f64tRdZQecncybADhwbSefl9OYunMn5GjhmwtZR+vek6Zs+YoWRk6kHnHGg1QOLuJqyBJeX6tav8fCjIRZFF8+fzvVHOLwWrqKJXD1OBVViiJDjl/bv3yUpMsRlgKdhGmpCyap2TJjgKthFHDh+SaNevy58fPY+QoBOCMcSyX+mVNEZRMtNnS/EAdN2tmjfl+0gsacXGsr/ExrIfv6Z9+qhpdc9gpF3QiKrJLPmlxvbo+v9wQQodpKJ5SUHqXgs9Xdko6WQmIxVFJlFYKJ0zMTWeVFBSzzgjKz6ej1muTIk0d2vEnjnD51THfUNqIgVtKNKoXh2lhQIUIcOjsv0pyCZWQdWmZ6UsOEQZi+bPExT4o89SmVvNw124BKJrIpVXGmVH/44cOiQYR/dYvmwp2fGlk5l+4Oh6aTkkXU5JDapJPdchA63ZJSbhIJ1t/B1QfBYZnL+TNUUBFlQfiwwdwwYPwlgHB9y7exe2w4cpzSKiPOBe3UwRG3sePr4JAx5ovLWVJTfpzpo1C2f9UHaVMqiw+9hRduhlZsbj3FxX8jED9h1MMzcZucQ83N244wVlT5ErLCn8/ffBy8NDMIpcbOoUKezdxxxuq4QdNOrVq49RdiMTZESNHjcO2bJlw727SXeW0G/TFhs2+CbYRp9lJ0NjVv3loZJK1IQev1RiygVfvmQJj6Uc5iGDhgmOf/HCBf5O3Lp1B9OmzYTDGHsWNm/fvkZw0An079Obl00aZTXQsJE2f4aNm+gKjqOMlavXcLlj8149+X4HDR4CNzdXWPY1x/v375XskfFQbdpNY6iu8r6Dh7mZ9urVrtwUrVu37nB1c0HB/AXhMMEJD+7fw6IFC1CyTCm4uLqhVOnSCS4qLDwUjhPGwaCjIaY4T0e16tWVXjRZTN1WukCSJQtX0jx4cD+s+1tgzvyFvO5LC8gau97HG0GBgVzowNdvc6L1ueSh+tK09iMrLBUHkHL75k1eQxYpWkSwjzzkGy6nUQ5HjxxGu/YdZO/06NmLI9+OHDoAA6NOvI2qcIaFRyE0NBQa5SsIjiVPQ21tLJg/l9fIdH1SFi5ZxueqVqOGbJuunh6GD7FBQ+3GOH/2LAoVLoxXr14hT7688PT52UzPfa0b/wBTEYoNPuvw+esXTrWkro8X4y8iKOg4fDf4YMniZdDQ0MCXz1+QPUd2OE5wQqPGjRNcW9Vqyj97KWTpHmZrx/+81q5B/KV4tGvfHtWqVceYUbb4r0pVXoOTjSfD8jfUbGWQ5XGARV/2k8ZERvC6sHjRgpJTMdFKRv/kxPFjAgurPKR+U5aOk8M4DtwnSy/5JRPbJ6VQJhUlOxh1aC8JDQn57aPRcUYr1Ic+fOggJ6NQ9pE6+1NklDLLNmWGKeK6coVgmzIOHTzA6rYiypJFqmhpcrmnMXa2Ms+AfJQXfT969+jGHodrV6+yj5qi06SZavQ5Udw7LS8cxoxWageQklgHDlWQ2k/raUrNpPPTunvcaDsVo9M9f2fNnBi0X5tWLXgEGac6Gxn8VhIDtaeh8/uu8+Z1ntQlpm5G1u9w/lcWF63HUuMHw3b4EME2VetpZdCXU5n7iLYrrn0XKpmgqlDmepoxfarA7iA1UsnXU5NPtKBnRe/R50uTVlnCCb23a/s2wXZFfmcyS+nbuye7TiW/KpfQM6ZMsAxG/WzTpk0jpWJaamsW165cwY6d2zDBaZLgvcSoUrUq6tSpy2rxp48fkTdfPhw/fhSvXrzkKiQUuFFILplAnpjoSBw/dgyX4i/h6ZNHMO/TF7ly58GBAwGYPn0WzPv1SzRo5HcgNwedM+78eS6hu2aNJycNJNUpUR3ef/jASw2tyv/JRjdv3hxbNm/mJUcZJaGW8lDAR3BQINcfk4ca2m3e7IdWrf8fxvr+3XusdXdD02bNk1wOUFDItWtX0aDh/0sY582TF44OY9G0aVOULFWKt1GLn6Z6zbgVbY2aNXkb1bx2WbGcEy6oa2ahggURHR3FiStUIUUR+ryr/9o3MTZt8EX3nr0SGaGabj164u2bNzi4PwDlymugSuUqiIqJxJNHj/Dg/gMULVoUefLmVbl/OsE93UlmRUg1pl9KUsPpV5qCBJRBv67yCfWtWzQTSIrUhqRvjWqV1ZaUv4OyapWU6GDd30KwXRnKJLPkV16yYuEF0lyUpTcqg1xkylrXyJfKlbankZfMkl8519LADmVBI7+DukkeSUHhv6R5kIVeGnTyJ7wdqUD6b09DBhHzPhayJASnSVNQsXxZrF71/+SBubNmICo6Ch7r1nPrF2pP071HzzRN5KDzGHVsh149zDhdMK0oX0ET586cSXD0unXr4/UbYSCFMkhKKu5PkPaj2Ojc3sEB4eHC1jHKIGNRQMA+wTv51WhO17Jla7x68zM1s7CK1jZ/C9KoqCOKl6cPxo0ZxUEwnh7r0KdvL7gsX5aurlWRdD+ZSc0iVxP1kXKeMhEvXjxH/36WuHbjBlYuX4aRQ4fg5atXWLHCFZt81/OYDoaGsBk0WHCslPLt+3fuqLF9y2bOyya1btqs2Wl6/z3NzODkNJ5db1LoC9a+Y0ccP3pEMF4RckcNHz4Et24kdPlRueDtW7cm2EZuJoqnun/vnuA4UijSTtpG5tZtYaRamzZtuLAiFUKkbpLKlhvFShRHmZJlUKRQkQTx4ukJEgRFixVjV1nN2rXh7raWo+7SNeldzVaEDFiyoA+5MryrVqRt316yjNM5nSm2cAAAFSJJREFUpSr/n0QaG021ueRRZohShjTCTZG5M2cIAidI9VZWalfyq/MHBX1Ia3OR0UsZdK1k6CIDGB1fXs2mbCn6vOj7Qc9SWQni3yG11GwpdDzKfZeq2fQZHD2SruO7M14XSPJvkho0b8482FhZosp/mmis04QDKtIKCiro2bMbhg8ZiejTsUpzfNMSChQpXLAwnit0j6xdp65SFVoRkuT4ZbiShwxk8+fNSbCN/M63rl8XHIOw7NsHo+zssWmTHzfRUyZ1pXnG0b/6ad2Xi72m/OXBg61haNSJ1dZmes1gbGIiOEZyoWs5d+5cqnwC9IxoGUf9sXLnyoWWrZvBd73fb3UU/dOkWdBI6zZtkTtXbo4Mkg8mSC3o4d66dRsrV7pxkEVasW2zHzw9PODntwXaTZr8tQ+KosJu3rieIHBmwIABMDXtwoks8kEcyvBY64X4ixcT/BDp6DZFH/NeCNjjzx0bpdSoVZujtwoXLoQH9+5hvMM4Tkpp1rwFTsXE4Nmzp7gSH5+gcduZU6e42f3zZ8+wd89++O/ayR0pq9eoia1bNnEEGHXIbNxIB2/fvuXoLfrhSClLFy3Els2b0K5de9SpUQ2j7cfAZvCQZB+VIvVCTgTCz28jJwN9/PgBcefjOGovrRJuUps0m8zUyjT+0nUsnD8X3yU/MHz4SGhWrCgYlxLKli2XZhN56eKFXNS+Zy8zjlRLbZdWcqH73Oy3Ebp6zWR7UhvUfhb9sXvXDvTu0zfRI9Jk9Vzzs/WtlHz58yHkZARaNNdF/KVrKFK0KL/T33IABg+0RM3adXDz2nUULloE+Z49xdkzZ7Br7z4sX7yIx1HRfKpdttt/N/LnzYfJzlP5GpcvXYpSZUrj8rXLPBEuXryAl69fomrVahg2YiRq160ruL7kQD8Y8+bNxoO792A9cBDsxznI9qamCZYW5qj0X2WMG+uolkHOy9ODQ4YbNGjIVV+u37yBpk31YD1oCLJmzUDK65+oAUZrrD49e0imTZkseC8lLE+kcdzvQG4JKjFLa9HUcpmkJg72o5UGo8i31UmMyU7jBe4oya/PZ9eOhEXvO7RpzQkOlOUlXSM7jLHniDJaa1NQhVZFDXYdUnTXqJHDuX559K8i+VQxhdbO9P7IYUNSxc7w8dMndmsZtG+baK45PSNyF1JTBfpfWcQcjaH7oggwsrdQ5BmV+43+VWdMGeKa+ZdU8du6De/ev8OQgTaC99MLlF9LVSZpTa5Oc7g/TVkNDcycNlVw1vKaicdUS6mkVRk6jeoLttPn8+17whYvJKHevHmFWrVry7Sfli1bYssmP9mYzp1NMNZxPAYPtIJOE134B+yXLUVoaZUndx6EngzBkuUuKbYzkN3CrJsptm7ZgnU+vomqvqQVkruQmgt27mKEfuZmCd6n+PYyZYrBxMQYNoMGwXudJ+rUqYM9+w9C+1edsYzIH9Ud5y1YxGoYldcl/2lr/TaprnonB4reunAhjiPGrl+7glp16sBp0uS/dj1J0c9yAHr1MEVEWBh0dHVlKiCpx9u3beVEisTo09cCJ08GI/hEIFq2TljEkNbjNGGkpZEkEkBTUws3b92Ujelo2AmDbAagoubPzywu7jxWu62Co9NEtG3XXnDmO3cfIUdOoZFMXWhNfjEuDrGxsbh54xqGjxyJjoZGau9P0YSPHr/Avj3+XFKpbLly/MwePngAuxGjUFFLCyeOB8J9jSdnYWV4/lYR/KtXrshcPcpUP3VIqZrduZMBRz0pU13TM5Q8Il8wXtp3Wd0opeFDBgu2URF7+Txwcs3Q8RSL21NEGbmnSM1W5cJKDajdkDTOPbEEC3VZMHeOZLCNNY+2tOgjcMmpg6hmq+C/KlVw9dptlNcoD4N2bZQPSkMogqx2rTockEJqWUaCXEIRcpFaJE07GXTCnNkz1boLxcL44BJA9eHqvlJQppbcPvJ06mSMT59/lgnKnz+/4DipBd0LuR9pyUNW9ZRA1vqt2zZj5py57HYqUqyYzF2XmfirJlqKOKIPi+pAUZ7tyZBgVKykhX79LdWyQiYHUiFpvXfnzm00aNAIOk2awmawcP2YEXB0coLPOu8Euc2ePr5YvmQxFs6by7ngyrh29Sp8fLxx9dpVft6dTbrKRpFKus57AyaOd8BSl5W87fbt2yhRMmGnjkePH0OjzM+cX3I9pSbk2nr25DHq1m+AsWMdUFVFfro6UJ68l5cnNDU1ER4aio4dDLhRf2DQyd9e2n3//l2wLV2Rnpqtk7pL6t3QIeqls6mrZpMaSlFH6jRMyyiQ+qssKSKxVECdRg04kolSEFX1hiKLtESFmn3u7NkEZX9UHeN3GGc/mkv7pBT5CMETx4/zMk56TylFVLOTAam7VFanRbOW3AWDOkpQjG9KoA4LVHJo+vQZrAUkVaUjo0CVQsinqkg1MvrIRXq9ePECExzGoW7N6mjXth0O7D+oNJmCpDx1/Lh67Qob06T8+CFhHywdY7zDWBgZdOLgEwqm+N2UQ3k2+/lxYkzRokW4tE9KoLJQVGmVSgLt23sAG9b7cG1uat6eGshXIU2P/N1ICBVQ3nGnLl0wzn40l4cd4+CofGAinDl9CpYWfVmV9w84kKbru78BrZPLV6iA6IgINNb9fx0sQ+PO8PRcywX/Hz16BKv+FrCzGw2tShURFh4OLS0trsHVsFGjBFdN7iUjIyMcPxECh7E/G/hRQ7Y9/rtZnaYsKbJwUwkkEyV5x8mF1uI7t23B5UuX+Uc2pQwcYImAA/vg5bkO4x0d8PT5U8TEnEW58uVT7dPJljWbYFt6Igup2aRtp9cL3ODrg5NBQWjcpCm0tbVRo1YtWfL8iqVLYGc/Rjb21cuXiImOxpMnj3H16hU0b94SbdsLXSaZBerjNWSQDbbt3C0rCED07d0LjRpqI/hkECpXqsw+5J27diD2fDwiw8I4dbFu3brst6YiErfv3EZlrcqcgE/r6oePHuDBvfsYPGQ4fH3XoXq1akC2bOjZsye0G/9+SCtpWaeioxEeFooHDx6w73ngoMG/bR+h+uKkNYSHh3E4ayPtxux2atW6NbR1Uj/09vixo2jTtp1gezqhQbpaMyeGdD1N7iQp8mtmSpSn8qzqlKLNTJCLZeGChCV/qCwt1d6iTClpAQGqUx0RHsbrYOr/RWtKio6irDN6rsvkniXZFaSlcFe5qO6wkVyoNBAVkUgpZAOhwgfSHtl0n1K3U1piO3xYev7mZJysKel6ukN7A9jbjkxQkvd8bCz3Hdq+fVeGyG5JTcjF8vWzMCf45cvXnOFU6lfklVkfC9yQy4aa6jwDT5884awzYsiw4bL3yK7Qs7sZr4spUCOl0JJHS1MDes2aY8OmrSk+HgWAkNofGxePsWPt+T7dPYRdPFIL+q6RzUGSfhVYJl2umRNjuK0tT94LF+M4EYIat5csWQrRp85yMvm/iDqulrz58nLCQ80aP+tpUeRb48Y6ePpMeSrjWi9vwbbkQMkQS5cuwtdPn9GsRUucOnM+RcbHgH17EXvmNAoXKcoFDfLny4+AvXuwYdNmbvGaFsyaPo1tLRQGe/hY4B9PfU02GUXNFlENqc/yywtSs+WbqUmhYgKkOpOanZpuJWVQW9XUqptFpX3b6bfilrWkWltZqlf/7HehpQup8VSpMwNRP8NJZhEh9eo3QPduJqhU6T90NFIdu2xtZYPFixfgjZr1w5ILFR/w9PRg6zcFtrRo2eq3j0UdNmZMm8bCRle3CfT09DB/7hzs3XcANWrXFoxPDSiHe8WSRfjw8SM8PL2hrWa3jPSCOJkzAWTJ3b17L4yNDREa+n83j2I/6fCIMK5YktpdEMlHbT/KFuUrVoDdaHsO1f1dKFJvrftqXLoUzz2yY07FIPB4IIYMH56iH4fEoOcxZ9YMXL9xHWPGOqKJbsaaxFLEyZwJoMCOH99/cNPxWTOmo1rNn5VdaGJQoMPObVtx+NAhdtlpN9RGxYoVZe1pUsK52LOY4eyMbNmzY/GyZUm2t0kM6n+1drUbQkNPopNxJ3x8/x47tm9D23btYDvKHtmypb6t9vOXL9jk64OQ4BCMc3TkCisZmXTvZxZJGnc3V452mjhpCg4dPIDS5coCP35+pM+fP+PYd+qrdOzY0VSxJhPzZs/C3n17EBoeJXgvuVDZ4l7dunIh/PIaGujbrw+WLFoO60GD0uzTn+joyIkltiNGcQJGJiDj+JlFlEPGGmk7H3pNsdNU4F4aP92mdQtObaTXqVVVlFqj0vGiIyME7yUXOgYZtag9jPR1WscK7PHfzdefyWISRANYRiTw2DFERISjYIECyJ07Dxo0aAC/Db4oWKgQ9gUcgEkXY9QfPxF1atdFVxNTtGzVGs4zZiRZ9C8xSGX3WOOOTx8/cR0ySvr/3eNR7PjmTX64ffsWqlapCtNu3ZE1SxbcunUL5+Li+T5SG6r3vXTJInz+8AnaOo1VuuQyNKJkzjjcu3uXXSYd2+pLjhw+xC4min4KCQpKcA9UNICyxB4+fJjie6MsJGljc2qLk1LIvaSr3ZAj0qgxoGGHdvyaGqmnFVTcoE2r5pJ9/rsz75dDIqkvrpkzCBSD7L56NYYMHYqrVy7j6NGjaNeuHVeQVIRilimQJqVFF8jVRJUrG2lro6dZnxQdj4xNrsuX4uTJUNiNGo3Nmzch7vw5LFvhgkaN06buFlnZXV2W48yZM3AYPwFNmjYVjMlEiGvmjMC8X+tf6o1MsdadDQ0kvXv1SLPOGrdv3ZL0MO0iGW03QhJ3/pzg/eSyYtlSiUlnI0nA3r2Sac6TuVonSei0hNbfA60HcGeNfwRRMmcEhg0ehDevX6F9h44IDQ1FvXp1uVrK4cMHufOCrd0o6KdCNg9J4jVr3LlV7MhR9ikq1/PowQM4T5nMa1VDQwNERETi65cvXDe7bv20q/Dit2EDoiMjUKt2LVhYWqXITpDBECVzRoDWrPK9lKz69+P+R9La0T1MTX6rQJ08y5cuYemfWutKsx6msoblzXR10rwlKhWFpAojNlaWgvf+EUTJnBHoa9aTr5KyxvCrG2X8hThuZk6F+LJly8a9nXJkzYZG2jpo0KgRKv9XBVmzZkn07m7euIHoyEhezz598hhDho8QRI2pC3XHPH/uHPeWio6KRLly5VCkSFGcO3cWA6xtuK52WkD50ZRAcuXyZVTS0kIvs96pXj8ugyBK5oyAomRWRNFvSjnD5LdNjAkOYxM0Rk8JpCF0NvqZZx4ZFsbXQuvktISkPvmkvT09/vWvh5T64mTOACQ1mSW/2r7Sl5uS9Cl5nwoBkBuLXitCWUjaDeumSr1wOi+5x4KDTsjan6a1Sk2tfOkHg4JhqKWQCCMGjWQWqCiDpdUguLuuhO2woXB1X4vQkCAMGzQQY8c5cIuZ0JBgrHZ15c4OJ4LDUuxqmjFlMr7/+IGjR09glctySJAFAfsOplkzv0+fP2Ot2yoEBwVnqO6MfwpxzZwBUFwzJ8Xz5885XjsqKgL9+w/AjZs3EBkejsKFC8PFdXWKLLxUrWTe3FkoXrwE6tdrgICAvShSpAjGjZ8ADY3UK54nD7WpcVu1EufPnUX3HmZopa+PPHkyVuOCP0ADcTJnAJI7maWQ9FyxZDFu3LgBKytrbkhO7V/tRtmjg6GhYHxiUKeL5UsW4eGjh7C2HohVq1YiV66c/OOQVlDp3IMB+7Bzxw7Y2dun52J66QHRAJYRUGfNnBi0hqV1LQWdEBQOOmfmjET2SAiti2mNam83Ulbt40+ti8ndlJahnpkI0TWVEfhdySwP5TUvX7oEFTU1kTVbdly8GIfKlbSQN39+Dv2krpLSEsb4VekjKjIKb9+8RsjJEN5Pq3IVXL4cj+7de6ZJ4AcFmFCLordv33JXylat0qZkbiZFlMwZgZRKZkWoPK20TC1BVuGJE8bLRlHihpamBlunye31J9ISybJOFvZVy9PWpZWJEV1TGYHUnswExSxX0dLkutlENxNjntQUSVWz2n/sO6b3Oht2lI1JS8illhq9pv5hRDU7I5AaarYyqFNiVHQUvn/7ziWAcufOhXLlyrMVvImuHlu9tRtro4Jm6jfEp/xoahpPnUeKFSuGChUqoHGT/zeQF0k2DUQ/cwbhzp07qX6hVCC/cxcTfk0Tt3efHvx644Yt6NS5s2B8akEJHSYmxny0iKhT6b8edQZB/BnMAMyaMx8VK1aCj5dXml2sgZERB2K0b9MhzSbyt2/fscHHB9OnToXvBj/EX74uTuRURJzMGQCKdPLdtBkxp6K5TQp19EgL6DxpmTJo0bsXgoNPYOfevWjRqnWKiyeIJERUszMQLqvcEBMViY0b1iPH5hycHUWdD9VpT/O3oKonJ4ODERQciG49e3JWk0jaIE7mDAb5XaW+V1p71qtXEzOmz+bi8+kJCsFsVK8O3rx9w+vivv37/+sfXZojqtkZGEpouH3nIUJPhnDT9fTE4gULZJ0axXXxn0GUzBmcQoUKYZ3vRoSGhMB1pQtuXr+Olq310dnE5I/eGCV3+O/ayQ3gq9esCQNDQ9RPo+wpEeWIkzkTQBlE7Tp04H+UXGFs0AFx52PhNNk52TeX9zcrjfS36IN6depj+qw5omHrLyGq2ZmMXDlzYu/+g1yUr6txJ6zz9EjWDX54/16wTRUvXrzAlIlOGGDRF9NnzMKcBQvEifwXESdzJoTcSwNsBmH3vgDkzpMH7du05nxgalKeGpBxizo1jhg2GP0HWGHdho3QTqPa1yLqI07mTE5v877Ys+8AN2QbZDWAi+lTx0VVlNPQUPHOTyjoo1uXzihTujTWb9iEKlWrCsaI/B3ENfM/AKm+xiZdUa1GTXTv2oWbs/v6bVJ641SNRBVjRtlyI/W9Bw6qGCHyNxEl8z8ESdFzFy/h/dt3sOjTS+mNv3r1SrDtwL59qFi+LG7duIU1nt6C90XSB6Jk/gfZ7v+/bWS4cP48w5SJExnu3L0NXvedlZMLPpwANMXEAN3VBOoXf/r4kcHIxIRh1+59DCqjTepBDUYz8wgEoG2GRsbGYPzx40eG6VMmM+RkpDHMmreA4dvXLwxPnzxh8HB1ZnBxcWVo7+4ZSVe8DGkwup95FIDB2tWrGRrqahjevHvD4OPly9DQ1MwgLUub0zZHAU3A6OmcowAVgHZk6errY4iPgkEPRjPzKBgFwwQYjo5mj4JRMEzAaGYeBaNgOAAGBgYAQ8ZC5iDspXEAAAAASUVORK5CYII=" id="_4989f791-b93f-831b-5d40-402089695052" mimetype="image/png" height="auto" width="auto"/>
+  </figure>
+</clause>
+    </clause>
+    <clause id="_determination_2" inline-header="false" obligation="normative">
+      <title>Determination</title>
+      <p id="_5b5daed2-989a-48e3-6d9e-5ec813ba0653">Weigh, to the nearest 0,1 g, one of the test samples obtained in accordance with 
+      <xref target="AnnexA-4-1" style="short"/> and separate the different defects into the bowls (
+      <xref target="AnnexA-2-6" style="short"/>). When a kernel has several defects, classify it in the defect category for which the maximum permissible value is the lowest (see 
+      <xref target="table1" style="short"/>).
+    </p>
+    <p id="_18a57f74-5653-c342-718a-43fbdb2eb965">Weigh, to the nearest 0,01 g, the fractions so obtained.</p>
+  </clause>
+  <clause id="_calculation" inline-header="false" obligation="normative">
+    <title>Calculation</title>
+    <p id="_3c7492f4-584f-d6cc-4191-977927cf7455">Express the mass fraction of each defect using 
+    <xref target="formulaA-1" style="short"/>:
+  </p>
+  <formula id="formulaA-1">
+    <stem type="MathML">
+      <math
+        xmlns="http://www.w3.org/1998/Math/MathML">
+      <mi>w</mi>
+      <mo>=</mo>
+      <mfrac>
+        <mrow>
+          <msub>
+            <mrow>
+              <mi>m</mi>
+            </mrow>
+            <mrow>
+              <mi>D</mi>
+            </mrow>
+          </msub>
+        </mrow>
+        <mrow>
+          <msub>
+            <mrow>
+              <mi>m</mi>
+            </mrow>
+            <mrow>
+              <mi>s</mi>
+            </mrow>
+          </msub>
+        </mrow>
+      </mfrac>
+    </math>
+    <asciimath>w = (m_D) / (m_s)</asciimath>
+  </stem>
+  <dl id="_e504d366-420c-5589-72c1-7e78d2c68598" key="true">
+    <dt>
+      <stem type="MathML">
+        <math
+          xmlns="http://www.w3.org/1998/Math/MathML">
+        <mi>w</mi>
+      </math>
+      <asciimath>w</asciimath>
+    </stem>
+  </dt>
+  <dd>
+    <p id="_e5c85385-253c-1df7-4f45-a4f78c9d3338">is the mass fraction of grains with a particular defect in the test sample;</p>
+  </dd>
+  <dt>
+    <stem type="MathML">
+      <math
+        xmlns="http://www.w3.org/1998/Math/MathML">
+      <msub>
+        <mrow>
+          <mi>m</mi>
+        </mrow>
+        <mrow>
+          <mi>D</mi>
+        </mrow>
+      </msub>
+    </math>
+    <asciimath>m_D</asciimath>
+  </stem>
+</dt>
+<dd>
+  <p id="_6a8713af-5a9a-dbe3-4bea-5f9c5dc84ad2">is the mass, in grams, of grains with that defect;</p>
+</dd>
+<dt>
+  <stem type="MathML">
+    <math
+      xmlns="http://www.w3.org/1998/Math/MathML">
+    <msub>
+      <mrow>
+        <mi>m</mi>
+      </mrow>
+      <mrow>
+        <mi>S</mi>
+      </mrow>
+    </msub>
+  </math>
+  <asciimath>m_S</asciimath>
+</stem>
+          </dt>
+          <dd>
+            <p id="_00ea8e8c-b2aa-4c40-6e0b-d17963490d4f">is the mass, in grams, of the test sample.</p>
+          </dd>
+        </dl>
+      </formula>
+    </clause>
+    <clause id="_test_report" inline-header="false" obligation="normative">
+      <title>Test report</title>
+      <p id="_3ee43fd9-43f3-f8c9-d010-ac07d4351264">Report the results as specified in 
+      <xref target="clause7" style="short"/>.
+    </p>
+  </clause>
+</annex>
+<annex id="AnnexB" inline-header="false" obligation="informative">
+  <title>Determination of the waxy rice content of parboiled rice</title>
+  <clause id="_principle_2" inline-header="false" obligation="informative">
+    <title>Principle</title>
+    <p id="_dc34d3c6-2fa4-e25f-45ac-c1b38490eaac">Waxy rice kernels have a reddish brown colour when stained in an iodine solution, while non-waxy rice kernels show a dark blue colour.</p>
+  </clause>
+  <clause id="_apparatus_2" inline-header="false" obligation="informative">
+    <title>Apparatus</title>
+    <p id="_7651fd7a-2987-6dee-4e11-84c52fe7aa1c">The usual laboratory apparatus and, in particular, the following.</p>
+    <clause id="AnnexB-2-1" inline-header="true" obligation="informative">
+      <title>Balance,</title>
+      <p id="_f8ca3c50-1314-d6e2-6e41-d84421c5cd12">capable of weighing to the nearest 0,01 g.</p>
+    </clause>
+    <clause id="AnnexB-2-2" inline-header="true" obligation="informative">
+      <title>Glass beaker,</title>
+      <p id="_5668c201-ae27-fb8b-dda5-190d98da9dfb">of capacity 250 ml.</p>
+    </clause>
+    <clause id="AnnexB-2-3" inline-header="true" obligation="informative">
+      <title>Small white colour bowls,</title>
+      <p id="_11ea6fbf-faa4-4b8b-a22f-3fde6a11690d">or any white colour container of a suitable size.</p>
+    </clause>
+    <clause id="AnnexB-2-4" inline-header="true" obligation="informative">
+      <title>Wire sieve,</title>
+      <p id="_960b4ad7-76bb-cfb3-4519-d8da9b5487cc">with long rounded apertures of (1 mm 
+      <stem type="MathML">
+        <math
+          xmlns="http://www.w3.org/1998/Math/MathML">
+        <mtable>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mo>+</mo>
+                <mn>0.02</mn>
+              </mrow>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mn>0</mn>
+            </mtd>
+          </mtr>
+        </mtable>
+      </math>
+      <asciimath>{:(+0.02),(0):}</asciimath>
+      </stem> mm) × (20 mm 
+      <stem type="MathML">
+        <math
+          xmlns="http://www.w3.org/1998/Math/MathML">
+        <mtable>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mo>+</mo>
+                <mn>2</mn>
+              </mrow>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mo>−</mo>
+                <mn>1</mn>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+      </math>
+      <asciimath>{:(+2),(-1):}</asciimath>
+      </stem> mm).
+    </p>
+  </clause>
+  <clause id="AnnexB-2-5" inline-header="true" obligation="informative">
+    <title>Stirrer rod.</title>
+  </clause>
+  <clause id="AnnexB-2-6" inline-header="true" obligation="informative">
+    <title>Tweezers or forceps.</title>
+  </clause>
+  <clause id="AnnexB-2-7" inline-header="true" obligation="informative">
+    <title>Tissue paper.</title>
+  </clause>
+</clause>
+<clause id="_reagents" inline-header="false" obligation="informative">
+  <title>Reagents</title>
+  <admonition id="_66a4eee8-5de4-52e4-29aa-4abee70ea73a" type="warning">
+    <p id="_598d89f6-04e1-c9e5-f3fa-c5940bd9fc98">Direct contact of iodine with skin can cause lesions so care should be taken in handling iodine. Iodine vapour is very irritating to eyes and mucous membranes.</p>
+  </admonition>
+  <clause id="AnnexB-3-1" inline-header="true" obligation="informative">
+    <title>Deionized water,</title>
+    <p id="_b93ac6b7-2fad-4877-cf2c-ad50ce91fac7">Grade 3 quality as specified in 
+    <eref type="inline" style="short" bibitemid="ISO3696" citeas="ISO 3696"/>.
+  </p>
+</clause>
+<clause id="AnnexB-3-2" inline-header="true" obligation="informative">
+  <title>Iodine stock solution,</title>
+  <p id="_d1128d20-073c-de12-8b0f-e770c17cc9b1">containing a mass fraction of 4,1 % iodine and 6,3 % potassium iodide in deionized water such as Lugols.
+  <fn reference="3">
+    <p id="_bb142326-fa7a-d7f0-a679-986581cad924">Lugols is an example of a suitable product available commercially. This information is given for the convenience of users of this document and does not constitute an endorsement by ISO of this product.</p>
+  </fn>
+</p>
+      </clause>
+      <clause id="AnnexB-3-3" inline-header="true" obligation="informative">
+        <title>Iodine working solution,</title>
+        <p id="_9b1eeae3-4fe4-d1f2-38f4-986eed214fbd">obtained by diluting the stock solution (
+        <xref target="AnnexB-3-2" style="short"/>) two times (by volume) with deionized water (
+        <xref target="AnnexB-3-1" style="short"/>).
+      </p>
+      <p id="_b32a1e8e-ef5f-c586-a6da-8db31483e06b">Prepare fresh daily.</p>
+    </clause>
+  </clause>
+  <clause id="_sampling_2" inline-header="false" obligation="informative">
+    <title>Sampling</title>
+    <p id="_e1ce00c0-44d4-2215-e193-e27957c73ca7">Sampling shall be carried out in accordance with 
+    <xref target="clause5" style="short"/>.
+  </p>
+</clause>
+<clause id="_determination_3" inline-header="false" obligation="informative">
+  <title>Determination</title>
+  <clause id="_3" inline-header="false" obligation="informative">
+    <p id="_de12dad9-6914-edc3-31a5-97132804cbfd">Weigh a portion of about 100 g of milled rice and put it into a glass beaker (
+    <xref target="AnnexB-2-2" style="short"/>).
+  </p>
+</clause>
+<clause id="_4" inline-header="false" obligation="informative">
+  <p id="_50fbf623-57e3-fcb0-8ba7-54e112fdabb9">Add enough iodine working solution (
+  <xref target="AnnexB-3-3" style="short"/>) to soak the kernels, and stir (
+  <xref target="AnnexB-2-5" style="short"/>) until all the kernels are submerged under the solution. Let the kernels soak in the solution for 30 s.
+</p>
+      </clause>
+      <clause id="_5" inline-header="false" obligation="informative">
+        <p id="_3e5736a7-4c43-107c-95af-d436a76b5b00">Pour the rice and solution into a wire sieve (
+        <xref target="AnnexB-2-4" style="short"/>), and shake the basket slightly in order to drain out the solution. Then place the wire sieve on a piece of tissue paper (
+        <xref target="AnnexB-2-7" style="short"/>) to absorb the excess liquid.
+      </p>
+    </clause>
+    <clause id="_6" inline-header="false" obligation="informative">
+      <p id="_ee4c7907-e50f-2f7e-4f78-05417b6300a2">Pour the stained kernels into a bowl (
+      <xref target="AnnexB-2-3" style="short"/>). Using tweezers or forceps (
+      <xref target="AnnexB-2-6" style="short"/>), separate the reddish brown kernels of waxy rice from the dark blue kernels of non-waxy rice.
+    </p>
+  </clause>
+  <clause id="_7" inline-header="false" obligation="informative">
+    <p id="_812fc00f-7247-44ca-54b0-714e9c6d67f9">Weigh the waxy rice portion (
+    <stem type="MathML">
+      <math
+        xmlns="http://www.w3.org/1998/Math/MathML">
+      <msub>
+        <mrow>
+          <mi>m</mi>
+        </mrow>
+        <mrow>
+          <mn>1</mn>
+        </mrow>
+      </msub>
+    </math>
+    <asciimath>m_1</asciimath>
+    </stem>) and the non-waxy rice portion (
+    <stem type="MathML">
+      <math
+        xmlns="http://www.w3.org/1998/Math/MathML">
+      <msub>
+        <mrow>
+          <mi>m</mi>
+        </mrow>
+        <mrow>
+          <mn>2</mn>
+        </mrow>
+      </msub>
+    </math>
+    <asciimath>m_2</asciimath>
+    </stem>) to the nearest 0,1 g.
+  </p>
+</clause>
+    </clause>
+    <clause id="_calculation_2" inline-header="false" obligation="informative">
+      <title>Calculation</title>
+      <p id="_fcac1a0e-ac88-7823-e539-6afc246f4c84">Calculate the mass fraction, expressed as a percentage, of the waxy rice, 
+      <stem type="MathML">
+        <math
+          xmlns="http://www.w3.org/1998/Math/MathML">
+        <msub>
+          <mrow>
+            <mi>w</mi>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mi>w</mi>
+              <mi>a</mi>
+              <mi>x</mi>
+            </mrow>
+          </mrow>
+        </msub>
+      </math>
+      <asciimath>w_(wax)</asciimath>
+      </stem>, using 
+      <xref target="formulaB-1" style="short"/>:
+    </p>
+    <formula id="formulaB-1">
+      <stem type="MathML">
+        <math
+          xmlns="http://www.w3.org/1998/Math/MathML">
+        <msub>
+          <mrow>
+            <mi>w</mi>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mi>w</mi>
+              <mi>a</mi>
+              <mi>x</mi>
+            </mrow>
+          </mrow>
+        </msub>
+        <mo>=</mo>
+        <mfrac>
+          <mrow>
+            <msub>
+              <mrow>
+                <mi>m</mi>
+              </mrow>
+              <mrow>
+                <mn>1</mn>
+              </mrow>
+            </msub>
+          </mrow>
+          <mrow>
+            <mrow>
+              <msub>
+                <mrow>
+                  <mi>m</mi>
+                </mrow>
+                <mrow>
+                  <mn>1</mn>
+                </mrow>
+              </msub>
+              <mo>+</mo>
+              <msub>
+                <mrow>
+                  <mi>m</mi>
+                </mrow>
+                <mrow>
+                  <mn>2</mn>
+                </mrow>
+              </msub>
+            </mrow>
+          </mrow>
+        </mfrac>
+        <mo>×</mo>
+        <mn>100</mn>
+      </math>
+      <asciimath>w_(wax) = (m_1) / (m_1 + m_2) xx 100</asciimath>
+    </stem>
+    <dl id="_8587d26e-04be-d19f-84a5-948d705b2a11" key="true">
+      <dt>
+        <stem type="MathML">
+          <math
+            xmlns="http://www.w3.org/1998/Math/MathML">
+          <msub>
+            <mrow>
+              <mi>m</mi>
+            </mrow>
+            <mrow>
+              <mn>1</mn>
+            </mrow>
+          </msub>
+        </math>
+        <asciimath>m_1</asciimath>
+      </stem>
+    </dt>
+    <dd>
+      <p id="_5fbf548a-bbe0-c874-65ae-db364e508904">is the mass, expressed in grams, of the waxy rice portion;</p>
+    </dd>
+    <dt>
+      <stem type="MathML">
+        <math
+          xmlns="http://www.w3.org/1998/Math/MathML">
+        <msub>
+          <mrow>
+            <mi>m</mi>
+          </mrow>
+          <mrow>
+            <mn>2</mn>
+          </mrow>
+        </msub>
+      </math>
+      <asciimath>m_2</asciimath>
+    </stem>
+  </dt>
+  <dd>
+    <p id="_d0e57c49-25c5-9e54-747b-a753ab365bc8">is the mass, expressed in grams, of the non-waxy rice portion.</p>
+  </dd>
+</dl>
+      </formula>
+    </clause>
+    <clause id="_test_report_2" inline-header="false" obligation="informative">
+      <title>Test report</title>
+      <p id="_8b31469a-a8bf-eb68-6fc5-c6e659671fc9">Report the results as specified in 
+      <xref target="clause7" style="short"/>, giving the results calculated using 
+      <xref target="formulaB-1" style="short"/>.
+    </p>
+  </clause>
+</annex>
+<annex id="AnnexC" inline-header="false" obligation="informative">
+  <title>Gelatinization</title>
+  <p id="_3f84ffff-39e3-0018-d39c-77f7d3fad186">
+    <xref target="figureC-1" style="short"/> gives an example of a typical gelatinization curve. 
+    <xref target="figureC-2" style="short"/> shows the three stages of gelatinization.
+  </p>
+  <figure id="figureC-1">
+    <name>Typical gelatinization curve</name>
+    <image src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAXkAAAFKCAYAAAD47S8+AAAACXBIWXMAAAsSAAALEgHS3X78AAAePElEQVR4nO3df4hl533f8c83Ev7DXbG3xbRIoGhKYEUKYicsNMTF7KgOKSm73lFdEiSR7giZVXErdiwJhQjcnU2pA0auR3VpkSBo1GAtNhWatRb/kZDsbF0CLloyoiCQGpOR3e5ip2lG3e2Wisjf8ux8j/bonntn58d5zr33ue8XXObe55wz595zzv3e5zw/zd0FACjTz+z3U5nZQTP7upmd6UtPaS+b2Z+Y2eHauq9H+sX0uvEPAQCt2VeQN7P7JK1Imu1LP5HS3P0xScuxTrIoaT3SNyQtNf4pAKC9IG9mT0au+pNm9h0zez4C9Tfj8cnGVsHd33P3hySt9S36jKTL8fy1FPDj/xyvpf9+rAcAxTKzQ6P8bHdK+u8RpP++pLskXYtilHvc/cHGFjtzrVrL3a+bWfp7w8yu1ZZdqa9XZ2Z/Kel3Byxfc/dLjQ0AYExE/JyTNC/p8ymumtncqGJXCvL/N54fj+KTuShiWWysvXM9SZv1tc3sQKRXen2v63ru/kwjFcDYMrOjEdhmJH3R3a9Oy9kys7sl/VotuFfeSKUZo8yc3hl/FyQ9WXu+4u5vNdbeuc2qnD4qXdcjR78R6ZfiQljv6HMCaElqVFH7/h5Jd93ufr5Wz5YyifdIKjrIR53kfF9g34w6yFQ6suru7zc27FgK8v8rnRx3vxAVppvufnYXH/RoBO4ZM1uLMvf0Idfj/y3ESVdVCWtm65G+0PiHAMbdagrmKU7E9z+9/usR7GZLPnu1HPtC7bOmwP6SpFfHsTh53+3k4yTXXY5c+8E4CJv1u4L49ZuJH5b3Gv9wax13d2ssADBy8Z1PQf7BKIa9FkWvVWu59P3+trufG/ezZWanJP1q3IWsDgrSEcvmaw9V6w/bZpyMZWcogjwwviLIf03S05K+IOlPd3P3Pw6ixct3JN3f93ZSGfojkv6GpH8cdZVzsSyVVPyBpP/o7u9Oyme9s5ECALd3R6zx7KRVsEbO/PtDGn6koP6j2rK1KJoZi/L1vSDIA9iLzQluzjw/JMBXenGn8o1hRcqTZN/DGgCYOrPRwXFShyWZaaQ0fa2EAC+CPIA9WK+1h58otQYhtzOwo+YkouIVQPGi6eOp6OS5XVGNomf9Xnv7jx1y8gBaE00Sx4aZHTGzFyX9t2gN9O1oLXN8SG79HUlPNFInGBWvANr04zSUeIw0OzJVW/4I6Kmz0r+InrkftZAxswckPSepGkAstaB5obSrgeIaAK0ys9OSfpB60Xd9ZFPOXdLzteCeetkvT2rzxzYQ5AG0Lg1THoOUdRJco0J1MYpkPiS430KQB9C6qOh8NbXCyR1oo2hmJVr7pB6rT5bS/LENVLwCaF30gl2sDU7Yumo60eiVmlrMLLj75wjwH0eQB5BFDEz4WjXbXJvMLM0q97akz0bv1Hvd/RXOZBNBHkA2Ufn6X2MM+laY2UlJ/0nSTyQ9kCYYSiPfchYHI8gDyCpy2JsRnPcl/sdKlL3PUTRzewR5ANnFUMRz+5nUuhbg07AKj9ByZmdoXQOgE9HM8fdS5ehu91dNIxqPOQL8zhHkAXQmOiv98930iI0AvxYvZwjwu0NxDYDOuPvl3bS4MbNPSvqWpBuSfpEAv3sEeQCdqrW4ObOD/f52TNH3yCRNuTdOCPIAOhctbnrbtbiJSf9PxfAEkzoL1cgR5AGMhLt/KVrcHI3hgPtVvWWXGkuwYww1DGCUUgDf0FbO/Y+rXqsxHk2afWqJcvj9yda6JsrbevFYrE5UpKeBhDai7WwDrWuA6WBmf1abRjDFhL+tW+m9GK6A3qz7kKW4Jm69rsXt2GuS/lC3Avxd0Xzq0A4rXgCU69OSXopPN5NmljKzpyLw/yYBfv+y5OTjV3ihqixJOfMU3CV9L26/zkeFS8rh/8KA7cnJA1PEzI6ljlLxiXulzbM6SrnK5NdimNFLMUtMZTMeinK4zcaWIdrRDpqDEUCZVlPmMD4Zla0tyRXkU4BfrBXHbKbbLrNG5ny7WdOXuFUDpouZzUYuniaTLclSJp8qWVOlaq1idTX+9mqVLLNVrfogBHhgusTwBbPb3eFj97K1k49ZW07HhLqLkbxcux2bjxHlAEARJ1Y5Eu3K2YTyWDxdq+fKI/0eSe8MuyWj4hWYLmb2KUl/HkMYPDyseTV2L1tnqBifomFYOoCp9k9SLj6NTzOg7g77wLAGAMbB8ZyTfk8zgjyAkYqByA4NK77F/hDkAYxaqnA9x1nIgwHKAIxaanH3y5yFPMjJAxiZGKfmBzFjFDIgyAMYpSclfYMzkA9BHsBImNmJ1Au+GkMeeRDkAYzKIs0m8yPIA+hcNJucY2iT/AjyAEZhMXq4vsfRz4smlAA6ZWYHJD0uiUlBOkBOHkDXnpZ0mWaT3SDIA+jaAmXx3SHIA+iMmR2l2WS3CPIAuvQIzSa7RcUrgKyiuWQ17WeaNOjTHPHuEOQBZGFmhyS9KulI7f//H0kPSKLpZEcorgHQumgm+f2+AJ/8NUlvxJAG6ABBHkAOqey9t83/XWqkIAuCPIBRmOWod4MgDyCHAxzV8UCQB5DDu7f5n6uNFGSRrXWNmZ2KX/O7JF2oujDX0q+7+0uNDQFMPHe/YGZvSDo+4LO8I+k3G6nIIktO3szOSPold//X8Yv9ZqptN7PTtfRfjdcACuTunxswfEFqUvmL7n67nD5akqu4JlWqrGvrRL9VS1+o3aatxmsA5Upjxi+4u8XjUXd/n/PdnVzFNanb8oqZ9SLgL7v7dTPblLQZ62zUnjeYWeoZd60vfYPxp4HJUI1TQ/n7aOUK8r0I4GvxfK6xxq31AJRpISYGIec+QrmCfJr1ZcndL0m6ZGYePeB6tcA+s11OPlXcNBIBTIT4vi/UxqzBiOQqk0+VKr8Wla1Hozb9p3Hb9nis83lJtK4ByvSFNHwBxaujlypCsrwJMztZy62vVLdstfS1yOk3pJx/qqRpLAAwEczszTQD1LDv+HZS6zx3P7vNKtiFbO3kh00KMCwdQBliaOEDewnwaB89XgG0LQ0+do6jOh4YTx5Aa8zsoKR5Sb/MUR0P5OQBtCkF+M1qGBOMHjl5AG36iqRnOKLjg5w8gFZEy7kP3J3y+DFCkAfQloUBA5JhxCiuAbBv0WxyLsrkMUbIyQNow1K90yPGBzl5APtSazZJLn4MkZMHsF9pPKp1eriOJ3LyAPbry0wANL7IyQPYs5jcJ3V+Os9RHE8EeQD7cZxmk+ON4hoA+/GwpHs5guOLnDyAPYkerms0mxxvBHkAe/WkpG9x9MYbQR7ArsW0nj/n7t/k6I03gjyAvVikwnUyUPEKYFdinJr5mKsZY46cPIDdWogK1/c4cuOPnDyA3Vqkh+vkICcPYMfM7JSkH9PDdXJkyclHzftcX/JL7n61tmyNAY2AifNbMawwJkSunHyqlJmtvU63d9fM7ERcIMvpb7wGMAHi+9pz91c4X5MjV5BPufSH3P2spI0U1N39ejU9WPSQW6FcD5goTO83gbIU1/SV1y3Vim5mIugnm9s1wTKzA/HDAGDEzOxumk1Opqyta8wsDV70Wq2p1WZtcXr+YWOjW75gZjf60i67++XGmgBy+3VJr9JscvLkbkL5lb4K2F48FDmCHzW2CO6+3EgEMCr/NAI9Jky2JpS1Eerqv/yrtXkgb7awaWwIYKyY2WFtZbze4sxMnpzt5Gf7K2miInbTzF5OZfPu/kJjKwDjJrWOO8dZmUzm7mP3xs3S23JrLADQKTM7GPVn97v7u13s28zORIYQLaDHK4DtpGaT610FeLSPsWsADJSaMUt6VtITg5ZjMpCTBzDM5yV94O4XhizHBCDIAxhmMYYgwQQjyANoiGaTMwxjMPkI8gAGSbn41RhnChOMilcAHxPNJhf6RpLFhCInD6DfYvRWp4drAcjJA/hINJtcrA0/gglHTh5AXRpTapNZ28pBkAdQ9zDNJstCcQ0wxWqVrPMxRs1nJX2Ra6IcBHlgSkVb+LXaHA+VlJN/jOuiDBTXAFPIzD4l6XsDAnyyYGbPN1IxkQjywHT6R5Lu2uaTP95IwUQiyAPT6e7bfOqemd3XSMXEIcgD0+nq7T41k3aXgSAPTKc3bvOpGZisEAR5YAq5+9VoOjnIevR6RQFoQglMKXd/xcw+LelYFN9ck/QHkv6Nu1/nuigDQR6Ybr8i6bkU8Kf9QJSK4hpgSpnZCUWOnmugXNmDfOpVV2+KlbpRm9lRmmcBI7dIBWv5sgX5COYX65MP9HWjXo3XADpmZnfHiJME+cLlLJNPwXyxb8jSmzkHdz9vZjPxmjEygO49HN9F2sIXLktO3sxOSfpQ0j3puZkdikUPRPOs5AfxeiAz++SgdACt+IKkf8uhLF+unPzPR3Ost6No5vtmdm+kVa71ve7322bWv3yNyQyA/Ul1YpJuuPtlDmX5shbXVHNEmtmGpPsj4Fej3vWGjIB3k7s/00gE0IaFHfR4RSFyVbymyQdSmXs1KUF6fiWKaqoZ4FOlz2pjSwDZRKu2FORf4ihPh1w5+eVoPfP1CPCpAvaqmS1G+kzk4od1qwaQx0LcZd92gDKUIUuQd/f3JT2403QAnUlBfonDPT3o8QpMCTNLzSb/Hz1cpwtBHpgeX5H0O5zv6UKQB6ZANJvs0dhh+hDkgemQyuJXo14MU4ShhoHC1ZpNznCupw85eaB8VbNJxqmZQuTkgYLFGFBpLKknOM/TiZw8ULY0MchP3P0C53k6EeSBsj0cPdAxpQjyQKFi3KgjNJucbgR5oFzzUeFKs8kpRpAHypXGqDnH+Z1uBHmgQGZ2TNInJP0R53e6EeSBMj2dxox39xuc3+lGO3mgMGZ2OCblmefcgpw8UJ40Oc8KFa4QOXmgLNFscp5cPCrk5IGypHFqNtz9Eud1uDQ1qZmdbCwoEEEeKMuzkr7KOR3OzE5FkdavmNmjQ1csBMU1QCEiZ/qBu9M2fnvvRCex4gO8yMkDRVlgnJodudkTuFoxjbdvZqfrxTepn0FKG9tPsAsEeaAAZnYomk2ucD5va64e5OOYpcdMCvTRBDUdz14J5fadBPmYmQZAPg/TbHLHZtOjllPvxXFbi9mzUk7/UryenYDPs60sZfLxS1jdNqbJg9clPRbNu5bjQG6m20suSqAVx6OXK25vLmJQNTrnWmptEwF9rTZN4kbEqYmWq+I1BfZ3U7fqeH0l/i5G864U8F+MVgDMWAPsg5kdTVvTbHJn4jh9dKzc/UvaOo7fjAHd0o/Az0q6e7w/yc7kLK5Jgf1P3f2yu1+NtHqFx3cl/d3GVgB2K2WeXuWo7U0qYYic/FfdPWVOvyXp78VY/BNfkZ0rJ78Rtz5LZpYC+5K7v9J367O53a1Q5PSv9CWvkVsBbon6rvQd+yKHZW+iyPhL1cbx+pkJ+xhDZQnyMSv8Q9q6CNei5vqVKMap9Ppe9/8PinGA20vNJldrd8voExWs97p7MYF7N7IU10S704Pxsp5b36jVVs9EhSyAvVuk2eRgUQzzurYyjVMZ4JWxuGYh2pyu9F2E6e+yma3HOguNLQHsSLTh3nT38xyxjzOzExF7Ft39rcYKU8TcPccBPiDp/nh5LSozqmWpxvqeVN4+7BbTLL0tt8YCAPXvyZsxMchLJR0VMzvj7mcbC3a2bWoV8zup9Uxpx2WvcpXJX5d0ubFga1kK7AODO4CdiZzqzxHIbolj8rik36D/zS0MUAZMpgXK4rfUOlmmPjifa6ww5QjywISpNZucmfZzFx3BlqKZNs2rByDIA5NnMZpNvjfN5y46MCXzFM8MR5AHJs9Ut0yL4pnfk/S7tCy6PYI8MEHM7B9IujGtwc3M0mibaWank+7+w8YKaGA8eWCy/DNJz03bOat1bPqb7v4gAX7nyMkDEyKKKdKgWb8xTeeMjk37Q5AHJkdqUXN5mioZzez56FD5YGMhdoTiGmByLNXmaChajH/1evyo7an3K7aQkwcmQLQH7/XNTVqq+RjIcHHam4m2gSAPTIano8ng9ZLPV4xt9ba7P9pYiD0hyANjLnq4Ht9u/oVSpLGtzOxdrsn2UCYPjL9UFr9Cr07sBTl5YIxFs8n5eAC7Rk4eGG/zMTEIg29hTwjywHhbigewJwR5YEyZ2TFJn5D0GucIe0WQB8bX0zG9X9HNJpEXFa/AGIr24nNUuGK/yMkD4+kUzSbRBoI8MJ6OM4cr2kCQB8ZM9HA9QLNJtCFrkE/limZ2sfb6QBo61MzOmNmL6XVjIwBfkfQfpv4ooBW5c/L/LiqPKo/H2NBno2nYv2xsAUyxyMU/IullrgO0IVuQN7PTA4ZFTZMPr8fztb4fAGAqmdlJM3s57npX03ckDdTF1YA2ZGlCGbmROXd/yMyWa4s245Fs1J43VDPC9KWvUU6JkqSiy0E9WlNHKHe/wMnGfuVqJ59aBazFRAdVrv4HjbW2Hzp1iU4gKFnMXdoI8OFVM7uXJpTYr1zFNc9ISrmQKkj/Z0l/FM/vj79pQuK3G1sGAjymwOI2H/EuSb/eSAV2KUuQd/c0L+NlSX8VSX/l7jckpaKb34ocfppx/quNjQFUfokjgf3qop38R5Wr7n6+9nre3d9qrA1Mj+2KK1VrpADsWdaxawYF8ZiYl8l5ga072+16ta42UoBdoscrMCLu/oqkN4bsfSkyRMC+EOSB0XokWthUzYlTEc1CdBgE9o2hhoERilZkZ+MBtI6cPAAUjCAPAAUjyANAwQjyAFAwgjwAFIwgDwAFI8gDQMEI8gBQMII8ABSMIA8ABSPIA0DBCPIAUDCCPAAUjCAPAAUjyANAwQjyAFAwgjwAFIwgDwAFI8gDQMGyzPFqZvelyYglzUnakLTs7m/FsjOSZlI6kxUDQF65cvIpwG+6+4MR5NNs9CnAn0wB3t0fkzRrZqcbWwIAWpMlyKccuru/0FggLUpajedrkuYbawAAWpOluEa3imxSUJ+tBfPNeCTrkeMfyMyOSbrWtywV8bw3aH0AQFPOitcParn2LzeWbvmwkXLL+5Ku9z0+aKwFABgqW07e3a9KumpmSxHsn5HUi0rXS5HD/1Fjw1vbf6+RCADYlSw5eTN7uVapOl/L0S/XimhS+kpjYwBAe/HY3RuJ+/6nt5pQKsrRX6ktOxm5+XV3P9/YeGsdd3drLABQvNTMmubV7clSXBOVowNPUj3gAwDyoscrABSMIA8ABSPIA0DBCPIAUDCCPAAUjCAPAAUjyANAwQjyAFAwgjwAFIwgDwAFI8gDQMEI8gBQMII8ABSMIA8ABSPIA0DBCPIAUDCCPAAUjCAPAAUjyANAwQjyAFAwgjwAFIwgDwAFuzPXRzOzE5JmJW1KWnH39yP9qKQ5SWvufqmxIQCgNVly8mZ2RtJCCuQR0FdqgX8pXi/HawBAJrly8imIb6bcu5n1UkCP9IXI1b9nZsvx+nxjawBAK7IE+RTEay+/LOm5eH6vpI14/hfxeiAz+4ykG33Lrrj71UHrAwCaspXJaytQvyzpG+5+LpKu1Ran53c0Nrrl4IDipE801gIADJWz4jWVy6+7+yu15F48kpmolB3I3S8MSgcA7FyuitfUgmY+Bfn03Mxej0Vrka6okF1tbAwAaE2udvJV08mleFQ59vS8yuVvuPsLjS0BAK0xdx+7o2mW3pZbYwGA4qVMoLuf5Uy3gx6vAFAwgjwAFIwgDwAFI8gDQMEI8gBQMII8ABSMIA8ABSPIA0DBCPIAUDCCPAAUjCAPAAUjyANAwQjyAFAwgjwAFIwgDwAFI8gDQMEI8gBQMII8ABSMIA8ABSPIA0DBCPIAUDCCPAAULGuQN7ODZnbfgLSj6W9jAwBAq7IFeTM7KWlD0kIt7bCkNUk9SevxGgCQyZ2ZAvxRSR9I+nbfomcl/Xt3P29mfyteP9r4BwCAVmTJybv7JXc/J+lK36K/I+mdeP7jeD2QmR0YlA4A2LksOfltbNYWbfa97rdkZtf60tbSD0hjTQDAQF0H+V48+p83uPszjUQAwK7kbkLZH8TXJc3G8zlJq40tAACtyRLkU3m6mZ2JgH7EzE7FouckHTKzpyR9KOlrjY0BAO3FY3dvJI6aWXpbbpxmYPqkDKK7n+XUt4MerwBQMII8ABSMIA8ABSPIA0DBCPIAUDCCPAAUjCAPAAUjyANAwQjyAFAwgjwAFIwgDwAFI8gDQMEI8gBQMII8ABSMIA8ABSPIA0DBCPIAUDCCPAAUjCAPAAUjyANAwQjyfczsaCOxw32b2cHGgm72fdjM7mss6GbfB0d83E80Ervb97R+7lFeb/el/TcWdLf/To87Qb7p/kZKd+bc/f0R7bsnaaaR2oH4zHOj2HeYbaR0Z5TX2yg/98iut9hvr5HanU6P+52NlMzM7G5J90i64u5Xu94/AEyTTnPycYv0XUkHJP3xKG9VAWAadF1csyBpxd0vSVqWtNRYAwCwI2Z2yMxeN7PTw+o4ug7yqdx1I56vb1cmZ2YHGondGNV+bxpVxesoyyhH+JkroyyfHeX1NsrPPXDfHV4LA/c/gfu+S9J8ZJo3zOzPzOxlMztWrWDu3tgqFzO7mHLvKScfRTVr7m79uzOz7t4UAJRpU9LPd13x2uv7FVtvrLHV2qIR+AEAH2dmRyS92RdTVyVdcPfLGkHrmv8i6R9KOi8pvbk/bKwBANipP5f0tKQU0C+7+/X+7bourjkYvzIbkaNfGGG7cAAoXqdBHgDQLXq8AkDBxiLIx5gtF+vNp6L958WqDWhjo/b2fTCaHJ3oSz/c/54y7f9MetRen4j383o0hzrU2Ki9fZ80s+drrw/X9v1mzvE9zOyp+ueupafz/peNDdrddzrnX++73h6uzoWZ/cmwNsct7HvgdRXjqdw89o2N2tt341qP43Cx9ni+sWF7+0/H9tSA91PtP+f1dqr/2Mb7ybrvar9xTb1enfdafEuPk40NWzTyIB8nfWHAuC3pYluMZUs5TkJc7CvRfn+zln469p1tLJn4Ul8cMGZL6juw6u4PxXt7urFxO/t/PdrX3lVLTvUk67Hvl3J1Vot9H28s2PJ0zjbM0XQ31Qst9p3b+nlIx/+9xsb73/eZQddVXNtrqa1zHPvWxeduXOsxjspSPFLLjCsZ9j3sWk/vZ8PdH5T0tXid47O/LOlY/bqK7/hc7HsprokcjkTd4y/Esa6OwYsR29J3cKXNTEX8cNwaTSCVyY/DY+ut3Hovkn5Se/4dSU/lep+S0gV4dEC6D1q/5X2nL/6ZIcvSD91zg5a1tO90Ibw4ZFm6CE8NWtbSvk/1f25JD6fPm/O4S/rZQed22HHI9B769/1mBKEUEO4etE2L+x54rdfex6cGLWtp32fq15Skb1bXgKT043Zx0HYt7ftI/f/H9f18/ZykjmmDtm3xPfyP+M6lDnBv952TVr5rKU5K+t/x+W6e584HKNuFH9ZWvdyX4yxe5O4+K+kzXX7WyAGknE0aSO7Zxgr59nswLvQHzexfNVZoibv/cMh/OhB3GNWd1NnGGhlEcVwKQJ+PVmeLZpZyfue72H8ligy+5+7/s7Ewn/SDvm5mKYf9uKQHOtz3dyMHvRbHPrmjsVZLUrGYpK/GkC7p9Y2+/3x3S7v6C0mvufsTVcI4V7weqT0fOvxBieLWbTluJxvtXnNKF2Hcwp7Ldfs8xM19VWXCUX7Z2QB27v5oFJXMRaDtat93RRHZY/HDsjygWKMLS7Hvzvfp7l+S9ESX11v8iM7FiLipqGYzY9Fs+gHtufsLupWh6R/OYrOx4d7MRdHfR8Y5yL9Tq5ya6X/jpYrPvFL1IchZ8dovKsKqY36h43Gvq3LhN+L18rAe0TnFF329w7FNrow6ExNBaC1HPcRtzNbO8btdjyfj7m+5+0u1sV9aFz1S59OPeHy/7otr7J7avnotxrf5sQvyaXz5qra/byS1c1HheiJ+BS81Nt7/vqsZidKXbKGq3I30Qe+p7f0fjQt9Pi4GRcXcbNxKXoxyzBz7Phy/+kdrudZ0gazG66cyVoQdjju1+Wrf8YVL57iaY2A9Y87qcP1vPP9O9SXsCz5t7ve+/usq5lRYi5YeR6MyLkuGpu9ar2celnLnomvX+rHacV+J7/jRqKPJUvkZ5zT9/5n6HVqcj/T9mslYPHcm9nsxzutCpJ+Lc3467iLeamy5S5FB68Wd6GgGKBvEzNI4NfWxatzjTZnZz8R7/HDApm3t/2M/dO7+0+3eU0H7/th+0r5rxyM9flqldbXvvmU5j3n9uP80jvsdtff0YRfHfNC1Hu8ny5dy0LUe6Xfk/I7dZt8WZeGdX29Veq79xj76M9L1c36zDqDNY9/4TJL+P9XpDQYGQZHUAAAAAElFTkSuQmCC" id="_eceee481-e3cf-2cc5-cbbb-460aa2002324" mimetype="image/png" height="auto" width="auto"/>
+    <fn reference="a">
+      <p id="_fff92d49-4325-ae5e-3552-2c9ea0e9f80e">The time 
+      <stem type="MathML">
+        <math
+          xmlns="http://www.w3.org/1998/Math/MathML">
+        <msub>
+          <mrow>
+            <mi>t</mi>
+          </mrow>
+          <mrow>
+            <mn>90</mn>
+          </mrow>
+        </msub>
+      </math>
+      <asciimath>t_90</asciimath>
+      </stem> was estimated to be 18,2 min for this example.
+    </p>
+  </fn>
+  <dl id="_865340e0-8159-a275-2e3d-7ec057521747" key="true">
+    <dt>
+      <stem type="MathML">
+        <math
+          xmlns="http://www.w3.org/1998/Math/MathML">
+        <mi>w</mi>
+      </math>
+      <asciimath>w</asciimath>
+    </stem>
+  </dt>
+  <dd>
+    <p id="_dda91e66-585c-f3d0-2ff4-a7ecf310e80b">mass fraction of gelatinized kernels, expressed in per cent</p>
+  </dd>
+  <dt>
+    <stem type="MathML">
+      <math
+        xmlns="http://www.w3.org/1998/Math/MathML">
+      <mi>t</mi>
+    </math>
+    <asciimath>t</asciimath>
+  </stem>
+</dt>
+<dd>
+  <p id="_f8a20f0e-8b60-ab58-e42a-addae00fd35f">cooking time, expressed in minutes</p>
+</dd>
+<dt>
+  <stem type="MathML">
+    <math
+      xmlns="http://www.w3.org/1998/Math/MathML">
+    <msub>
+      <mrow>
+        <mi>t</mi>
+      </mrow>
+      <mrow>
+        <mn>90</mn>
+      </mrow>
+    </msub>
+  </math>
+  <asciimath>t_90</asciimath>
+</stem>
+        </dt>
+        <dd>
+          <p id="_ad959d54-2ead-5158-eaf7-7019e9aced6c">time required to gelatinize 90 % of the kernels</p>
+        </dd>
+        <dt>P</dt>
+        <dd>
+          <p id="_9b4adc03-b1fe-3428-ab5f-ddf57ca839e9">point of the curve corresponding to a cooking time of 
+          <stem type="MathML">
+            <math
+              xmlns="http://www.w3.org/1998/Math/MathML">
+            <msub>
+              <mrow>
+                <mi>t</mi>
+              </mrow>
+              <mrow>
+                <mn>90</mn>
+              </mrow>
+            </msub>
+          </math>
+          <asciimath>t_90</asciimath>
+        </stem>
+      </p>
+    </dd>
+  </dl>
+  <note id="_f5d923ea-aa54-1de1-edfa-827082d40b41">
+    <p id="_670c551e-2277-bd7a-d15d-88d686874782">These results are based on a study carried out on three different types of kernel.</p>
+  </note>
+</figure>
+<figure id="figureC-2">
+  <name>Stages of gelatinization</name>
+  <figure id="_1a12816a-cf07-9595-cfe4-7bad8a82b564">
+    <name>Initial stages: No grains are fully gelatinized (ungelatinized starch granules are visible inside the kernels)</name>
+    <image src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKsAAACmCAYAAACldn/HAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4nO1dC4xcV3k+h2ehtnZIIpAjwFMVraFq5IkWVQWEdiMEUdOEXbeoqZ1GHivIFrRoNw9BSal2DVWoIifeFJRiC7QbEScKKt3NQ0GNhHZNqiIolid9JHjVKGMKtqBQJl2XtFHJrf7Jd2b+Oec/9zX3MevcTxp5fZ/nnvvf//zvXwdBoCpU2Ap4TZZj1FpPK6UaSqlxpdTlzgHDYf0VQlEtzGFHKVVz9vrRwa+OIzrsejVck9DGMW12DmHKujfhBaXUG3CsYtfg41TCWFtBEDzsHWlKDMVZtdbvVEpdjwfdrpQ6BaLaCILglHD8hFLqDP67y9p9RthmsGn9O6aU+lXrPPr3V4Ig+KlwXxrnSxjjOfYhnVVK7WSHnov5ke1QSp3H39uUUm/F9TeUUhOYB4W/Fca/3blKfnijUuoXKa9Oz3PB2RoN/ow7QBOb+D2ulPrHIAg2hnniVMSqtZ5USs1hQo4HQXDSOahChT697FVKHcR/l4MguC/N3CQiVq01cbRlsP3likgrJAGYXBMiw0IQBE8lOj8usWqt94ObzlVEWmEYgGgXlFKPBkFwd9xLxSJWrfU8ySBBEFzl7KxQISW01seUUq8LguBAnCu8ytkiE6qqCLVC1giC4BAp5FrrNYiYoQjlrFrrI6QhJ2HVFSokBcQCUsAOBUHgtUR4iVVrfRT2slSaW4UKSaC13g3lncTN56VTRWKFcb8eBME9zs4KFXIC6G7GJ8M6MqvWeidOqAi1QqGA16ujtb5Wuq9DrDBPLTtbK1zUIAUnjpJTABaYA2EAA7EBWmtyk9UqO+orA5ATZ5RS1xmXttZawe+/4JMd8wTdU2tNFoJpO75gQGbVWt+glHo4TCOrEB9a6/crpY4ibmE74g4o/uBPgiD4QZlTCRsnjYsY0zNBEPyC7etq50EQ3OCcWMzYKLbhs0EQ3Ma321FX1wdBcMI5u0KaCSeu9UdBELwbf7fBNUgn+DMy0zgnFQCjxIS5y2m71npGa72tDMZFH47W+t/po+Fj7HFWTOLVQRAcd87OGRA/7mChZh1Eb/1Qit4aZUDuW0QY3r4gCM7bw4UC8QEQTCL/+DBAQMl4EASHoy6DD+xGpdQXgiA46xyQ/1hdRZ+IFQQ7S6Fd5v9F/RDuR9x8ko2FlqF5bD9NYXxFjyvtTym1pJTaHXU+QhNXino23O+ItM/3Q1zyUd/+AsY8cG++Y006IefBjOGFbZP2s0lekvaN2k8pRcE+swmefzLJ8UPM8wpk53Fpf9ivZGKd5x8zN121VYHQWs/CRLYYJheVsQQNgamEZj/SuqcgR+YCRMuRuHGzHfxMMqHWekVr/Yh9bzoPSliznKnsosUyHwYUrCecQzMECetKqQ8qpT6CKPtTQRDsiXmHJ2xhe9SgtSbb4NeTmHugcJFceJfW+pdBEDzmHDQ8rrC1atXXE25VStG+z6t+Jse1sFqQ7vIdlvVQBjo8c4MTa9o0iFBA4TBf59eCIFgJO15CEAQPaq1Jdr1S2D0q2BsWmYbotQbigXurBVaVQ7TSELHkoFBOOFtevu95rfU3lVLvUUp9msWC9JQvfIA/dk4uDh2sVl1wMaCe5RDgEVmBZtwwE+QcGB9kSlkqceKi0IrY34H5yifW5CWGhY3LiCx7IY4NBC3BMtSAZaBw2JYSTqxJMinjYA4TcMAEJmitx9NeDC95PU/5Li0QShlGFDT+e0hudHb0McWSKfMc6yTiR1ew4hluWoczwMZiyXJrL6OWiwGZEavHbUtf8b1a69tDuEsU1jFxmaf5pgW9eHJXhimJNkAUU/hx2zL9P2u5tZtWzVJJlrm4QvZMrTWZCL8GLqr4e4Nc7Vy0QPToMtO6AQwTdp4/Hpq8No9qrZsSwZLoEKGg1FlO+6iAJnOf1vqMpACCSGpM9qJneJLmxzbOk9GetPCMY4gbkEeXPTL1HFLIyavVkZ6hZPTeN/dgncjKF6y1vjsIglucHf3989DybjUcCS+VXqD4GYNbLyAn/Q+5L7tsQIs2v002nP9RSv0A8QDrcbgvmZGCIPiwsyMlMG/HfNfE/ncEQfAk2zaOeX4fnmECtQQWhtQ7EoNopfdRcwOsZJhNaeSP9IQxD84s2zYpHEd2wjUYtXfCkL5XumbZv2EM6Hi2E3hOmpcx6biU16Y52y/ts97dknknOGfCGh+NbVo6P0/HgPk7MzEAvtwFmGYivz6IAXtIYYJR+hQUqP1Ykoys0oKP2IgHZ+l4rfXTRfrVowATnVdEgROkCQ57M9s+je1tk4Nk6jNorZezKMNjAlOUUgPiBe4zBSWmEZbLT+9La90Je8a8kaXM2oT278iiYaCXobX+rlLqAci59NKaEbLrPsi+qat75AB6/lXpsviQp7jFgH3cHft58fceaOxZKZMtiCv/x2ToKcz58ZjLeyNOEExe4MSa2s5qIsx9X2UMjIMjxzofst9VsLuOCrHWfOMHV5pjf0+ygiFhH/ecFIScBvRRw3JhFN9lifCwAtSLjgiLA06sw7D3Odjj0mKXCU00Zh1pIgUUGs8wDAxRYtl/fwJXc5bLbmgFFBDqOjjvHMyMnOOWWsmRE+uvO3vjo1sxTmt9OSLiTRW7c4gDOANt8qxU5U8p9d/s733wT8ch1qzLag4Db5VAZi2gD/Ek+eqhhZvxb3oq7F1hWReGxVsjAqp/An2B3tnPlFLPq35cB72XZ50z8kfPXcyJ9WdD3HYRisOAnAk3XQ0T0MA2bgRv4+/3aK1fQ0sVqnTExciYr6SPHcHOn4SsumgFtj8OTtXB/EhxD1kSKuFLSqmvws7t6AQUg2GNn7xdTV7zVWt9KQJ2fASfNXpMICsxQPR+MZlnwNAMGbfBCtveTjk/UCjoxa7GlJcazpYSAM7ZCw1k3qJ1qWgDONUi5Mgx3/yxjzoTEPcG8dFY96i+ote07mneTRvjfIq9tzlw2cIzSrIi1rr0pfqAYw0BGwWju+zDdLWgta5ZMtI6e6nGNSlq3yVgm+q/zAV8gKKXTkFBJKLRWteNyYjvBwE1wHHX7Y99GMCTWINjxnBMCg99namE7YthwLktiHmFY2jTFRSGzARvmKLuU32Otc1yVxoxgmyv0tJZOGDHXANxLcZcFZpM6zbKlym6WwP3W8ZxmVk8IJqtIoAlzUdAH9FdztYCMBSxYjmjCW1TrjcjWvOFxjJ94DpPYiKaxnZqxXY+bJ2zShM/QuaVGRABEWDkmJiRvQGzFn2MX7X991rrBefk4REaA8DEGDHhsaxUfU6sXm02BJ9VSv0GFIFd8CeThvsW+ltr/XH/qb36/USQ38KLpjz7Y1rrSAGeiBSeL9HnXTQg2pDt94TW+hmPdt8F6jNciTmnD/x+pdSfe575OB2fVYo85u1GrfUtIWasXQhukUQ78jJSFvTfOXtyBifWS1Pc6h3sy0sc4Q4ZjzjSR2GiMCFs0kuTMIpp2h/HczhyH3OtfkNKNZGALAlyL/8wjBsmAUxn09LKBHn5DH7TLAa5Y8QHpdQ1WYwjKTixpjGwpyYW1p+gha/4UeyqwypActttEWkeUzHtsYUBSsiAN5DFBSxLrmQT9BxCjPSM25ytw6FLfOSyZuWDOtZPWXTRhKhGJsMHMx5PJIZVsCboS/RpvREwZpk6iH4KttquggVivhNf9oLnRY6qB2uVmYSaGL+oDOLDJI5FGvqugouMzMGVG/uDR2zsXzs7CsBQxEoxkuSfx9fJcQGcoOUzaYHAD5gy8HhhlJbcdbXivEPGHKS1XgRxriKX6SQik7IOVh4asJ/+nESCIAh+zXc9cNQWs7fe5ByUH1qYPxU39oCN1yuP54msoq5mfAZ62EtNOaB1TsAsAOYxBKXU7bx7HHuzGpRxD8K43RrBzAEDE4EfhjasAZN4rvvtY/HMZNJ6NOQ6iQFxpQlGQB/JJ2KskLbtu1hIQa4JAmMPSgHTwnHb4Ben46lwwhH8+72waixhP1zzoO8Yds8JaX9BgcN/IW23jtmL+XDGiWc4Bm9TbqWdlFKXKaUekcZgHXdLmqouQ46tVymIb0xcxoYi26XtYT9eCohFp/8I0emx6z75ItatiPd5/H4U56PKYaIP+sYZ8/z9URH+GY+XrBXP+Wp10ZxK23Mek0isaTjrsaTpF76PAlxwBYQ2HUW40sTBzrtmEwg41BoI2aRnZJY24vvhvs44E5w/lkW6UYp7rhmCxf8nMWeFjiWwiHVYmfU4Iq7EhgU2EBbXA+yONUTxkMJ0kgVLUDwlmUe+I9gCJ+y4AJx3xEqB6QK++AUW5dRKMu60wH1bkj0zDspIg8Y9u/HJuHcN89Uqvc8Eo+BUXw24YKwqf4hTnQxYBT0sdcc8x0+g5GXvqwZnfEQ4dimGzLXbcGzc9wjOe47dJ3OOO0yFxjIrKGL+Q1e4AsaQGWdVyKGqxUy/IJvpN63zyWzTls6HQ+BK2CzrCBap2R4U7G9HOBCUxd1q0LDJT37A3AM2UtLin86QkyzD2rGAFeHpOGnvsGkOk4ExFEakkHPP2sPLBw0Tdf8vPtOVhUsMwWDZr8FsQ/GRzzhHA2RSwfFEXNcIwRW3J4kE4hVj2HjMPUys5k/If+6cnAKwAy9jnGRQf5zKScKNSoUtJhDMY8Z3Laqk/HLU8qBKwKuNyzeTKoL0BWqtP+PscPGv1nmHwT3OxDQ0X2EHXyDk7emEkUC/5fN+4UPoluSEd8kX7JEIRiZn55xgWa+fwcpBWb5vxockVU95JeJnppIhJ9Zho+5bYd4kKEBOZJcv0NdzvlT8bCaFoTpu98RVEGwm+fs2YIR34nc9ruVXKkzq0/NcDBjWE9StNuepRKdAVMPIQAshRCkRcRhifZj48ObwXKcRHJ0baIWqCNVBzWSIZEasMBfNwOQkyXozaQV2s1x65LeaL/4AYXDzljy42ycCeLCAtGlarsdRLnIJ5c1nMbaRBJ5//6iOLwGyJVYFgjX58HiZY6pvT00V8Q5iWPVFLUUQnqmCcivbVo+bu8VFDzzbYdgbD5japtD0sw7fSwWS//EhnWCWE2NF2aro0SWXWTNLAiMlSGt9HiF+t6KoQ2KZDxH1ZKa63tnZxwvOlj4aUFj40nqNRbwmreY6OxWZ6sny8Dmt9WXGamGSHrXWtFpcgkizUgBt+SDGRqLSdr6KkSluoBrfVkWexmcY/k+n8Y/DaO8NVGHHrIX1k7KN/JLzA86CNasX17Ttl4cTYSf7/6zPj16QwXwe416KmmM8z4ki3MwZP+NR814yqXXlA7I+m3DdmZC514W1YlR9Y3jN13de9cUD0uqvghxKy/FddscTnzxrwVTR44qaZDHYEMLomkj8a/ssITliM66JC86bZ2C1Wcfzrse1xpSIvnjKKDj3iBrjvmMcYT/bNwZOdTpm2KHjwmTX9XI7XyCNdcy4fRw4kzMuVjN2GlzAe+8c5jN05RGOHxc6OZ4uM4wyxphnJc6aexAzk6NIdjoMhcCktdwUoUjFuT5dcxUBxW0W9L0heL3CMC4oYVMSFwKnNXn/ddx7XeDKmSLERBgGUjgfYmM/CXf2sbIaH8dA3ax4mVoDkgIvvwOO67S2SXnNp6Cpm1pa9IKOwOS0htSZ09CaxR5R4DS95R5iSag1w5iwYA2ZcQ7IHmFWEOUxqW3ziEXHt4KJKxdrQBIMwYF2OFv6uBeZsQ43heZsav9fDZvwKePGheH/Hex4+v/9npfMcXvConJDAUUyxHemtX4npQIhv+qQ6sdDvOQc3HeXHxyhWrccoukqdY+qkvANqUUmuGBYJWfToOx508bH9IbC/gUohKZIXF0waQ0ASY+fZNvmwlzPGeJVnku9hPfJC76No3KhD0+PWIUbB76HHXlAhFiAF8k4H6Ly7xVKjdvB2ScRFTWDSKyBvrJwcBxFhNSArAhCfcwqs/4Ub+OYI5xYC9yfZPSrLPm/4QsWAtedMtnCzgEjgi1LrIBplLEKotknKUEGJu7V2QEIS30HZrY9iH3YDpk3gBt3DbEDEjI3BQo4H0fRwjGiTgKz360ovnElni+N8pY/mImg8GSwjE0ca1EZoDCei0ZxyaQFU5hkrjpq/f8WlqA4HXicDzk8c6TpCqY1x8wX9J0hR3mGMUu4FOephPfaM13l2bu1aCyHLb2sRoGjKCVppGscEHwblLOmqSHLyl/mjXOsSIgDPPOiNBbI9sRNb+axwJif9ZAVo2j06JIT67miBkGaJ4ItjknmIztyPg6gzGzHdSft5ETEF9iVYwxoQv7e2SrLvzdKSgheMtmLXw/rQu61Y+GtO28yDvg+WD3mMN7n2fYJZCHc6ROZMJfUI+L9zs7iscEH1lsiJTacITvfbXuY2JJzi7X0ziOJL3EBDOYJo/v8HNc/GPZ8vkRBaSn3dRFkHRPH2LZxPEvuXi085zwrJmLHNYxhvy3C7Pd1bEQsRGjMQVliQG4KAZYqs6w0Wd7T8/D/b4fR/jS2H4bv+gFwyTHnoh7gmvdAG34TuOm4T3EwnQEl8cAzJ46iYnoEMJOYwYRJ+4Y1Yda5WkbAPHYwzzu42Qwa/jI8eb1STHgvNcyN40RAWU6vaFUQxNgAUQgf8qsw3CZWVRG7qAO4xLzd4zXlWMbAQdcY1zURWw63NMdb27Z5FK55D2c+wf7eDS62ktSnn+JZx1kP2BXc144+O8rS0q+V5hfzX1pUWdDn/C+n7+dMrIka5hriFLbTiw7ymjhWO+A53McQ9HOYrJ045r+wbSzof4yn7TGD0E/76kJheeXiwjQ+nswCSqKYBBO3VkLqNhzB2AoRZaQfDyDKjVi5rJFmYGzbTsPhQABi3GqOkzWLF2qKc4wxQl6yx2NMRWEfKTj0acbZjLlLJJqU4x7zyeJs/6Rn/Et4BkPQsQuZ5DD/k1LUVdZ4IUUtggbvr6S1fjuVYqR6+9hEGv0ntNZvQcOMM4K2nikQu9CLXzC9A6R7wL8+ie7WkgxsrnEBmvZdsFqcQoOPv6X/h7iKYwNlgDqYU2eOeHsnZED8MfOIfdHOl6OymBHdCXNHbsRKFZzhpkzUat16UR9RSn3BTBDchd1a/LB3kg/eW7C4SEB5e0OcSiuq3/HkEJ7D2EH/CTEGokkpJRyFkANKFjGVeyPe0yfQidypJVYU8na3ttM6G5if31fgtgFtfV3SZEvAVIgdNwwNlpR4Hs++hJiHFVhJvp/EcWEAq4p3TCBUsoQciiBU8x68beqLQN7EGtpvyQfjeZFa38DkcgzXvsrU7MeLLTPL1JsSbiCZzhDU3UumhGlpER/5Ap6RfqHxtCGYQfyuHYAzjTm8h20bQ8zDc5JnDAS7KjlyikDexFpPYiNFI9vdPtcprrWKVuTdF0wcATbGBXQdKQtRy+2SsbeybWKACZ7pMLNHE8dtWdfb6SF++1pn4U2bMwSIOW7ahMqKiLQkjsx67hbm7eTIU8FSIKApuzugDSpEppT6fdalz2m/A6yiw4i0ZJHI8QFna3FwiM7AFNZAtcKjbNdMHI4JTtZW/aV7BgT1IlVwjJPmTpFjLG63zUMgGcwS75v/Brjx0ApgGuTNWS8Ly0CgKH0s6fTFflEp9TZ6oUKfqG2Y5H0eQlWoB/Ccs7U4hMnmr4GX7qCZD8NVPUTBn30HOi++Fz59yu+6EqvJt9DNMRYgklHmwIv28aaIB+uUI+GU1Kq+AOxSFmdNWi8qDn5Tih/Fi5rzyaXWsTtZYLRvEhU68VEQy0t5FFEbBkgb2QbOZDIK5qwAb+K+zwqmoQeEfq6z4K6PRs2fDbRxfzpN/zKY3N7m7MgfThVByQ8+LNYhp9VBtGR6+hBrce4lPtXnKmJXPglkNoKitV6CeaUdlhbCS17iY+1p1VB2plA95ga2/SgUyB6YlUS09cZEYsbEOkKWUdy4u2oN2w4zFEhqmwMXJU7wLPWIDSteYeHWKI4qYBn3K7pUThucUyRWC/us5EJKObkZaTPTKEixG2KCzf06rGVoC2JBUotLA8ErZtxOY2d8FLtYYuYUVsLSVq28Oasxd/SM3JJJRAIihR5MyiHxooetNZsGnThzCCJcZ//fyeRdIoyv4O+mR/maYpFTk9Dyp5LUsSIrAObXeLjIVr3JDjEr4aNsrMvCh1MU6mbgxgdbiO83TgwCFK5UaTYIPPH2csr52bw1t/hzWWkk0yxGgDf5EINQpPfE4ne9sQBhP9bgzokVKPvHI/G4NaCopr2hNjooIndaysc2VoNftC1SZLzW+m5E6r+X+qbG5eIZ4kaqH6C1PuK55By6DvIl9y2oXzDJ+vsTV32CPRf1IjB4EfPRS5038btop3kn6gbEBo0HWb0nS+SePvzSbC80Bwsv5AlnxyC+QBowO2cnSgvdi4CWAWcBvC7ETT+tlPoSxSSQHZAVdxCJOw/gpdN9n4TL1ClibAeIoAv2DhAyL+1jbJkfA6c113gA9uSHbI8dUsgPscCfiwGvNs9QdCr2rjAODu3XVhgWmUdl0WjRINKjTKues/PiIccVnvgGJYTkzWPsY2n6il7AtrnHY2yvs/L2xhnQiPDYSdfZkoDO0nW4FF3rSizTjmVtybQzdw5AN2YsdW0Yxw3hkrXgvhBFrM2XzKKA5fQ2lMRcg48+MhhFOKYJ7qtYL4QZiApikYuLCdxdn7e7dQAwjq9AW+e2vn3gjBLBLRpOwlKLD/uqiwhYRZpH4T3ywSm7ZjoT14DaqGHljWrWNfictBGnOoWyRj4zGRn+xzzzuaWA53V6CniX54zRgjlkBkv0FIriihMLod8EXKwiEqlLeMSFYoYH+gijMMCdeRVWMJ8CFoWa6l9LJFTMx14pEGirg3PWS6kqXRAEqZu3xcQ4JprbXg/GOHUVEfhnEdl+D8SKXdREOIRTEd7uE0GKBmycEylr/Ds+fQ7IxyTH/m4B77FIdG3AnLNSJ7d3FTCA44KGHhqHCnm2yZb+PyXTFAzo43BThuEHIfsKBywCHYhEAzIqlEufc+Fx+3gomjtZxsHnLjJCVcZ8xTlrIeWD0GeAot+bzKZ3igdWYOLNeJrcewI/+gZkmdkY7thE3p2iAA7bggeqAZndWEHE5nTwzs0iLPAkTFfLfK4i5mKrwo0NKLALsnElmhiBC/BVd8AdTGnu31FKfcoyZa3D8D0JQo0qRjxVQpxALJjgFqZ8kfXg3yTGgedtYm5m4Ncna8BNPvn1YoOGS8tMxoWiCBYcstcRhVIpjC3Vqs00L2wbhxLRCguswD1qHnPYSAEEey9rT8+tJeQ0eJDboLH6vJDAKrJlQfZ0ioewA1m+XdQDYUlbwVJ4CoQnccBVcBSeDr0Rk1t2JC41isDHGCszVvULFr9S4JiuXizBo3Ujlum3Un9/Z2//paRKVwEXajo7Kmw1kPI/QJyvY4EUhQC+dOKQH0Wt0WnPfb+eJt2aFSSrsLXxzzaxtkt03x1n/m4HkDnFfRKgMS8ZV6xwSIWtha4pz172SyFWNGzYgwYMS5707VixCwhuqbNeABUuEhQaGxAF2B5NH1YFjbgNc1UrKskNKd3tvLv7VSgHNrGGepKKABSqPZBRr0BB3gVWU0DM3wI33hu31lSFrQebWMUOdCURremJarpcH0AvgmPMz7+JzINdSMn4tHOhCpFArMVrI+IrSodNrCPtU0ZlQuK4Vyul/hdxASZWlVJhRioGYCsA83kHVRJEc+Z1NHweObet3RV7pGRYCeC4x4VdFdJhDtFsF6AvTCHbNZPGz1niYuqDVSEhWG0CU//2KSQfXin1ziobdlpLWKfpChcf5jwuboXMjDhxxkXAibraMn70iw0sJHICtu46/p+24kok4N0TQxEVuKzW+kZUfik79NAhVsq3v8Q5rEKmQAzq+5RSv4fr7kB+2AZCJU+xNBwiXCpTaZcbygIfijLzUR8slNu8E9UHy8KLNrH+mGnWFVKCFTAzq1QDjo0OlBfilk9TpkNMbnXKbnU5LBCDcWecyyDJMyoTI290729r/0m7q1RwsQhZ8GxYdxPELogODgFZu8FbUhE5jKmBmAruKSwqmTQUtjUgtLRPhXCAq7bNi/YRKtASagT4kKlnEeOTtP2WhzC9sm2R6BFrmM+9QmwieD5uwA3iF+JGkhUSYASz1R6W77YDmRpTnuCiotCd054YgMFsaTEABdEmkHWQZS+pUCDN5l1mCdVar8b8+JdNyoazB8B7yYNY60hlqqE43BlWa8D8Syvt19hY50piat0QQZ6DRVrpbwdBsOIcOkIAYfCXtwMEStv/BmnXE/gpTPh5vIyNYf3f0ObN9S/Hvw/DVb0JrZ5qAnzYOVkAlKcdvnLr+AD/KktXMrgln4f/ENLVz/G5wnPfhSIjhcYQUDZ0t0AIq/G5M+9uzUPUPTXdsU0X63n0Pj2K2qTemqI4fi9rqut0wE4wjr2msbCp/yr1pzX9T6VrSD/UaHXGhVqzTrfqDOZTHBtqoYbN5W7fuTm//25NX3vjSBEruKVpQz4tdJL2Tiwjmmlr22SaCQeBnhBaoc/y4sCcIKSu2Bi304gYhLnXOi5zQsW1pQ9jmn3QP5e6k3PCKZgOuvcsOkEwKeZNVxPKhrXskusejZajaTd7gDdo1epHFQp4cciHfoNgG62Z1jfWfQ6AE3dBtk3q9Af565CdG4agkU0UADk9RHvNOJCUwBorvfkmBLNINbmkcwvByBAryuCModjaLF7YbT6BHkTjLT5muuFJ56PWAJXv+Z5zonudebg8fdkHi0w+trFpHTcFjVvM9Q+C4DGYvqjP1c3Ch5EVpI98YC7xUUs1JMpwyYvWgEJh2jKiKdkmBtVifUujBPmwNjcLYaYh4iJa6wd7wrsAoy2HBHsolDHyESuVntwPrtnAeA9AmfXBV+cqE0jtigyEGmQTKK7BIdlh88Zg3QB8xQ4XymnCtiHifwaBvu8mgsESdBimnGucEwUg70rCG2N0et5AW3LfNQ76zNPWF30AAAbsSURBVEpoEGeM9febF432QN+H9+oxQ3yY32+DUMnV+SnhmpcV4Jh5s2dePo86udfhXxJt/tI5qhxi7XJ4WwzIPZAFHPxRdM47HBJRdEcIx+LwHUNd9I5GNcGAyegmYZy7mY1RAgVXfA5JjE8ybjWOTIab2LVMzQMyn/2DUurLHlHggwUElv9EqsGADGMKwr4N/1LB4586Z+fM+T0YLHmZo/HZhukY6CPSLiBrJm5eYYkzHZRpDyVYD7eYiVAmOiYOABy2zbp2zzAZ0PjhjRw4Iz27KQIs7csYC3BczEpjQDPiWaTEr9k/z1zlje78lREbIHXN88HxqHFi5C8WytkxBA0vsWinVWjZYTJ5C/GdznZnSx9GeVs0qSCsY3fdcFooc70mctISjCioZSy/uQJVs0lZbNBHDKJ8BIS4yCo4zkE06/1YpfKiMahgAQ5xZAnIhknMMadMe0i2bQEVuk18pSGoBmr1nwIBnMbk0/3exjr3SWhLy1uENl6DnDplAqTR+lMJcq5XgwahNn1KXo6omXoMEc/J54MCsssoxzTYraUgn+/ehMvIOudKDGeY3GXMMG2TlgMCWECpzD3olRr2QuoRS76EJgi1w0w8LUkehF+9t+yidf286eJSdOUYrDIt9GsQ5wXiwLxgIejE1CWyxGD5ILsBWJaA9k9y492+jwJ19o+gk2B3LDBd2dx+FfUN7sD/ScM+iOteh7ZD14AbU+r2tR5lxtyXFKJLlVLfFPZ5XwqS6w7DbmpCATegXDnHQk48BgK9gA/xUIKmy5khzEYNIj0Ga8BDgmjy3SSlOTNCy0wkd2vl4m6FSzK0lyrcjZNw902y7fOCa/Ja09s1qs9r2L4g2k/u3DvGs86zvyfhWj2d5lo5uzDFPq8YZ8+17XHNXuvrLZvTWJ3erXkirGeTgSka3BI04p4ogCXsVst+GRbIvOzL0gS3F8USXHc5zLHgQQfcaQXcawYeqcO+JbckrHqcKst4D6uYN0cMg/1Y8oLliqKIte3RtnuAlnogzFukWD8p5LYbLPuWNYgD27gsCRPNEvpvee/HgpDDLAk26tCaF0aQQHtgMRIrVtPis3DOGIXP+VghHjU88nke6H4wtjVgM487oTogmUheDILAdt/FQajyg3wnCibe4XHRPoa2lMsgpAY0cFF+trCK47mZbLel2D0BZ8AcLAOi12vUgFL562hMfJswr46DAgR6S4L5ywLd1a+w+qxQJCbwJSf6ImPWzw/jrhsgrmXTAzbtRGOFmIGCZMw4D+DeCyEBLyMJcP5zUSsfQxOKYd7OCwdF9269Db7xveg/SiafB8O0dU/kj4QXlFIfwXUVVontSLYjN/L1EfcRwfp2kYuYRI+HrBpQ9+G3ZUEuZ1RofAQWDbJXbwjWEFKsLo9IhMwD3ZW1l9ai0JZSYv15AcvpHMLiBmRHttTOsDbtCmaMHyKffafJe8IDfdfywsU2eIcB9+m2Ui/hRRUKPKuph/u41aC5XUaxNhIhaWUulVj5fZVSH2OenjZ+1OroO9jeYPvHmf3VlNjx9sOqsLVh+tyORIlLfCBRH0nhMlKF0cKop7VUqNCF1vqSilgrbAVQpN5/VsRaYSvAaYepRqFbS4UKAkRiraoIVhhFjE6HwQoVIiC6W8+En1OhQikQxYCKs1YYRYic9bXVq6owSkAsSTeSzibWFSHnpkKFMvEHRjy1iXXTF2ZXoUJJaJhwxAFiNSF0JZfkrlChC9Bhr5+B5MFqj2IrxAqvSDR5jpxDrIhXdAo+VKhQAqZ4RoJDrAAVkr3F2VqhQkFAIeOB7FuRWEHNVxSYvVihQg/Itn21nec1kClgnTCG2qlF12Cq8AoHuOrn7JQkkbOqftYjlXM8nWdpoQoVOFAT7JSUO+flrL0DXnYSXEeZqc7OChUyBNLBp3z1v7yc1QByw4ZUfLZChayAyo9eQo1FrKqf0PesVUe/QoVMABm1EUaoKo4YMHDwy9YBU9XEWyOqQoWY9ERFNL6MKtuR2cuJiJXdZBYxBF9BRbkKFZLQzxiKm0zE7XGr0qZio55TE8V719A9r7LJVggFqjfuN8WBkxCqSstZBy7w8ldiSpbXTcMJq0aV8e++Hh2gT6IlD1X/G5PMFBUuDoCJXY0W93WUdEolQg5NrM4FX9bqTAHamlWM9lxEUmLdU9y3zppU1NAu/UXUt+qw7WHdVeKgIzSr6LBrmw4wNdO2CMdMJCggVxY6KF7Huxu2rLlrsC6P9PezQtho23ofPjTYfK2bJiGeY2Mhc2LdqkBHwAsQ+s+io/YZfFxbOd1nG8Z/ufVBTYB5nLca350Dge5i/zfPv2kxm00UbutF8/N9aao2hqEi1gpbA0qp/web83eBfaXwtQAAAABJRU5ErkJggg==" id="_61960713-55d0-5bc9-461a-5a65846b0fb2" mimetype="image/png" height="auto" width="auto"/>
+  </figure>
+  <figure id="_13d3b64b-4cf3-346f-c700-ed40bff54d37">
+    <name>Intermediate stages: Some fully gelatinized kernels are visible</name>
+    <image src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKsAAAClCAYAAAAj4g1pAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4nO2dD4wdx33fZ+JGiRUe7gIJMkjbuWdIIJ04Cc+gYbdJ5HuCUQdVRPNU1TIkV71TZVCt24CnP1AKOymPSKKmBmXSMGKXhF2erUiEjRr3RDoyrEK5c5XYjSuVz1UR2UQFnpuEhziy9Qwqsh1U3uJHfeZu3uzM7szuvuPd8X2BBXn77+3O/uY3v/8/nWWZGmKIzYCfuNy/ktZ6PLdziA2JdeGsWutRpdSYUupqpdQvKqVaSqkJpdQy+5dzF72KEaXUazinx3Xy7xVKqSu5boJzl5RSOzhmny/nfFcpdRXn9Tiu2DeS+9U12OcKLnD+srV/zNrvQ4/NXNPyvHPLc10KetazVLl2LOIe7lj4IOPwPO+2lGXZNzznVMZAiFVrfbNS6peVUm12nVdKvcT/v2X9PwYXrHPOQxTfV0q9gWMrSqmdHP8Jju1w7vucUmqU/484zxPCNvab8/Yopf6bUuo655l895Frdymlvq2UeoHnG7GuM895oeAeRTCT4znuZd43NGEMZIK/zP+3cx/z29sqPIfi3c7yXX9VKfUWnmMHx+R3PquU+nKWZc/krk5AY8QK95xVSs0opb6qlHpCKdXJsuz7uZOHuGyAmDXDJqvffJZlX7kkxAqRHmU5Pgr7/3buxCEue2it9yml5pRSXWFsqYysloKltd7PbBECfWuWZZ8ZEuoQIWRZ9pjQiay4QrBa68nAqV5U5qxa64PIcXcMl/ohUsGK/OdKqf8gTC7m8kqcVWt9Qr06U94zJNQhqgC6uUFkWa31dMwtkjir1lq0u2NKqYeyLPti7oQhhkiE1lqsEA+JZSLLsvuLro4mVrS6eZkJQ7l0iKahtV7EUhAUCaLEAKj/KBpc44QqgjYyzBCXKbIsE5FgqkjpiuKsWmtZ+h8XbS53sCIgzilssz1MX12jKVa1xQ2xeWFWbwg3h1Ji1VrvVkp9MMuyu3MHI8FDCGG+C+9GGwLt2g9mGZDl3LEsy940pL3LC1rrA+Jiz7Lso+6LxxCraP4fyrJsJXcwEmh7QpxfV0pdE+Mzlt/NsuxOJksLAhef83KTHH6IjQet9SmxNLkPViizYvT/Wh1CBb+CQXglIbjhC1prEQXuUEq9Tin1JGLC62Q/lokhtib+UGt9b44eizir1voMHodawIHQaSIKR2t9RCn1R0qpwyHZZojND631OVcMDHJWtLK53IFLCGMxqBu9M8SmwFFiCcqJVQi1YdkwFLOaglmsBYqXifJ8DLEp0bFilS+iiFi7uT3V0arrlkXRUsakxUSayZ04xJYA9vy2/S5eYoVjdXIHqhNZL3cg7R5i0jqaZdkh51AT3HqIjYu+yCwvsYr2TvR3LWitt6PN/07V+6D1f0gptTd38NV0lSG2Lp60uWuIWK9owFwluFUp9XCWZcF0CVGaxEMmvmEMwvax7QTOPBC4x4Ui99wQmx5/aed9hYi1bgKbQbtoqbayDB5FRm5ZxybZP1Mg7y7h7RpiCwJT5yqx/oPAKzalXI0VEJoiMOZOnA9dE3GDzDxVZkcVZUtr3cL22kV8eXTQcQVWXINMxF7TWZyDAivVy+aboAuIefJrJPxtqHdhnFf1nRBnraUQWQhyVSAC9Bn1KuF9BpFggb9vzp3tAQS+hJlDOPFcU7UACiLBZvm3ze+JGLOv4PxLCsZVHDNPyzeR/6P4zjJ223mXjrG6EAl3StzenD99id5vLf1bPFjuppQ64dufsimlhDtOJ14jcQj7fMeKNqWUcNZx/i+DfaDofN9mXS+E/ohSSibROe43aj2j/H3Eee79PHvtcRvEJuOhlDpovZ/8/aI7TkqpRfOu/F9EMTHMH+T9Fsw4rdNzj9pjnTuBkw779if8iHBF8e1u8x33nH81A7LH2jfJzBfCudd3HefJ79xk/b3NfJiI3/05eVd+4xic55Ts5/h2nmuR/RIJ9E15tsD99nO/PbHvPuCPLWNxk7yb77jn/D28p3fMqQMgxx7mvgN/R5sWcwc54Yhvf8IPnPLt923MHiGU3c49TkAsk6Hn4ZxpZ18UR4djHLO5ZuTzFnJtixMJV97vO2fAH3cUgjsDJ1yInbxmTH37nXPMJB74SmJ/y9xBToh+Od8mnMi33/M7+8xy4zm2G2LKLT0MVk5kYObHctUF3/6UwYs492Boog3y4zorzXgisUaPC99goGKBPX4hBatKzSQbx7Gb7ssdwatFnOwYWn9Oe0crvU8ULZNKg6JwACL2xS6sKgkoFEVItnigTUeb9fC4ja2XLdiqirNqI2fsUkyRKd9+lhiNScZ8cgCF7lafPWS6qmUNyLLspFLqJJp9H0FBbO0S+6m5z0vWddOYi8Tt+rHcyWuY5zyxNMisvMc9wWi8Fd5rRWudOpHnGfDchGwKEMgsFpG59YpKk++nte5Y1pHvSHA9YzTVUJp+qZ21KfR9WK21KB9XxZql1Bq3mCEYpuy6bVb27be11qEQx/WMKegxOYNZmw1gnkmcm5igKSePD1Pud4EhTTX9ziExoHGwLP+ZOAHK7i3Lrdb6Jq317xFX8HzBhzDXiCb7Y2PUZun9ZO7EtQILyZkGWus3p646PI/YNvdLlrA8p9b6ytyJFaC1/jkYwDMekcjGUm5Pc3iX505fUkq9O7e3GlZjVHKctWGZo4PcOoGHKjiglpHauGhlgP8gEBNgX2fktAlnhrc9UVo2zkqQTJZlKQE776sSjSbPgYz+r5GVpYbs+3MnJoDv9AWl1F0RXqeJ3J4GAEP4Tc/7ytg+QS2A2ZpesVWm4uOsraY8WMiWbQjHS6gmkAW3nyxlbxI3q3xgQ6h4UM64HhQrtqDniW2dKJl4y268ZBGYTCNVBp6POkbxujsr1kF1Ie+7N/J5osQexjNFRJoJKap4FkUUmGfVq4rVVcFHrI0B2eViBWqfq84ittNo/aGBb3vk33G4nCgUH/MI8/O4QsVdeFvujq9eGyUKWM85p9asGYtsZ4q0faP8OFx/G5N0tOjaCJQVD/aioKhIK3blsFKMQt9MWd/kQu5gBeTEAFCbs1opJ6Ykpk8z7EQuE3MEWZgADJmpnyoqZSScXGttIrlu11q/3ZZ70WRjRYB5ii8YjjhntF0+2icKtP1ZrrfxRcZlDM4zn1IjwQTSlIg5Nla/J7pDG5Nax7nHRMK3b0fKwsuJolYQPs7aa0gMaJnKKj47KoN2NGYZ4x5GcdqHS3Om7FohZK69GyXHtftuLxEVzOrQcWowLZuJw78rPk5lLf99IpCY9hAJ3gSxzCXmk42Fll/PM4w6MusEYtZbMe/Z9ugJ+74ogwcCzzYRSayVackdUx+xCrd9Jbc3HVIZbr9vmaN21g4iwVMeXuIArlVK/UYF2fEH1B+wIRzultyZa78nH/KNnmJhr2CtuE1rLb7yH7orBw6ED/gUEA/+N+GNUWA1EQXmS/IcRdfwXM8z5oLPyzMTltkz/QjIyLjGcsDsJ8ZDGlr8kp3Hj1VkT2hVcyDPmauuEol+q4nHvbWvStRSaMNH7bpLJ1Ndur5opwpuyFxEl8+dm61FHeXOt55lmugl37UHee+dvut9WxX3L27n3Ph6zjviRI6N8uwL5h05Z7d9jfO9Tlh/Hw6NjW9TSt2WGoFnPWc46sp8BN/FFYnknGffYkoACcSRdI117TjOgulADMKkG8tA9FGlIA0IIPlaE7jjO1a08X7nQsTgfvDQ5j6zFUg0ztiPW8ceCd0ntMmkCh0LbWZSmeM+MaDXVKYA8t6Ms2+frSxF3GMUhabUPRuASZtp++Qn5OmOI5ft4bpooNkfQb4tdXx4MA8HSgJL8QQVpA96XMlTvvf2wHUjzxGDMY8yZ8QDWTWO5y8vRVXZddX75iNW5XnwqvDd5+LgeZSdHJCzjP21al3YOYivG5JzsQfPOMqW79mLMG+n5qSCSbOr4rXfJwWoy8Sz7ZqtyInXR0wop+9BGbPTYCZ8CnMRkN9ru7hDxNoUljyG97Kugjb2w6kqB4FAoLdHzGwTQTSKXTCaWFEil60cslHsu0+7GbslqGWPxOogXPYwaTaGuGJWpJjvMWcFraRgp8d8F4vCHKwrG/RgCZG18YvL9jAP/ukQl1NwVLTcfyzeHkwoO9m/DW009TkKtW2e57eIgv9hbK0DuP/t9vkQh7hUPyxp5HCWQsANv1d0Tgz47d/AavJlqa0b8dtXs/oEgWPluxVXuB97mFYp3EnmcwpckdtTA7KMWJ6sB5RSD9rNM5j9t1jeGOOtEofBfyV9Qln9XhViRMs4HMo6GUIIL+cOOMB4/R7MNE/Jc5eEIyqI+/c8MQxSi/bfKKVujKzBIET/Z7m9FZBlmbzrR7XWe8t+2xSLVkpdb8ncvpVsf420939Fx8la8BFr47A/OKnTJqbVBK0YF99yShlLK0hGvEAyGX7TQzSKgX4gtzcAU3XZtFCyQt7m7A/J73d98aO8cxmh25Dnf0eBJ6wKgqIMRNpGAX7SUoRntdYTzjfbV+CFLARjt1JFls8pix5TxwGfiadBU5bJmiy0DVa47yS5R6PO/lGS/Hb7rivajEnLZM+SLGebcCqlxoS2pnO2eO4ztk2b9zD7vbZSjymvig14lG9dOUXKtcf7ZNamagbkgLengwu00a4vcLz74bIm930cDfltRTJyAQxn6vG8h1DCxql3EAruTgbca1tT91Ovjsk9VhzAQfSAjtW+1BsJh/t3kYAXs7oUuqU9mA0U06v1QuvCWZnNN/mODeC3zllepMrvYgzlNmfBw/dik2Nk3XNgqc2M/2LsioYTZdEkZhY5Hiwu+Ncm41jex3dehXFZ5aw+mTUo59REb9BdCbXWEtD8ToR5MQO9r2bEz9fwmYsPfpIVwURz5eTUxGedpDLiTrrr/WzupAZRlmnhAhlzVc7UWotc+5DWWjIA/lOWZU9hCdmFTrATT+M/ldQl5O+66Ivl8BFr42BZHsgk4KPPcv+zVBxspJ9slmXHWQY7LKdG+REj+122AoUHzPbW5UIfseG2ed5lY7PcDP1vUVzvNtYDrfVnERmXUTzNu1bxboXwI9ubui7EOqi0CjDXYCalD8tYAlrIrAruKjJdl+Jw20z/LmJc5YMuaa3faGU7TFpEujdgtdjwgCgr90RLRB+D8ylYjQKO067hwQgCs8jRQXImFIRlz/NPYeY5QexBx4px/YYp2mad3yK+4Z7NSqiXCKsKv4+zNpamDIeZqBjYEYOJCKN9bfg0WgjzZjjmiCuPC8FqrcV7NY4lwVTsG7a8j8dYmbu1SdlyKlWwN9VUfEHbGxEoXSHF8RDiQAbnHXYTT0chZx1rKPtSlfmbXeAWFR/0aZbQMm/W31dIp1438Fx9uVXItxLz8MvsWrFCAz+VZdkjG/FdLhFGyPC4CB9n7TVonE5tULENAp+J5PAPSi6+MWDnjm4wEAv6FATcQdP9EWF4MjHfGch3ulzxGiwCF5Frh8mALgWCGaKBmWYJxcIoKH/q86M7vz9Kkl30ksk1nY3cHjN2XAkmSbaLbkUwFvPGLObjrKqBvlU7sUXOYuw20ToSZ/kiJb+9uesEEhcSKuGCk8RsTjMRqsRZrieigpYh0uWyegSXCXq2wu+TWVUdJQsf9412mjXEdzEKCR/zDBz3YoSPVS7IPNwEzyAxmb9kGk2wjRHud9Y6f2wjN6GAQ0THEYiFQ2u9RByCiAufp4LhbjsN/HKA/a4+Yq1cN4ClrlVkqrICQuzrtuOum4CITT76CjKLPXlyH0trvdHbC7UruDtl8t3AyiEy+Q/MZNVaL9fISdtM6Kt+6CPWMepsJgFNfqSIUEMgQHilIJazUCzAF70hgfafVB/BhuujV2s5/e9r2LW5EdFn8/cRq4qJqvfg15RSH8/vjodVHaSHYF3KOeA8lYlhkEB2/48DkKc/hzVhqxNrubu14vLSqmP0RtbtoCyNxWRkIv+218OLVRH7CfJoxBlAHO0JxKSkVPFNiijOWgV1qyv3+ABdKzKpDDOphXLh3r118iidRQ6vpfwRNH2XWXGs7oZbHaUya5XBnKQe6jSDuJLqVcKsU8VOGlt7dDcaecdwbq31z+MhmXcKe7xk7MHG7ptSmMOCyPE7ic5KIlie9yi//ReYAU2hiS7PHF3ufpOiT9GvTaxO4lmb2dCmCULXsS5ccGqKLrOdrdGFO9bMNuXEXX5M9VfOnrJMY9dqrV+xuLypMRubqbqKKo4KTF0tN0HRuqeEIUoFwO0NdS/fqCjlrBcSB0GCnU3JcTOwh9CC91ClzhRv2OHEHfwUkeZi3L+O8+zjUqPpm7lf7EesmW1PQfRUbj+rxS4Te0rt/uvstj0R+FuTYVB2KtaUq0nfPhlp6hpNfJ7NhlKZVYzwn87tDWOH7wgxm5VdtihcH9Ba34JcapZpkQGfJa1kIlIR20npxmhAYPbzf5zylU8l3OO3qcyiXIJlRTIxEGZ1+I6U7MndyI8OKTzf3MLOgr6gfR+xpuaHSybkQR/XqgMyLyUi/3dZik1V5g5VY1rWhy573pEGentJq6KLRBYrf5piwjaHsHKvrvUUKU55HomX/TQOlSnuPbXFwhD7lGdfIMuJVMO+1vpcQk2lHBAZHjaFxRKI4aBdYyoEtOlr65q4IIxHY+VQGnuctzin4RTHaWxX51nEhPX3onzhnt2Ni3vDBvOkwm265+OsSeUujX20gSWobZlkSonV2FgjS9qMNGHqwT/fjSwrpCBUwx262KJz74aSN0+/r/tzd+k/11gJluzVDE47n/BsmwF9yrOPWFOT+5L93i6Qb1NTkecT/OPnm+iyh+zbwjLQhgCLcsCecXoK5AjVwnKoewy/e5tV3GzW6rEwatUHM/9uFWItNV1FF2ajU941tsbLUrmXQOo2Gv4KBvK/zbJsIXejapBsgl+PdDn+TZUqds67iqz575RS/xIOuw2uKe/lXdIl3YX6/X9VFMeLKUo+zP9xflPG8j6qGv53rASu/VosFLcyMb5QkGKzGXGN/cw+Yv16bk8AUq1Oa/1BlKy2pfR8Xin1LawKY4YbKaV+VWv9760Z02U5C5WxKcJIQqGJn6kRSWaWaCHM95rMVMxZrymTPcWsR8PlQgO+q6Aij084tmEfhMCfqKqoNQlWgGPccqkBpbs/oMpTsqVqLf0jqcXPKDljytrYpWoKewfAtVP64u+vUgiOCiPBEkSUKAqW1LHOG6fXwMGyMTI9DkJF03wb47bQZC+IimP1tPl2PNOJOgX43F4IvhMqVX2rSuTOPfYx6Iv831v7iWp+KR8z+Z2s+k6Fg83zehtX4BQ5Yz4adcTk/4c9547TBeVExUYfo0yGylX7En5rW7ZGoLsZq0W3Ow01r5K61hR9t0tCrAzsZOijmDZCzNRp59iR1NKQSql7fftDG5w46n0MkQSO7ec9py3OOs1kM6U/9/FOC+ajsi+5FU/qd6h4/2kKsL3IlkGQ3hWDb/lIxZWtb1x9IYJVteblXPHXMOYJKvGayURGc8o1LpBztYDs+WjuogCQOW+Pre3PeTtjbc1YAgpTzpEnZ5wMiA4mqCnku5vpeLho0nrI2k0tNTmownpmbMT89nrJrWPTlM/0ytXsP+RpBJ0ODzXf5qPyiFmwDeHau3Q75x6Daz7tO+45/zCcaI/veNEGN7seLvc0BYcnfUs35qHkgr6Yknz7r/Yt+aHNvQ+ToPR6zjtG0eRK3y/y+3pXkMjrq/TO6vs9nzXg1pAppghox1+lP0ChZkov1SigFT9bZiwvwctSEVDMXHCqKVoJtchI+Awc+Fane3Usclm6vOcLWuurEly0b5DnsOy2/68oZQfP3C1wU4kc+yrbIHBLTcdKcqqUCx+x1nmgTo0mCTlgChmraZZp2S17rExbc/+fZ+kdS61kDYHP0KO2F/Ac9RKW5tOIPo9ZDe9y42l5sRROicfYb+o0DCI+IDYgPoSeVferEnwyax1MFBG71vqvY5q1WbhAUHeq3GajhQcrBzGwy4fGn96JtfdSj8uklwiRvr6AIJdi9QAcKxIU/iKT9K32x+V3F6zW9zfYz2wVgGsUDbnUe3W9iD7OWgc9OEEuNBAu9BCDGUUUeIqCxJ+AXVUqVVvtz8f417gzu4gPxmvndZOq/lquSzFcRdq6e55Dlvv7+HO+RFQZazIo26weJb8Zgw4rRY42YuHjrCEOUQpTl9RqF74KZuXelEQ3Uo67NcPeSj1XfJAWFV4Osi2wSsxY4YkPwe3utONTcYEWuXNnqSZ4JnWVYMkXQp2Ck5aJRPNONkZdzLGEn/BV0IkF37CdYDHKo0wDq6DBCRe42XcsUfM8FtKyE++1x9Xw2XevZR04xt/GLrrHZy0o2rjmVJE1hLFJsQ7sRMO/2nfct/Eu0eeHNusb3GQ9+9M+Az/dsw+X/S7nLcY2QpHf7/vbc0ITnqhTvv2R104X9WiqeM9jGNpP2G5d37k1f8fbJt4552DEOeOWCzXJmO72sKrxLkdcU6HV28rdbzx0paZI6x5eh5DnGVbP6xMDiPJpog/W2SpLBkpLi7DDKsEtIZy3UmCmWMabvL9B16e92yC44z4cHQfd46ZynnEUXIrIf0SVlhsphign73evUzTOODhK0+K5x6yn7L0XRbWuanVltmCII0qYRsZ9FkG+yXaQBhdMi8sBI3ai3479dM4Jr5QV4PENUO5yPjTpCGcUm/cnJIMZa8pjsUqzWgsUj9GN+jycroLVlGB+kg9RqkzAgU+H0o4bwkhN81csoopuiAMFjjlnzDlw2Wca4PjzWA8qAY5ZWLoJS8MsVSCP5E6IQ4yVp7B8UFKf/RB4mRlshrmq1JTBOYIxXj7u7QOOx3ymgZqzo7Shl+c+4NaXNRaFFGKDYFu01uzhZauLTollogxHY8ZKnh37dI9v7LWfM26TVj3dE7yvl3M7KExr+WmS0GqDD3GzScnADPUSWuZLcNNPeiLfB4H/RUJiVJoz/ff/BfbZPYg1KxD9k6xAu/Bcyf4/UEq9RToS5m5WjpNo2D7vVxLgzjuqerAQQz5CkQ+JlPpslmVfzp1oQWRwrfVJvvEkmQsjjJmpAfGcVexvnt5hx3I3K4FLrD9MSWuJAcR4yDKw99a78G+WZf9Xa/18kY/eyuOfYIWRLIdPFy2HWuvPsYz/Pmam5dTKfjI+Wuvv1HVFmrTvlLgLz/XnTeYD3+sjWut/WBbxb75x7kAxviqFPYrSfXLwmAsGHrx7qTa70S6mlkmrnflCHXOWCUD2HYs055xJte0690g2c1nXbgs9O6a2gWQglEViuWbU9WqHuVHQxZPUsYpPdFHughw0AZVcw2jYM/RcMGJRdKVDozzW4MxtZN0cWOZFztxny+OsRC1TKr/ibycp9L4iF1sp77wPLG1TTStzmN6ewj5cmeipd2Vr8rOY8wqVNlzDR6taU6jj9buhZ2cyzFuBKGZSGkXMVMb5QMqyjtXiLwtEs746YT7OOrBI80sNONhUWbxtKojlrVISsw986NWPrbUWzbwjFQ19KdZMktN2UE0qmMBni54drllY6QWCflAqLXoyQB7yPT9K61RBPQW7E7mXWLc6xJx2CnPZhm74CwHdgMls0eO0+Ukh1porxY1o67UAQb/fvQde0Tu11vcx5ivsvw2Ly3sLfrev6N9lR6yYTUTjl4JvTXqKBlaJ2mQ55A40g2so1BENCPATJmC9iKtDnMJx/1i8c9SXkO3tWZb9k9wF/eiLQ/aFCG55GJm8KA61ApY3aZO1i3InjprJyHfYa7lkj8aE/SGXTnHd0Sou5cuSWMGSo8zUxXIT9bQuAaZIlTaVy2fxSMl2OOCmftRk5ZqmebkzPLAyGVpVAp36xAAE9i2rYNkggv8RZMFuA8EjY6nNOC414KJLoSwA5Molo+gZ8xSyfnK/M7VW59b0SggqdaBv8ruc1VvFequC8vJTzPRxtWY/rIL2JuygMltkphRvFmk2y1glFkIxAIkoDaUEfTEOLrH+sKF41k0DNO7fkjLsxC88TmyAYhksleG01jdTYn3TlEnnXb8kypLWOqfF2yAM8K2MkwSuPIyForC4RwEkhuIXwodX8YT9h0usP325iAE28G3fQeVDCeT4SYj0WUIdTRfv0MeRJfHB3N6Nje2UAhX583dix0k0/yzL7uDaTyHbTgdk2xBui6xv0GcN8AVfN8ZZWTJMNevugKLzGwFc8WLTCyKOfoWglo7VeuiNWuuneJ8pa2J/chPW8u9QWv8GX8ZCGayeD5Ms1xJHKw6Nh0MeKdXvpk3ukDgwO6vVyc+kL0gFlOtrVlZZL8gzXmEt66sRRTSmm7BqN7WK7IwbFUTrmzSaQqcA37JtpRytTkyrq80hFLIO6fOmP8RXrPuMm5TsKiJTX2wAxt79dYrAYpKQmM+nXA2bl7arnnR5+B2E2HWKBP4hmgNWkGWCUAq/t2k0Ykr4l1lOTAyGReA7iZMeY3LHNJAexR67ZnVwQrImaxbfMsV3owqoEaZ3EBnGlLksrYk6gFC1UStUcJHnSa6Rulk2xjo67I/xMWU7vaUtI+4xWZbV67mmL0TQPbinJrEe9OWVJ95jO0bqnU3kv0f+3jEzwfjd2ZT8/k1KsKfqxM9W+L3k8XRT+l1rQK6SSiyM4Fw3TQVf8gfp0/+nUvcJOXFQeLtopia0DY1XhP93UZll3HhbxGmC5lu5MskGwkMU9VgvPFth3PrCDV0Fq04UUjCANxXINBe9Kryg3NeUpVQN2zNNfa6+yCWxKzJJ5qkfJbtfIW5VXJJzxnKyGRUs0KhNHZ3n3ZasamqELVl/V9ZJmmrhbjI7G1eOiEGdJ8C4hVF6JMuyt+VOroagT5/Qu8+oNTPcc+RM7bZKQHYh3KlN2DvV+94pYCyMMjXCZO4wEbp8vz2s2mKzLkzzLoJLrFXFgClPwG2TaOPDNtFSjzRxbyLk3xVj83NKS5oiDfOkfUxCtFNFNsYNhmI9vxgAAAyFSURBVG7V8pjEkNxlXNWM32zo3Y2IRUzAXExops/t7RLrrtxVcWin9nuNgRMJby/TjQVN40asgrYx+RAjO4VhvFZqy3oBjpfkrbQygG+l11mQQANYSpggORHFJda/S40cgsVXyZcPwmr/KDnod3uUtt9vKNr/dbk9cc932BX+4bY3Ulbn7o2ehUD+U6kyzHl7+fM8S/yHpWFf7uRyXJcQ6J0TUVxi/XHuknL8olLqzytclwMKzQxy5HyBsfrDEMtdVQR2PClHq4gucBdvZ0GKH39kAFkIg8AtRVwOPeRhHDwPNuRO3haqQh4Dl1hHoOgU7baHTFlJVmNQjO+9U7a0WDWhjlN1sArmIdYnK1w7W9R7AA7bchpZbCgwWYMJjjCNKVa1RipoW0htZL0KX6ZATlYoAopHctML7JfTiB0XqCh9KESo1ExacGpCVY0f7RL2lrRUI/L0IrjMHOat7bkjGwNjxPDuZtvO+O6z6lAJHRxrsqAdJr5epN28V9YVu2rJy6WU8jcET7Tx/cYqOHOe3PiqHKzq7L4Xh0UZTGPlp7XWn8f/vmFiHuD+psa/aQRt16+9+B2ZbI9ibmoqfd3UZi27X07585W8zJ0UgfkY848oTiaNBG06agDMTPQZ3ysutcnvyAT7YtnvYcaawjryNiMmEfe5YTxfMvYSkMJzHicS6pATUbVCpcCJhjIEzPfq+kxTHvRxVpdY/65KFUFesEuIWA64KUXW/GeiWTJQhR/dgIj2q9wAYWb9sv23ifCPQMfXpCMECPBKn1LlPNMkLswPqbWPfYgcp+N0OtwwsL7LW4pijYmymuBbNAER/d4RcZ/CHCyxBvxF7pI4LPkqEMJNPo6c+GCKnMjH/0dStdpz3TWIAdNwa4l4/8+RMpYsea/J7fUADiBL1wP5o33Pug/l8P0BpeRxNPCNBHGICDH+dtkzYZn5UY3iwTaEyZTVDFBlnHWkhr+46yZ4QajzKQ3RHNzuczbAFWf4zZZpuyPaK1yzLG8qKn0YAjTemeBKgOI1W2QK4vqNllAYnUat1tzPop+cqlMjgZU4ZiwKFSzFwyfb1PCIKKNoGU5T5DMvqn5HO8hQFRKjbPVdh52zDZcvUtwm4MozlrJl21xHCJdcZhIEwYS8t+g9LbQr1DEdCCyTYVLwESnsz2EpqJTCHtuhvKzydV3MWiUlW0UfmuWkhfLxRs8yP+XToJkEZ30ErqxJE4IJumFbsj7WmBUldLqoqp71LCZN432RMvgg4yeigIw6axrShUyFRcCjeAMi2IuUEMp9Kx/4fmNViLypQJaL4INJaJ0EzQZLoltLiFfkcBrpumhHvOhSyKQFMXcLLBGx/Vsn+ehRsQAbwRKgtb6X1eJncwcDsLqId00UlTnTRKVRv3XRLrxWgJjv54Urs77UUCr250o6hjxDbKikOr/Dw1XFlvl19yJjlM/dLY/n8EOHEKVceX7/SvLlj+EvvyPBdHa9753WGW8omKQhPAihjqAPHHbPQ6+4nxDAwyFLC/tTbNx9bd99HqwmlIDHjKbpA6117kfL7wtswKb6eGCGbosMtJFa/0Ua7ndze0rAc/1PpdRrxTLA80dZNrj2dJlFYR3wPyp4pJ6AwK5F5NnjK2gnYYD0M3iYrICcl4rxShGF+n4nR6whWTAFVSOOzJJTYjnIReN43uH7cIGQIJ/kwUK+lmveJrJZgo1YOpicQ0bTVNw7EeI864ARwhgXSRdadLYDrrgCJ+5awebKEwVnn/8NSg5N0FjZNf6nrNz9jMlJ0NrvS9yqmCB2oEI248GizFaTDes75tt4htz5ZLJGNbugsUVSAwiuWeB9Rp1j002Oc+Jz7feNLyvWOOO16BszzkvK+OWeC4YOTKMP37mea3PZsIMsJjzPTMy5SAvQKuLsmMRSZmYvMJPn4DBPYqifca7pWlVXVKjKngvLgaDQkHOatnAqMh1CZrlBo+WaJlkJZfuYxAGYFcC1cae6tvleMwT1mKyCmdyJYfRHALozz0flNWayt12Nb4MblXK72HRvZvFCiBuQOy+K0oKzb9LefNf6Nrj1oo9zeX77pkG16ynaGLuovH++xyOh8avw29OJ9JAbf5ezvlnkqQaj3E9j13so4p43RjYcO4n85JWbkAf3k6ITbLpG5NEfKaX+uSgMpGDnOGEZrEj64wkmmRWcDusCxkQm5n+JfUeM/98ThYl2R6d9gUSxYEV5d633dai5cVmKGWoqnRzzzVQ4TXTDNEl5CezfTkWXad9x3wYHPhBzDfc/QH990+jtnO/coo2UncoN4hJ/a7ROJRXrHkeqNoZDJj4RkoV9G5y1b4xcztp4sDAzdAltehfRWW6r9p20n6wEy3B9B9aEaA5pnAQ+KwMy6IQV93kNJTHnTaMyvDg7izRkD0YIbFkPzJAZXDnrltXpHtMPC077QGjVcsZwlGYZZwvSlKLgC2RpHPJS1PU8zsefwmRizBovYeo4wFYW67g6qRjAOZSivTU+yqxryrHKWs6QyfB6TFdfsRTBJThlCi7USe9IRM6JQlZAcgaA1Ql7CS9hYYyrFch0si6hKo+7tXIyVyycWTqLdt8ySYIQh8zepQIZcMSqgjfmySBIxZgdIZ/4Pt8uikUIQDjTryVaSioBWXGBcbaj4tqUpuzQ5e+jCe98Umv9OB6rGaLSfGM3R8Sdr2FbDAoDWQbCWX3g5e5h9l3ntFF8jL7+x1gux+CcPQh7hSK4++BQdb1uJumxaurGSlHHbQ++1XCnmDL04Gx93M3qVL7XmvxHY97DYjqTMJejTm/XaZwhVcd0zCVWtz7rLEXJNgSIBZhEe97JdrG/f5ZlLzT5jJbP+3hqcTmJGVBK/XFRlJlz/h6UxIEXVsYSIIHp95e9F8+1HzFLRLY/iakPwG8IF/0roR8I+Hal1H01vJlyj5E+ruxq5T7N7HLZsFycoBxkzvtUtKV4usQq4ts/QIvAuKk76zvu29D+k8qfIrsbS0mtGrvYZfssGLnWQluknGMlkJ59J+UgFfEFi5S+LBuXpSop6esBSzGKtu2iL1yIfHdzzUlEqpAMm4KJsrSWCwH35GUFtP1DfGDjHgwWtlD9wTOFGjI431S2aCLOJvb5Oo6uUKr5W5hoqARorj6Dj1hTfLdbHnClQ9RoLeRMRMtPRZiFvuiz664DllK+L6Gcj1ltMgsJHYU4mIeWiJxpzyXWpSFnDeJopAbfKSMILB/t3IEBo2pVclaNWTrueAkWhehCEyU/Udjy9mHbGsCJhSkplzO01lIP4AWrfJEXcBgXF7Bjf4X6DGJ/fHPurAFDrB5VrRAQ0UNUEXzBOSYK3HubsNLQ8fBP3AB8X4jgMzJLNnHp8YFB6h7gYTtnZDlP5PsUJrY57MEXuZllE/63iACfXO/nh9iuyh2IhIgFWusHKDhyv+r3Us03aE58Z5ZluYLRPs46jjYX8h5d9rCM6ROITWZJX65RI2HgoKLK39R9PrkPVRxHmaxHm6rlBf39um/1ynFW3IebsW/+usFunclvbohaAJFoQic5b6XSu0FJdTFnyi+5yOVggbmGysQMsbFwGq2+rtlsxyAI1aToB5JF82KAdeHiJu1AMkQJ5NvGuoZtYAkQzvf8IFzFpjZsyKFQRKym894gqh8PcQmB7Ho+FA1FqvV+ei68warbe5Zwv2dyF9WAZWU4HXomVUSsao0tpxT8HWITAMVoyVKOVm2jpCFNoWSvi0WIcvvdMiUtJLNeBA/bCdVdHWJzAtGubblSDxKSeY4Xaq8joZpC0YWEqso4q3XDUyT9DW2vWwxw2Y/gsJgPyYuDACv3XHRoZSSxbqMszPxGtSEOsbmAReKulHphUcSq1mZgx9Ptb4ghkmDJxdenBGcXyqw2oP69FOF9uiwCaYghXAjNYBJdSSVUlcJZ+y5ayyiVHgIfHNpihygChUDuwx1dWPK+CJWI1QDuephwrroZpkNsMSCXzlgZyPViEuoQq1qTZU05xDHk2iW3SvIQWxdW6ftfUEq9HXpoWc1PGmFitYk1d8M1LW/ESqddLqjoZ2PZ6SByjVX9uGXtv+Ckjfvubf/9CqFxY1ZQb48Cub5A6PP4vw1MqvdV3MtOC++RDbqLSdpysgC6VtS7ebeX6TfWS+2YAtpcd4U1PrlgZQ9GnHEw4/bdku6SY8415n3tsVxmLJ+FUdUOwnbROLHmfkDr1yulfkDF6NfmTijGj5RSP6WU+h73uI5/XZj7f4dIMvd3JM7yZ8y1WZb9QGv9Wvk3d6e0d6t9jyEioZT6/6wmKqWmbYoTAAAAAElFTkSuQmCC" id="_7179e390-96ac-31b6-547f-e667555c8f23" mimetype="image/png" height="auto" width="auto"/>
+  </figure>
+  <figure id="_ab707549-49be-8961-7d09-d478a252089a">
+    <name>Final stages: All kernels are fully gelatinized</name>
+    <image src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKsAAACtCAYAAADPsY8EAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4nO2dD4xd1Z3fz4EEFmLLbwMlMmniQazsJC3yIGfT3ezSGRol201tPCjSVial4ygrUyEhT0xKtWzQjEWathHEg3YrBavIQ1KDmq52xjZKNqnSeV53ibqFetC2SUCLPE6CrbAQHh0KG1Jyq9/z58z85txz77t/zn0zwPtKj8H3z7nnnvs75/z+/2ySJGaAAd4MeEdTfbTWbuJ/x/jbMsZcbIx5g/9f5Cf//wNjzGZjTMcYM8RfwUZjzI+NMaP8e8F7jG5niPfZwL87SZK8TF+2GmMuk+Pu2ABvPkRbWa212yEqIc4lCG1RXaL/vwOhtSCy540xl6hrHHG6djqOALln2GtLt6cJuZPzb3nuz40x25gELfV3B8/1+xtCm4l2qbqmxfGsvpSFjMOLaiL7femoid9Sz+uoMR1ijF9Xi4Ke/C01+UPPcG3MeePvsEjbV9GuLBZPpa6qgVrEaq39gDHmnxpjrmZATxhjXkmS5MnUxW9yWGtlxf6lMWZTkiTnA2Mh502SJK/wbyHgdxpj/g5jIzgn5xm3dwVG5G+4vgo28B3OyTfw7t/K5DtLn5a4xt3jJuaSWiCeMca8P9CfJc4ZJrWPJSbvNv7KWF1ujPlPxpgnQ2NXFJWI1Vq7xRgzwSy6O0mSs6mLBhhghV5ksuxhRZZVe7rKqluaWK2148aYvcaYmSRJHk5dMMAAOYB+JmAb/lWSJM9kX12DWK21h9TMGAgqA1SGtXbEGPOgMea2JElOFmmnELHCj/2RMM5JkjyQumCAASoA9uDBort0UWKVBh8pOgMGGKAMrLVHzAXh9DN5t12UOpIm1KPGmD8bEOoATQEi/Y4sik6rEkLuymqtnWTrP5Y6OcAAkQEfO5UkyY2hljNXVm7sDAh1gH6B3XvGWnsg9MjgyoqpVCwwowOpf4B+A9bzdp/2slbWKdGFDQj17Q1r7U5r7by19gz60X7hoKhH/WeliJVVtTMQqAYwxuyCfxTL07C19jSE+5y1dr9yVooKDAUdWNFlpIgV68Lh1NEB3o74c3OBeF5OkuRz+IFcZ4zZjvPRd32Ciogvy2TRza1yEURJ26njbDDAmxNKTjHK++yL+mWUaVScYB6VH6ut89ISd877Y+zKQoPW2iWZDK493591s+faNsDbB1NOoGa1nCjiPZckyfUQegs3yT+w1rZiaJGSJDmIib9LrD4bsCO2D+IAbx44gVpWsiRJbi7acdiEs6y8E8rhPgaGHG/sE+vGiA8Z4M2FxYi9DTluV8WMc/ZeJlZ8VN9yTtMDFMZQjKFidV4gciQG2rAoq1ZW4Td+Mfi2b1tcFevFhdc0xjyUOlGtrWVdvybW3zTG/G3q6nUAWfWttbudmkQ7O3BuhN8edogBSoAQnNcjj9ln8S2JgW6smNYGyDbwv9b6I0Ns0/Ap3zHGvEoA4RzMtvAwl1hrXeBbWwXAyYR7zVo7MBP3AELLNOO2GVVUNIigbq2dxhpVF2IgeHdjodgFB2yLi9+CSPciSYrnzTEcGl5EIZ0JWXUZ9A8TxDZnrZ1aj1Y49Z5r5s2mdKoTrFqXr3Pdugh/a0OsENcEK+Uigt0SAzetVChfSd2cbusQ0ucEkaUnrbV7IVhZcfeuh4BGCGSM37dkQlprhyGariTex35Oe05K630X6oaxh8ytjQJC7X60JEmuQdITldmcrDRFt2/5+GI9gcBXOd2g87se1iHlENHHd91AP3crq5BMnsOwNotMWuln21q7L9VIM+hXso92JAcY2TV/tuwiCDP8WJMx/9baTxtj/mGSJLd5xyU+/Q/941mgnU8SbObHyPvPFAK4wRhzb5lIyqqAddmBSVLe60c0dX+v5xM+ZNhpHun1blWAkLoxSZLHmh4Lc+F5EoJ9UZIkR1Mni7ch3/AvNBtQJ2NIkQfKDLsiRJBJkvzIWvu4bOkF+FOJ1/lekiSfTp0MQFYxa+3TkmRBGP4mw8fhR68r2jcfMjboJ4WNOWWtnSOYLiZ7IKzHmLX2XsWCfKNBnvWbohlIHS0HyZzzLs0GNEasEOpQHg8KES1mefGwnc7LALONFgbmw+shgiZRewxFimbCjsI6tHEwigX5DjcyHjP0+UH8VnfHHhvYjbo7hEyonzVOrAzAaBHekTDvaV9Xyr9n0BLUWRkXmtLDKgl7LnWyArC3H4O/l620Sp+2W2tnZTdCH71Pm1WZGA8nSXITvHMLLyq55xC66xiWqM2pI+XQNd/6etafROjYMnjR4V4hth5GWU3G1PY3gZagripqqAmJ21p7nzHmY02EAaGvvDV1ogeYPHsdETLZDRqYFjvUSf0cY4z8HlbqNSHuy621Q7APC0zIL5dkG9rsmMOo7Mp+R1lIX9Mra0znA4e9eJgfKbrF8LFHUe3sUFt/LUJl4kTfPVCdSf+uX2eGiFF8k8+ygt7I7xqnY2UV3e+HP3PPQeG9xfuKd7NuIVFsw2SvnYpJsw+tT4fnlrVsCW1e1mR+VuGzfiD8F+a8XUi7IuwczpN08an8Y/SRX6irPLfWSha7u0R7kDpZr115rzf6IFn/LHWkN67N8k1m4p+ESIWQ/rO19mtJkuRasZiM8i2Oca8Q75esFTruftNVCwqr6S3GGGn72xxbJHNh2Xf5a+mAQX01iT+rqfsjleIs6SFXtWeMkRV2PnSO8zITj3C/EPzp0HVlfsYYGbTdMd7N6+tk1ntEfs6DoeN5P8Z5f941qn2ZdIf4LiOha/J+xpgtjMUTxphxvuEsbW7yniU73GRee4H+7TfG/FpTxCqd3h46p15uNnBciOq0HjBevtTLBdqV1WNL6FzNdjMnXWxirdJ/IZbQ8ayfIrIzvNuerGtDPxYpR/SZE6UCsY6HzK1LpiaEByIqMpMBF57IWiuS+biT7uFjhlCp6GuF4Z9NNVIeUflV9L1zfeJThd97RPwd+PdiQUFRVIGbivaR67oRAvCid1hr70LD0dOXAdYuV08OROuwvWRUymVawIrlKT6UR6gO+Dx29Z4kNVjM0RpM1XU3i0lUCIudfmVUZDzHkOwn8HtoNI4fIevzTlBTAlktXSwC13BJelv0ibW2p7jLjZU6kQGRTq21Cem78/Sn0tnRGnHqm2PpV+nDRL99DtC73kxs1ChWqF76y0XURi5RxWRZvSnPfYD8AWNod45XIVqevVBhR+q4zji+4EBVnhVB6Di8ytbQNYF79sGLiR3966FrvOvlw8gKvDl0Pu/Hs0oLDqEf41ToHZv8wd/fHHqGMeZK3nn5e8BP3oBsMs9vpxwPtZH3o31p54d8k9yxVf15ouLzdvoC1qEqxOqY8mQ1g55JUFxzSDPgDHwmQ66u2+4LYP0kVj54LWEv1o9x3Bfo4yYWgd29hDIEl9NMwEyBOO/npHs1Acb95xpj7qM/lb6B0wbUNre6ADH1/7JFzoe2XXRz034GbfRzw722eZTbIoDtK7kNnYtk9AhVJ1krjKKz9jGMx9axXkIYplYn0Er2vpfKpgXimxyETbhNWSAPYe7dRJWaYzUMO52YPOvyvQzQTbz8fu+6fZhNQ/zpHITeE3g17S0hdD0TKXpzRyzbfxHkOfUgnIbcOTtlQ+rFwQiiHWZSz2F1LMXjigukCMlYyRbQYkxHcGSRtl7Tqqs62oC2VpFIp8W2j1OKbO8POOk1S11BGEthrygRNJi9Pd0KI66s5yPH1zuhY4z+SYTpRznVIfZoiIJtf+UVVJsOWQHxJfgHqQcVAAuNaGkOqn5NYXWaK7MysiA5P4M7UheUg0yiH/j+rOcqNrbA8r+sh4NwPyNEin2/UyDLxyrdawFMMZi7e+gAt0XSs27tZZJ04GN/COHT8PwF/r7PGHMnq73z1OqwAqXykpqV9lqsqFNZWzyrbl0vJ6McW5bDkNDzTmQtOCGgU6+bPEUmy3OaWD9UNm8AHv7/GBe2W1IXrJ5h4vwg/qxfzfKYJ7fRE9ba72Vd410vPgT3CI+mJ0oAsn1/I324NH6DrXmbulEI4zeoxHdObcEnIL7HEMx2MKFd9b5doZUxC45ArLXbsggVvNG1o0cEC8Ex/D2ENRAL178vok/PqxFQAs90KzIqietIWZUMUt5IUZMjKghn9w9Kqphi50Pnsn60GZQ0kY5LtRf60c5xJN9JJ91WlaJr9CNXqtZagqZMwcgeZ+hL7jPQDtQy4zPOI5VjsOrE8rCt7MW1LmUFcsXhsHIVaW8cC1iKp8JU+1Bdzygn7ISe0U84v9DQuKm+Pki+hcJjWGE8XPiNKwo9F6IfGf8ySd5C4J2fqxvdWim4kG1lL47AvsbAIDC1sqThABZ9aR/P+HlimGK48I2to1xgvYTFw7FyV2XBhd+ocCHhvQ9gLesK03y/WALpZbWcr+sEmSFETKFfDRHltEvIVaCtk4GPM0fYcx4vWwatJqJNK2BBrWZByOpWdzUrAwj3pFMpsgjN8/1mYj1HE2uohnwQSs9X9yVfxnklFS+PEHEYlqAIupONFXWWvAR5gkhh8L5RVVZVwSRvIqojVv/OughaIhOi5fvVxHqOevRFMIzeLxa+JpVBAi/+KLrG/MpzF85dS0DcDDxqzFir98Rwn4yIv1xHfVkFZJ9vhdRvNSA7+EatupLQj3cWbK+DiiQKJOSBiMpT/kuiztqNKmhV5TlVTl76810mXBPpgn6KbjQFFbpxlVPkO28nvaqoVOatCKvNJakjYXTK+LNGwjTGoJ9GZME+aIz531VjsBYRODIl0optDjlFtAbWra7Ds/N5RRod7UcuK/S5q9gkiHSafmt3QWeynCKKVGMIfk5s+q8pQ8UCPPb5gllj2rowRA/Id2ossYcPxmrCvX+kpCIyxu/1LVgbWXJzQYfE9r85YiaPmSxiNSsE24JxF6fgP0GF069VY4JUON9H8p3JCL0urNpSjsgtJt4ok2KuR9G8oaxgQA3M3LME9M2x+1ybJMmvpi6OCOijUB8LQsbnOa14nS1jFMA1LOWiVlPpnorLCly3u9vxHsrohpThT2CAaOzZjMN+XPfmMUAsu1y6gMrQvVk/2ptHuV7q3orvMF82/ivvR7+vq6xnjV3VhVVklf1ezHvO64fM15N4Zn04Z9VpElO4Nzb2bOWZf73ix0XAHFGsRyk/B+XpX9sRh+8QzBBDnodZdNtFYrHK4N2aWF+tkGXvAwVCK8rgCvXS82QKlPCNHyKRnydz4JokvsW48L7IuacyQRzUA6T3uR9B7js1COGioloN0nXu8I7tg235de2eKTRAVhq5/tYGkt+JfvsFzbNeLR0sqfj+qmSJgyeKodd8EZey+2ivu4KRdn29lOg8hXTaePpMDycimE5/kqXV0ED7Iiu4ZHb8qCvohibDRb+O49DiXBYXCTBsAn/fGPM/NZ8xWyU+JsnJA1CxncQ5aqg49L46ixToZ+N8n/c8Wcmj8IDwk1vUvzexOJzhd1rz5XyTIxkJK7a4b4PDSiX6KdBnafs6X3W1sYpXt8sDkDpRECj1nQudTsC2D9/N9ZZGvN8WpFjO48bZ8XF077CCHs5aFdktgyHynNO76bYm/Sc0sbaKqq6yoAtaFLmW7UX0gM8qT3jtD3AedU7HVWxZJ+U6qyRpqAOpDh0lSQcLy6jKzRqrUEinQSvfYlcvrZbaQ3WWcRXZup8Q3SPeeTl3PFmd76rn9s62NKsiKDN9OWtuNU6903Mc8vxxG+jXJNt0VFYoRg4xrz3RVNwXOheh7XE/FDuGg/JmHKzfzxZ+XP3dSmqaEUKFcwki9KONo6FzNfq8h/7tgRU50CuPAdc18mEC4xn7fV3+hai5D5Avvlg2P1aJbxSXWAMP2aQjCfjIL9WJvWcFjJWwYkfovZlg46F7vH6cbiI7ofeM3H6UbG8zu0Iju5OjowZ2gcnGidV74Dgr6mSdLdRJr6FzFdoKtqNSdh6CZRnPyrLIx8lM6lGxX7t5dumtmvGZZCId8s5NNq1ZcdqD0LkabU76RoHK0nxBiB3/NhIiVNbHuszYeKSnEmkUBXb5oK4UXfNel2NL+fqGLDcTvZyhS/ZrHKGz7WdUzAI+vOO8kwhOS9w7RtIKZ/1qNy0U8m1j01LX6raqpkAFo0AhQFQxX+A2FMUTBVMshpAb9sGkWOVVRtIH3+WuA58eq/ZpyxWwS51ZSSlqXAwWliSX738RU+dXVAK5Fn+HST7RDzSh2ltdU6DBsI2xmJ72hG08zASruroOV1C1nPcjKlhJXolYBaad9bGxuy+oqir76MPNWLeGnCnWVXthnCYiekDloqHaDUM+G9CIjgz78kcaigqVmgPXpY4WgwzAX5S858+ojTDp2c3/kHRJO3C+2Zfl7NELbNPXOf8D7O7SnqygFxPrdBACvFmbYHOMJ5+SEu3keWgat/JdYkIWiV9oYo3m+e8A//XPjDF3p07GwU+rJEtjFZQw5R+lTuZArsfSI6vUfc4jLEmSF+Bx5V3/Hb4Dv9erFqvLVkMaJBcRuh2HngexvT/iMqzg0GLMSiG63001mn7GEfwBzpFsZDZSbassLDVQdlTe//+tkmpDklhNKa5QAYaazyid1x/pPkYKzFx/CPSZwb65NJ9KvXcIP92Xsu6pMv6+ak3VbYj+bZpKCerabFobEE1KzkG7aMi2WdECjNZhSyjNeSSLt1Q4mJN1cAr3v5dZJSUG/73ixZ+znZfp43bkkFWCGu89WjILYyEg8xSOki6B7jhHTdOu0VTZSR/wbB3SkB9PXZDuUxv+smrKd8NYzeHQnAm2wzmtZoPQD5jmx2gsa6IwQa5HBRiVYCm6EbvewQXa9JfamNtz6HiTP0ylmds7LnCTKPxPE6bSM19T6Me2vYX7c03HKmO3e+4ejjUWIlMwk/imMqn1Cz7X1TGLRk+M22X6QNCaU7FxySF/IHSuYWKVnPk7A8cvx3q20zv+AeW7cBRiL2SNor0Huf/rRXwdEBT2qH/vrFKQrcBzLi/aLnxmJV+NvB8LQcriV7EtceS5VBsFfpxafKtDVpx7rLW7VHHadh/8Uv9FRq1/kdIf93NeJUnyQzzEDqssM1Le8TrGo62U7R1Ca37OdR9x0a3W2iVKNvayDn3Cq0r9mLX2Yh1iHgkfJDFbTwifaa2VnAynxMc1hoULw8WPI6bevNhPeZkr2ZacCZuVt7/b7s6wetVyzGCbOcDWkHi/1O7gCkKE2sr7ITVPqr67Zzk3yE3qGVuLbHs5JUInI2+bpQt+KJZg1pW0DF2X99M+FXnXVWi3OzY65WW02S1F2EIrHCmCXERAS5UWz7OujKq4+kX+v+07YiP9viOQcnF3P4oBixAVErgQopzZc5h8AClNBDm9hI35ozqVC9kh7sny/C9w/wj9dWXbXWbuuV4+HRhCrspLx1mxT91U/H6SixgNj5DtOQUI5jFUOm5gxzwV17Dadl2/2oS75A5WRnpy2bKft9b+eI2iDKYh0LO8r4SUfNlP966qh+/jmnbFKNapLC1AEbiK2Wal6vdHINxpIjbaOdGrJ+DfY1deTBVti+LWxZbWSOBYgWentnu2pT38na/rohj6sVtMes/dAruS0or4QXuB806irmLwaCyYEc3HERVRMe75KxeqZ1bhud0xjFWtpQuX6W8N85j+39SRC/kQHnVeUdj07+bvn+OJXzfIbQcJfN1qNAX/9rUMbyz5yH9KiHlqrFTxEPn4/91a+9uYdHOBP8GLedfUgaotcCWT0bF0U4Tj/z1klMY6sLwihqi6wiw4FDOtUIHnbVKmy9Q75DH7DLZecatW2duqTKeF4rNYpVL9DVy3pegK6/S+oXN9+hbRQsa9drvCfxMWrMKmzyrA0XiENDZH4GfHVKpwH5nvpTJEj7kiY7jeHShjXcJS5YTFzLI/3j3HyPqd+xzakmwscwUcUIZ5h6O8R8LfScar0QqJjEMdt81cVE15mYehjDKNlcCLjymNQEvVjZpWJXeO+FI29/Z0BGbbPebKE+EtNUVGv7bKufq9riVlpc0hfs+4qIKSQtwMkyw30wr62L9CyHEO1qHnLPjaBucLASF/Fh1yS+m/De6h3yWrSmVdOGxgq4EUpF0By88bEKvhym3Bp40xuBvJJ+DUJzM5A7Go2nDhHYsuc7aE1KTuyACpihwPOqLUOJ+CJ+wEtCfDGSt7JkjjOVakUB3vfTOquCkk8zs8nnfY75c/EdUYbVG7zjaXIki0EEoj46ATJAcjGMCdfLtGEFXAAkO9srq48jiKCIwicJect3D5RYhTf6QJtuOnXHgHid6cCqzw6qFUObnEZK39fhUvM9FtUyfVFEloBoG3edYj1ton1TsVzonqZVM56San904bPH9h8dSawY/4vLcwtSk11YSVskubq+pgxaiZxBZ6FqvPRoSfbehApYLhu0kx4yrwmQjS+Kr+S0a7kFIco8SdbHsyuH9S1gE7C3XrZOH99M6ilfvUfTtQzW3EFv/h1EUNwGWPdH3l/T+eJMkXYj/NGZn0yhrLn1V4un+uIkdlVtzVxIxTRoUhIjld0bCLUxevNkq4KIY/ttbeAMtQqpBuAG5LrdQGtRNGWC2ne2y3+j553ych9kdSFzQEf0LJ2EmpzoYed7Xx/FljQbaFg4RcH6SmfVRCJS7pkKqxtMDWXzjuiX7dBBsyBx9YJ+RjGOn+NO2UloiZLGMq1DxUHywFFV6zZtUPed+QBTEGLrAaWu8X0nFV0IlFCRkJtLsJ3eQs7mcphxgsRpNVdX2wLLO+Q0eB+qQbnC5Q9XM+5FhToi/bXY6v0Hl13ZZYfrGhMJgS90X1i/Xa71qwVhFZ6MKKjR8PHa/R3jg88KE8hTtEvD9GjJHKijKPt9Vp59wdyFN6INQvVvozdbKg8O7ixhgkojITk0k1QpvzxHvJif9DP494XmaFjCVNGAK89md9Ys2dwSUb31nnBZRVarIM4emVLLarGn3SPgZnlLtg5tgpC1RdC9kRNWFH1Llc106e74jzCdXnnrsfmgC3ap5mAqfeoQl/C6/97sqqtQHi2f+VWEwGDH+7DB+FZOvcCIWB/1Mp6Ja6MADULL+fJMm0au8Amoh/HUvqD/S5UDVxtCQjSO3ilPw/SL2eq+bz2tis7PHSzt8YY35Luya6rDr4CexEODlHwuDKPhs8ew/jKT4YXxWLFccl0uDzDYRgu2dfcL9U1BvdWydvxfGuG2H2HqnK7zLrU+kWVdtNxTqV7i99cnxtZXaFbX2/Sh53mt9RtvGm3tmt9G6XCbIoEZ93JmmKZ1Vt9pwACBKZ8fUlnxecHAzu6SY+XgTe+FBNgh2njUmvVkCjfKT7vv1IquzoSKuumojxn8sLyyVWR3SKn46k3go6arA9iQ1+oYlsJHXKK+FgPVQlJBrWZ5ScA8vZGelP7HxTIcw0aV5V6Oqwm05ysZDl9YTHlAmFgtRAJs+E48cwziAxvYJKJdkIAYJtUf27TN+mvLqxDhvR+TbmW6rCdZpOlWpCxBokqjpQM/2QbobVdi52rA6WnMyPTXKHGyHYQgr3XmAS5ApXBdv5HPb5aXwFJvOITRkCUt5X7CQT7Cbu+k2xCuzRznTE4hm9kMrPGj0xm1kxI4p/6E5c3WSr/kQooDACrilIOLeTWO16rT0oC2WX/yQxU5kre8GxehLPqq2wZXdZa69mx3iSVfwcUr1k6/u3qUZW2pKYrzdktUYQk3uutNbqiIMdaAqcxsA9p5eWQlb02/tY6XFj97+xBIUigkSTjD/6xFIWIwitsvXHMf6YGZusLeCkfieBv1REIC471ozhflW4bWfAADIeSiTSMO1009XrA00T6wgftZGAtlBgXol+VSoVpBXyMfMuFHhuUOvhXbOpZqGRLehP51WqpEKVyxt43yRxAYN4L0XnWT1M4Zp3a+pMTcB/Vgo/xluoQ7K2iRAPGALSu5a4o2X2zoPnNJ0JMsV0x6YKX4m80XVYV7kEhjMEuqbRHVstYDWq6nAlxBtyzh2tM9kg0L0IN7tTF3jgmo6XFKQfqiKDqmgmdTQAlyGbZMX701f0BpPDhcWkUmj2Cd2x7RJrH2ujnkgdqQmVunIBYaISWEnG8IvNzVidpa7J00REetftFLIovFISEDnDe1XRBrhgSj8ZST+xQqygqbqbGi/HUhkpSLI0VxDjB6mzJcCkvUOyC6I6yvq4H6XerMajxGg1AjQE99K/su8lO8ctxph/SeRr1nuF8DEKaby81gWfNbE2Vs1Y4VUci7urIQRx2hV7qIjfVBkQP1i3g6KySZLkAKvJNzPYAll5T3n3idrn1ppJivMgQY839VApZULUTLyX6HJ/T18nakW+w6raYoQBPZTVZr9xkVnZvppIr+3jaZc1WgaH5X0vdu2qGGqCX4Q3G4Pn268m2EhO+s4prYiPBYS5Qnxqgfc6qaOPFU86qkLD3fE714hH9bHKKNCX+vmsCqlMhdbaZwLF0IJgEB1BdIuVqfDsqKwM7d6IxU20Ba+iQA8SJJGnsjr1zLhXFG5lLxL5WrJdV25fJtjdjP3DCGPz0MTvp25cG4x16Ubp5KJ7XZXQo+0oosBG33eEbXgyUInkQMg5OGI/j/fSx6qU7LX74cJ4QucitO1Cd1L69SKhPH2mj66+WB9IdbrPHTrCR3ZxT1sgjkR55ucquSH6RiZdGV9blQWwlKUHS9VuJmLSh3CRRosOR+znSqQArmZ3xsgbUAfY2rdiBj3vPPw5fq6ILRr+7mpnDy+TiSULRBw8UyYhMUKjOOr8F7zrz2HjFkn87xIpoH0JRkge8V8RdpfWMBvjuoLLqNPlWQmDWPP+uRh4P01kmSQYesLhvVSIF84CyvQqmbP36AqAzkqocnNtV8Kh/H0dab1RKAvYwlqrokpAJnoj6YPWE+YQhkq7IkJcU1iqquw4q4RWCOMp9e+n1L9PkvNqR4zsNFmgTpjL1TVNGqIW5Tc3Vkmv1Ces1MFyse4hfuHN/nMeOyV5pPvgkewUhP8AAA9tSURBVCvzv/CdpeLocRxphI+EFx7xjm3n229WNb3O9CMkpmTfV4W1DPXBkWWt4PKVZirrZUsmf+k8ahvhT6+JoC4qa56cYsXL7GsNpBylZXXHMiUGg7NYqq6hSuBsA30oDcZilZ41lMLxLQF0n+/Bd2BB1bUaQhDb6lI6Vg2xwXyprXCjxEaVak+IRvJc4eEUTdhVZUCL9uMBPLaihudXRMvRps4bsLPp8jtrDUVUTjr/awq3VQJalPvxSXgVDYTgZB3eE43GefLE1gbtHS7r2Y9Dj4zX/X2MCkhhOUNkEsFR9+36a3LMIhfRq1xHF772zFrJNJo2++0i+FZDY/nzMe+GnGhKgWDNytG38LXX4GJYuz8Vnr9Mm02kvHxbAP3rQgP587twjjR1JgO63FaMCFQczSfyIm6bAM/r+g+7sJYtb1E9a5No9cHiN4EnlDhQFwY8qiu/GTMJxQSrdKn+1ETLd75uxM3urQq3YvXh9cbKqhRZeM6z+OyNyeJhyGjj59pPdMfAqa7OL8dmr3PgJ3A59vUlogT6Lak+Sx8ag6oS83Vr7e8UzaYoZlvGpClL2ENoQPqpObrUqJX1Murlr0uQTWQ/CnuxLv0jVEVCuI83HfukgZJawku+nzoZ7xnbWRUPouf8eAlDwZdSRyIC55pzTT5DA37750atrOudX52BV5rxtrVjOOD0k4WZLlpFsApUDqkJdbuskkV9HFpN+heAdtUQ77Jgh0lFCvQlWiAPrCgumlLXx+qE4vkRJEZJataBLXioKVWcG7imCBW4ku/L7yCFkl0iuwJYbNohhlREv121Mk1VODZgTYQrtnexye9BH+iy0k2pco1zOROpperrt53nkBf0NonNfzKCzf3qJjUAWIza/mQomcJyCt/YxsBEyPomTSBVDrOvBIuecoyVZCvE1iaTyKqAPGttSqmtVjk9u09i/+/WQ1W5YadUNpFUDFjJfk8i+Lhasm3qbvkCqozn88aYq9SHdWoYcbp+nHudtD8BH3679zznqliIF2X8tqmarbqvPlpssQsupb6a6EPIBLsC7zVN37aHdrzIcKU5n3LEOpyVuKEJsFK0lKPHqgjKEtt4qs84rtyAp77OVngSf87SQAMhk+N6Cc/GOXxJayFcLn/+fw+OLMEoBQrF/boKPJR2vpixdX/SGPMfS7Ieoqn4LD4Qh3EBTNU9wLdB8HEhTGvtLer005hZb1OZC43KcLiLSdc0scpC8BPjCViNuQhipqsT6h1a9Udz8i5JceJvBxTiL6au7AFW8L0IVZkeSDoEBR7z+1leS0mSnPLzDuRAtA7vyz69Goz1qSJOMKrPhd0ByY/gCl+8mrogPuSbddN0aqNAkzyI2y6fdNWVycxch4ds5azAbYSU5VnvwkpcqDFJHZ4oUFVwmMTHpYQqnr0tAp/cyUo/7wNCHY3lrdUDQ/3OKaD9WZt0vl7w1RzW2hYrX2UH55z4qg5tLw8mvNwEk3JGxUKN4PA8E3K2xrdTCLwVOt8DUtT4hISsZPSzJ0gK3DMfgqtj6yWLawSwD/1Sd7qF9Gy/tAGpVVRlPKmKTNZFlTP3j4sH0Um94vLvG/M8k0ihHkxskQe22TE0FHmrdy90C+32wFgZB+sI6BexLj+nca8riDRry16ssU0uZEi4DoUnIBJ+Zn5XtAqZxJwH3nuU1btS2smCaJNHbESEIP42lXfr6tBi0BCWWVTHBlxZRfjoBbaLe3LyNN1DGszM8A8k8SxhJI/P/oZ8tF55/mnfrZ4pwCZcAb8rUvMv8JwvHNMPwd6Irldqft1bNEIBQeZnqRNpXEo/tyHdSz/3WWs3om0wRDT8hwj5CDb2KeukQ/cbOmLdEPPhJIW4gX9OZ5nlyFcgAX37coSCnTnEnofHWQ178XAv0OfZjL7udXwgk09UQqcknxX96mTsGilQDGQTzikP9RJQuPYRKTWZOrn6OmfduiNLEGTSXU3fDSvxTA09afTFLQeXdE8lK3n1a5VdVylzTpOLaqRonv68QrV5oSO9Uh6VCcMmFDn1rKywZMKW3fs+R7qf3P6oezeoituZ4160OEdWH/N+XmXssmmOdvQrzAXa6I6B5lnzttRcMGtnWJmkXM9hBJfgLA/gsRxhayEnnGKoB1821+P8MujrKl0wzw3yZoQtf4b3fW+SJLJcdVCJHcoTqMgB+zneeSpUXRBLUtFVu/S3E80GguUQvK6o8Mbz+q2woY8Wz+UxcMRaNzerqExurrqlYFnJItZ2zrnFHkLWXFEp3hGH+vduUqIX9oqHAK7nudO90sarInKdgKPKdBYfHcBCVWGKPnyecXKC4BkIN0u/+0rWJG4Sjljnqs4UPnLK7FkBi6FZnbeyUKEwjxgXS0zEIacRcCbFqk4rSh32CAaIXELiPebg9R3KfI92j3Eo0ueX2SludJ5ssgWzU8wiHGptRr9W1uXv54j1d1KXFATb5+tid8ciVLXkYl7R2tdTR1bwraw6BRD6FakTYWxU3v8XxYgEQFi7BYEq2Ed1rQhbv6JCRi5JXZSNd5QxyRbot2RneUDSwiMofxFW7Vl2iwedvb4PWBbkHLH+tOYzzxHq8amqISZ82Kyt5ZuhVRf06vtDOJb0wimXVQW10pestS+xHeYSWh5IzXMTkaqZbopkohbPqiuIiCg0WWjvPrby6IC/fpLfYzjn3ImWph9Ycp5gtY0CKMxblBGv65ScZRXp5GxzuVs9K1YeX+sw6m1tw7jtdQhBnq8TKAf/2fEiALpQaeCPcqiVZ6Tw2n0Znjc4CRrCK31kA1qOrmKYW8fyiKUonKWr7H0IdVkrskPI9W4ZKpSkq89FnzqFwHQM4fFG3OgyV8cCfX3ArLgQari8WJ/nXSZK+iFMoVVo1OlaYU/Vio4VkOJZKwNpOUall+EeA5A3oYZ7BA0uZX1I7vNDSUZD5lUErladTH+0scO7v2NWWIaDAcNErzaf4h1GUZttSF0UCap0fJOhPRop34C6aoghVpxJsk3Ph3SHNZE3IeZ6bPUncs5PY6XSarers5xC2M5nUBfN5uiA8/Comww5vHhZuMk8iqfXOL/Y7MEUodj9wvJu68yttUxnolt0ef85tEtl1CuK0RwCORkKbVHnxY3viSx3Q8y6WzMC6S7OUI+9kTqi+mOMkfxP3Xz31tp7YBsKxdJLHyiUdl/WKl4GaGCkrYOYdC8nXP1qNBGG/z+Leflp+M6n8SUQ35B3oxE5QX7alE8FK/ZCn/M0PO/+xxHrFXV9A/gA46zSpdMr5ghXDkFCVrgzgxgdbvdjsBh8v6ylIWN1IWcPF7pCXoPTEG2uzR/Mwe9/LGOylMEn5P1cO0mSvKqSUCz7XLjQG/WdXCDityHiIXawT0Hgd3vf8bN9dkM0q/LeKrt4rZI8pEasnN4bX4KUbb6M/ZuSkanj2tbu/ftAyDaPKih1f4HnbyFEJNNujk/Bfdjlo6RkL+OHUfJ7HtV9xA+ir/WxdLpOl/LybFXfAMen1t3O2FrzhKighcvDiRxBahOC2LxZXbkvJMxs7iGwBcE47s1KD6n4+MN+2E0EZPHklUDfblPlMff7+Qz6hGXraAzn6zZbx2gPIagI8gZ8IcfCpfuSFUTo6qrOQbBTfgkjhYPoPUsLJ3xMUYPtDVjzhlCFPdNACHP0GDoV0TqPei00sRtDavzVclsr07JyEUxtq1WW/NDP38ZDP7av/fRnv6v0l8dihH5qS6+07fHso/r+pqqg1GXBAu1twjVvHrZlTUpj+q6remUVu+/7a8xCWVH+jdjCrbVXpi7oAYSdLOHI4Xu9VGKsWAtEpIoS/m4k4yzn7iDY0hdCFqcC7yJCwWskcPu6OpapYagD3vnH4giDlqGyXwO7wZf5Fv+EnWCtMqOPorW4AI+K94QovORskJl4PHQu71d0VS66A+BcXEuAYXUp3YYWVumHW+EbLeasallVEhDVO0cV1mr0ZdVOepEi2pNF49PzgNrmMD6R8+o3y+qSgsvlVJAnamcJURqYK2vpL5VfamXFOv1wpYuCeuBYYDdoo5IqDVeis4/WqUzo7IHL8Cj5QEz+xOPXZNYfzbjuwTKzWYdhKN70jGuH335CNuqG67hqJYkf/pHVdhHeusHVSPjszaFzBe6dX0+rqj++vjbgsR4SeSl4aRtltj6mVynChY8QLVpmNm81K+qnOVata5xKSNVc/dW6EqyrVkLYyqhTaTHzU/kAVDK4vsP1qUK9qx0qYHI9rKobQjutziIoH0ZyGP2Bn8UvIs65LCykuHQOHCnTXgh8DFGP7bLW7uLDLIdxq6raTeEEqi+jUnGKiusUpsohtq7SQlkkZCb+yAJjKv6pt66jElM7QhHNyxUGlw9csPHvacqZF3u4q1onNv/nJOAudeHqezYQMatj4B9Zi3r8zqNJ6SA3INS8KyecvJ/9O07GwJ59QYa4Myvb4VrAVW0M9SlFrGbFWrHYVOItnaOKZ/03bdN3SdSMMR+CSFsBz6gBMsCCcG1esCNjPJN3zVoAA8Su0EIUJFZe5gxWi8Z5GFaD6yBKZ16Tv38pySrWAx/1ZgP66L3KhO3+zilrYLvfmQDzQJ8ztSZ5xLodD6J1NfMGKA4nzKpdbAOGimFW1SBRrAWgt4m8LIiZxGpWpO2+pFEc4O0LNCijvegsl1jNSkOXrgfhYYC3HlQC5J4JPXoSq7nQoLACvwVbkGJ8BxigCqy1ksL+l0XpqpCLYJIkszhkZPqLDjBAUYhhBSPED0VFWnQBLLSyrrphpeLyurB2DPDmAhbLoSrO56WJ1SjJjbQ+d60jy8cA6xA4Ku3DlO9cN0ujErE6YO36gjM70pEB4Q6gS5uOYnm8t65OtxaxrmrogtZgL0v8JS61trJXtzGzPu/Vim17IRktru+wcp9TNneHrbQ/zPVt737j2cifVdG7HdX+DgZywYv/cv0cUvcsqvTkLVWdrxWIHdM2ev98i3Tpv8t1+twzqiLhkDKQuHdaVM8dxg/iWvVObhw2UuxsSLU/RN+f9fpiiG7eqPrt+nU5/TGBsJmWejcdzuTee7HOKhpCNGINgeV/ifDfzbjzvUsRzpJXiWTDKs/wlWMmcHwJojrP/29GstSFxM7xEd6DMOm3cZZ4eZfvYKPXnyXv3K+p9pc49jRt/IL+hIQF51/q/Boup50Nqm1DGy/Qjs7bLzUF/la1rf2Oz6n73XNe8c67535Ajb+7Z4m2r6Fw8IjXxpJ6xnn6/EvV/41MGrnuV5IkeSH19pHQKLEOMEA0GGP+PyWqyYN8MxJRAAAAAElFTkSuQmCC" id="_f607630b-3d86-4272-f289-8581bab2e244" mimetype="image/png" height="auto" width="auto"/>
+  </figure>
+</figure>
+  </annex>
+  <annex id="AnnexD" inline-header="false" obligation="informative">
+    <title>Results of interlaboratory test for husked rice yields</title>
+    <p id="_221a9f61-9dd8-8865-0479-aec53e8dbdd1">An interlaboratory test 
+    <eref type="inline" style="short" bibitemid="ref15" citeas="[14]"/> was carried out by the ENR [Rice Research Centre (Italy)] in accordance with 
+    <eref type="inline" style="short" bibitemid="ISO5725-1" citeas="ISO 5725-1"/> and 
+    <eref type="inline" style="short" bibitemid="ISO5725-2" citeas="ISO 5725-2"/>, with the participation of 15 laboratories. Each laboratory carried out three determinations on four different types of kernel. The statistical results are shown in 
+    <xref target="tableD-1" style="short"/>.
+  </p>
+  <table id="tableD-1">
+    <name>Repeatability and reproducibility of husked rice yield</name>
+    <thead>
+      <tr>
+        <th valign="top" rowspan="2" align="center">Description</th>
+        <th colspan="4" valign="top" align="center">Rice sample</th>
+      </tr>
+      <tr>
+        <th valign="top" align="left">Arborio</th>
+        <th valign="top" align="center">Drago
+        <fn reference="a">
+          <p id="_b6937999-c576-6f2c-0699-3235bbf3c492">Parboiled rice.</p>
+        </fn>
+      </th>
+      <th valign="top" align="center">Balilla</th>
+      <th valign="top" align="center">Thaibonnet</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td valign="top" align="left">Number of laboratories retained after eliminating outliers</td>
+      <td valign="top" align="center">13</td>
+      <td valign="top" align="center">11</td>
+      <td valign="top" align="center">13</td>
+      <td valign="top" align="center">13</td>
+    </tr>
+    <tr>
+      <td valign="top" align="left">Mean value, g/100 g</td>
+      <td valign="top" align="center">81,2</td>
+      <td valign="top" align="center">82,0</td>
+      <td valign="top" align="center">81,8</td>
+      <td valign="top" align="center">77,7</td>
+    </tr>
+    <tr>
+      <td valign="top" align="left">Standard deviation of repeatability, 
+      <stem type="MathML">
+        <math
+          xmlns="http://www.w3.org/1998/Math/MathML">
+        <msub>
+          <mrow>
+            <mi>s</mi>
+          </mrow>
+          <mrow>
+            <mi>r</mi>
+          </mrow>
+        </msub>
+      </math>
+      <asciimath>s_r</asciimath>
+      </stem>, g/100 g
+    </td>
+    <td valign="top" align="center">0,41</td>
+    <td valign="top" align="center">0,15</td>
+    <td valign="top" align="center">0,31</td>
+    <td valign="top" align="center">0,53</td>
+  </tr>
+  <tr>
+    <td valign="top" align="left">Coefficient of variation of repeatability, %</td>
+    <td valign="top" align="center">0,5</td>
+    <td valign="top" align="center">0,2</td>
+    <td valign="top" align="center">0,4</td>
+    <td valign="top" align="center">0,7</td>
+  </tr>
+  <tr>
+    <td valign="top" align="left">Repeatability limit, 
+    <stem type="MathML">
+      <math
+        xmlns="http://www.w3.org/1998/Math/MathML">
+      <mi>r</mi>
+    </math>
+    <asciimath>r</asciimath>
+    </stem> (= 2,83 
+    <stem type="MathML">
+      <math
+        xmlns="http://www.w3.org/1998/Math/MathML">
+      <msub>
+        <mrow>
+          <mi>s</mi>
+        </mrow>
+        <mrow>
+          <mi>r</mi>
+        </mrow>
+      </msub>
+    </math>
+    <asciimath>s_r</asciimath>
+    </stem>)
+  </td>
+  <td valign="top" align="center">1,16</td>
+  <td valign="top" align="center">0,42</td>
+  <td valign="top" align="center">0,88</td>
+  <td valign="top" align="center">1,50</td>
+</tr>
+<tr>
+  <td valign="top" align="left">Standard deviation of reproducibility, 
+  <stem type="MathML">
+    <math
+      xmlns="http://www.w3.org/1998/Math/MathML">
+    <msub>
+      <mrow>
+        <mi>s</mi>
+      </mrow>
+      <mrow>
+        <mi>R</mi>
+      </mrow>
+    </msub>
+  </math>
+  <asciimath>s_R</asciimath>
+  </stem>, g/100 g
+</td>
+<td valign="top" align="center">1,02</td>
+<td valign="top" align="center">0,20</td>
+<td valign="top" align="center">0,80</td>
+<td valign="top" align="center">2,14</td>
+        </tr>
+        <tr>
+          <td valign="top" align="left">Coefficient of variation of reproducibility, %</td>
+          <td valign="top" align="center">1,3</td>
+          <td valign="top" align="center">0,2</td>
+          <td valign="top" align="center">1,0</td>
+          <td valign="top" align="center">2,7</td>
+        </tr>
+        <tr>
+          <td valign="top" align="left">Reproducibility limit, 
+          <stem type="MathML">
+            <math
+              xmlns="http://www.w3.org/1998/Math/MathML">
+            <mi>R</mi>
+          </math>
+          <asciimath>R</asciimath>
+          </stem> (= 2,83 
+          <stem type="MathML">
+            <math
+              xmlns="http://www.w3.org/1998/Math/MathML">
+            <msub>
+              <mrow>
+                <mi>s</mi>
+              </mrow>
+              <mrow>
+                <mi>R</mi>
+              </mrow>
+            </msub>
+          </math>
+          <asciimath>s_R</asciimath>
+          </stem>)
+        </td>
+        <td valign="top" align="center">2,89</td>
+        <td valign="top" align="center">0,57</td>
+        <td valign="top" align="center">2,26</td>
+        <td valign="top" align="center">6,06</td>
+      </tr>
+    </tbody>
+  </table>
+</annex>
+<annex id="_extraneous_information" inline-header="false" obligation="informative">
+  <title>Extraneous information</title>
+  <p id="_21233d7e-09f5-579a-b735-63a8b2b65b02">
+    <em>This appendix is not in the original Rice model document, and is inserted to illustrate elements absent from that document: block quotes, source code, and examples.</em>
+  </p>
+  <quote id="_7203bf30-4635-92d1-ed81-d1319c709076">
+    <source type="inline" bibitemid="ISO7301" citeas="ISO 7301:2011">
+      <localityStack>
+        <locality type="clause">
+          <referenceFrom>1</referenceFrom>
+        </locality>
+      </localityStack>
+    </source>
+    <author>ISO</author>
+    <p id="_c878820b-4987-1274-21a3-303edc155836">This International Standard gives the minimum specifications for rice (
+    <em>Oryza sativa</em> L.) which is subject to international trade. It is applicable to the following types: husked rice and milled rice, parboiled or not, intended for direct human consumption. It is neither applicable to other products derived from rice, nor to waxy rice (glutinous rice).
+  </p>
+</quote>
+<appendix id="_sample_code" inline-header="false" obligation="informative">
+  <title>Sample code</title>
+  <example id="samplecode">
+    <name>Sample Code</name>
+    <sourcecode id="_1780a541-a39f-897a-533a-f935721eca31" lang="ruby">puts "Hello, world."
+    %w{a b c}.each do |x| 
+    <callout target="_f4eaad01-1f05-7b19-91a0-ae5a8d34312f">1</callout>
+    puts x
+    end
+    <annotation id="_f4eaad01-1f05-7b19-91a0-ae5a8d34312f">
+      <p id="_910b9068-d8a3-ce03-b853-029f70dd6630">This is an annotation</p>
+    </annotation>
+  </sourcecode>
+</example>
+    </appendix>
+  </annex>
+  <bibliography>
+    <references id="_normative_references" normative="true" obligation="informative">
+      <title>Normative references</title>
+      <p id="_21ac2b92-2fe6-317d-983c-a478441ede9f">The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</p>
+      <bibitem id="ISO712" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-intro" format="text/plain" language="en" script="Latn">Cereals and cereal products</title>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Determination of moisture content</title>
+        <title type="title-part" format="text/plain" language="en" script="Latn">Reference method</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Cereals and cereal products — Determination of moisture content — Reference method</title>
+        <uri type="src">https://www.iso.org/standard/44807.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:44807:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/04/48/44807.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 712</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:712:ed-4</docidentifier>
+        <docnumber>712</docnumber>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>4</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <status>
+          <stage>90</stage>
+          <substage>60</substage>
+        </status>
+        <copyright>
+          <from>2009</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 712:1998</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 712:1998</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="instance">
+          <bibitem type="standard">
+            <fetched>2023-01-29</fetched>
+            <title type="title-intro" format="text/plain" language="en" script="Latn">Cereals and cereal products</title>
+            <title type="title-main" format="text/plain" language="en" script="Latn">Determination of moisture content</title>
+            <title type="title-part" format="text/plain" language="en" script="Latn">Reference method</title>
+            <title type="main" format="text/plain" language="en" script="Latn">Cereals and cereal products — Determination of moisture content — Reference method</title>
+            <uri type="src">https://www.iso.org/standard/44807.html</uri>
+            <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:44807:en</uri>
+            <uri type="rss">https://www.iso.org/contents/data/standard/04/48/44807.detail.rss</uri>
+            <docidentifier type="ISO" primary="true">ISO 712:2009</docidentifier>
+            <docidentifier type="URN">urn:iso:std:iso:712:ed-4</docidentifier>
+            <docnumber>712</docnumber>
+            <date type="published">
+              <on>2009-11</on>
+            </date>
+            <contributor>
+              <role type="publisher"/>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+                <uri>www.iso.org</uri>
+              </organization>
+            </contributor>
+            <edition>4</edition>
+            <language>en</language>
+            <script>Latn</script>
+            <abstract format="text/plain" language="en" script="Latn">ISO 712:2009 specifies a routine reference method for the determination of the moisture content of cereals and cereal products. ISO 712:2009 applies to: wheat, rice (paddy, husked and milled), barley, millet (Panicum miliaceum), rye, oats, triticale, sorghum in the form of grains, milled grains, semolina or flour. The method is not applicable to maize and pulses.</abstract>
+            <status>
+              <stage>90</stage>
+              <substage>60</substage>
+            </status>
+            <copyright>
+              <from>2009</from>
+              <owner>
+                <organization>
+                  <name>ISO</name>
+                </organization>
+              </owner>
+            </copyright>
+            <relation type="obsoletes">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO 712:1998</formattedref>
+                <docidentifier type="ISO" primary="true">ISO 712:1998</docidentifier>
+              </bibitem>
+            </relation>
+            <place>Geneva</place>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO6646" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-intro" format="text/plain" language="en" script="Latn">Rice</title>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Determination of the potential milling yield from paddy and from husked rice</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Rice — Determination of the potential milling yield from paddy and from husked rice</title>
+        <uri type="src">https://www.iso.org/standard/51072.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:51072:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/05/10/51072.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 6646</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:6646:ed-3</docidentifier>
+        <docnumber>6646</docnumber>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>3</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <status>
+          <stage>90</stage>
+          <substage>20</substage>
+        </status>
+        <copyright>
+          <from>2011</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 6646:2000</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 6646:2000</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="instance">
+          <bibitem type="standard">
+            <fetched>2023-01-29</fetched>
+            <title type="title-intro" format="text/plain" language="en" script="Latn">Rice</title>
+            <title type="title-main" format="text/plain" language="en" script="Latn">Determination of the potential milling yield from paddy and from husked rice</title>
+            <title type="main" format="text/plain" language="en" script="Latn">Rice — Determination of the potential milling yield from paddy and from husked rice</title>
+            <uri type="src">https://www.iso.org/standard/51072.html</uri>
+            <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:51072:en</uri>
+            <uri type="rss">https://www.iso.org/contents/data/standard/05/10/51072.detail.rss</uri>
+            <docidentifier type="ISO" primary="true">ISO 6646:2011</docidentifier>
+            <docidentifier type="URN">urn:iso:std:iso:6646:ed-3</docidentifier>
+            <docnumber>6646</docnumber>
+            <date type="published">
+              <on>2011-07</on>
+            </date>
+            <contributor>
+              <role type="publisher"/>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+                <uri>www.iso.org</uri>
+              </organization>
+            </contributor>
+            <edition>3</edition>
+            <language>en</language>
+            <script>Latn</script>
+            <abstract format="text/plain" language="en" script="Latn">ISO 6646:2011 specifies a laboratory method for the determination of the yield of husked rice obtained from paddy or parboiled paddy (Oryza sativa L.), and for the determination of the yield of milled head rice obtained from paddy or parboiled paddy, or from husked rice or husked parboiled rice. ISO 6646:2011 is only applicable to abrasive milling equipment.</abstract>
+            <status>
+              <stage>90</stage>
+              <substage>20</substage>
+            </status>
+            <copyright>
+              <from>2011</from>
+              <owner>
+                <organization>
+                  <name>ISO</name>
+                </organization>
+              </owner>
+            </copyright>
+            <relation type="obsoletes">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO 6646:2000</formattedref>
+                <docidentifier type="ISO" primary="true">ISO 6646:2000</docidentifier>
+              </bibitem>
+            </relation>
+            <place>Geneva</place>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO8351-1" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-intro" format="text/plain" language="en" script="Latn">Packaging</title>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Method of specification for sacks</title>
+        <title type="title-part" format="text/plain" language="en" script="Latn">Part 1: Paper sacks</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Packaging — Method of specification for sacks — Part 1: Paper sacks</title>
+        <uri type="src">https://www.iso.org/standard/15496.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:15496:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/01/54/15496.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 8351-1:1994</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:8351:-1:ed-1</docidentifier>
+        <docnumber>8351</docnumber>
+        <date type="published">
+          <on>1994-07</on>
+        </date>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>1</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <abstract format="text/plain" language="en" script="Latn">Provides a checklist for the characteristics of paper sacks to be specified when ordering. These ordering specifications cover the decription of the sack and do not deal with quantitative performance requirements. Is primarily intended for application to the types of paper sacks as specified in ISO 6590-2.</abstract>
+        <status>
+          <stage>90</stage>
+          <substage>93</substage>
+        </status>
+        <copyright>
+          <from>1994</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO8351-2" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-intro" format="text/plain" language="en" script="Latn">Packaging</title>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Method of specification for sacks</title>
+        <title type="title-part" format="text/plain" language="en" script="Latn">Part 2: Sacks made from thermoplastic flexible film</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Packaging — Method of specification for sacks — Part 2: Sacks made from thermoplastic flexible film</title>
+        <uri type="src">https://www.iso.org/standard/1818.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:1818:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/00/18/1818.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 8351-2</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:8351:-2:ed-1</docidentifier>
+        <docnumber>8351</docnumber>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>1</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <status>
+          <stage>90</stage>
+          <substage>93</substage>
+        </status>
+        <copyright>
+          <from>1994</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="instance">
+          <bibitem type="standard">
+            <fetched>2023-01-29</fetched>
+            <title type="title-intro" format="text/plain" language="en" script="Latn">Packaging</title>
+            <title type="title-main" format="text/plain" language="en" script="Latn">Method of specification for sacks</title>
+            <title type="title-part" format="text/plain" language="en" script="Latn">Part 2: Sacks made from thermoplastic flexible film</title>
+            <title type="main" format="text/plain" language="en" script="Latn">Packaging — Method of specification for sacks — Part 2: Sacks made from thermoplastic flexible film</title>
+            <uri type="src">https://www.iso.org/standard/1818.html</uri>
+            <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:1818:en</uri>
+            <uri type="rss">https://www.iso.org/contents/data/standard/00/18/1818.detail.rss</uri>
+            <docidentifier type="ISO" primary="true">ISO 8351-2:1994</docidentifier>
+            <docidentifier type="URN">urn:iso:std:iso:8351:-2:ed-1</docidentifier>
+            <docnumber>8351</docnumber>
+            <date type="published">
+              <on>1994-07</on>
+            </date>
+            <contributor>
+              <role type="publisher"/>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+                <uri>www.iso.org</uri>
+              </organization>
+            </contributor>
+            <edition>1</edition>
+            <language>en</language>
+            <script>Latn</script>
+            <abstract format="text/plain" language="en" script="Latn">Provides a checklist for the characteristics to be specified when ordering sacks made from thermoplastic flexible films. These ordering specifications cover the decription of the sack and do not deal with quantitative performance requirements. Is primarily intended for application to the types of sacks made from thermoplastic flexible films as specified in ISO 6590-2.</abstract>
+            <status>
+              <stage>90</stage>
+              <substage>93</substage>
+            </status>
+            <copyright>
+              <from>1994</from>
+              <owner>
+                <organization>
+                  <name>ISO</name>
+                </organization>
+              </owner>
+            </copyright>
+            <place>Geneva</place>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO16634" type="standard">
+        <title format="text/plain">Cereals, pulses, milled cereal products, oilseeds and animal feeding stuffs — Determination of the total nitrogen content by combustion according to the Dumas principle and calculation of the crude protein content</title>
+        <docidentifier type="ISO">ISO 16634:—</docidentifier>
+        <docnumber>16634</docnumber>
+        <date type="published">
+          <on>–</on>
+        </date>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+          </organization>
+        </contributor>
+        <note format="text/plain" type="Unpublished-Status">Under preparation. (Stage at the time of publication ISO/DIS 16634)</note>
+      </bibitem>
+      <bibitem id="ISO20483" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-intro" format="text/plain" language="en" script="Latn">Cereals and pulses</title>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Determination of the nitrogen content and calculation of the crude protein content</title>
+        <title type="title-part" format="text/plain" language="en" script="Latn">Kjeldahl method</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Cereals and pulses — Determination of the nitrogen content and calculation of the crude protein content — Kjeldahl method</title>
+        <uri type="src">https://www.iso.org/standard/59162.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:59162:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/05/91/59162.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 20483:2013</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:20483:ed-2</docidentifier>
+        <docnumber>20483</docnumber>
+        <date type="published">
+          <on>2013-12</on>
+        </date>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>2</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <abstract format="text/plain" language="en" script="Latn">ISO 20483:2013 specifies a method for the determination of the nitrogen content of cereals, pulses and derived products, according to the Kjeldahl method, and a method for calculating the crude protein content. The method does not distinguish between protein nitrogen and non-protein nitrogen.</abstract>
+        <status>
+          <stage>90</stage>
+          <substage>60</substage>
+        </status>
+        <copyright>
+          <from>2013</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 20483:2006</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 20483:2006</docidentifier>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO24333" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-intro" format="text/plain" language="en" script="Latn">Cereals and cereal products</title>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Sampling</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Cereals and cereal products — Sampling</title>
+        <uri type="src">https://www.iso.org/standard/42165.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:42165:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/04/21/42165.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 24333:2009</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:24333:ed-1</docidentifier>
+        <docnumber>24333</docnumber>
+        <date type="published">
+          <on>2009-12</on>
+        </date>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>1</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <abstract format="text/plain" language="en" script="Latn">ISO 24333:2009 specifies requirements for the dynamic or static sampling, by manual or mechanical means, of cereals and cereal products, for assessment of their quality and condition. It is applicable to sampling for the determination of heterogeneously distributed contaminants, undesirable substances, and parameters usually homogeneously distributed like those used to assess quality or compliance with specification. It can be used to determine insects in a grain lot. It is applicable to sampling for assessment of the quality and condition of lots of genetically modified organisms (GMO) but is inappropriate for the determination of the presence of adventitious genetically modified material in non-GM product. It is not applicable to seed grain.</abstract>
+        <status>
+          <stage>90</stage>
+          <substage>93</substage>
+        </status>
+        <copyright>
+          <from>2009</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 6644:2002</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 6644:2002</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 13690:1999</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 13690:1999</docidentifier>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+    </references>
+    <references id="_bibliography" normative="false" obligation="informative">
+      <title>Bibliography</title>
+      <bibitem id="ISO3696" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-intro" format="text/plain" language="en" script="Latn">Water for analytical laboratory use</title>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Specification and test methods</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Water for analytical laboratory use — Specification and test methods</title>
+        <uri type="src">https://www.iso.org/standard/9169.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:9169:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/00/91/9169.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 3696</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:3696:ed-1</docidentifier>
+        <docnumber>3696</docnumber>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>1</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <status>
+          <stage>90</stage>
+          <substage>20</substage>
+        </status>
+        <copyright>
+          <from>1987</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="instance">
+          <bibitem type="standard">
+            <fetched>2023-01-29</fetched>
+            <title type="title-intro" format="text/plain" language="en" script="Latn">Water for analytical laboratory use</title>
+            <title type="title-main" format="text/plain" language="en" script="Latn">Specification and test methods</title>
+            <title type="main" format="text/plain" language="en" script="Latn">Water for analytical laboratory use — Specification and test methods</title>
+            <uri type="src">https://www.iso.org/standard/9169.html</uri>
+            <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:9169:en</uri>
+            <uri type="rss">https://www.iso.org/contents/data/standard/00/91/9169.detail.rss</uri>
+            <docidentifier type="ISO" primary="true">ISO 3696:1987</docidentifier>
+            <docidentifier type="URN">urn:iso:std:iso:3696:ed-1</docidentifier>
+            <docnumber>3696</docnumber>
+            <date type="published">
+              <on>1987-04</on>
+            </date>
+            <contributor>
+              <role type="publisher"/>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+                <uri>www.iso.org</uri>
+              </organization>
+            </contributor>
+            <edition>1</edition>
+            <language>en</language>
+            <script>Latn</script>
+            <abstract format="text/plain" language="en" script="Latn">Specifies the requirements for three grades for the analysis of inorganic chemicals. Not applicable to organic trace analysis, analysis of surface-active agents and biological or medical analysis. The material shall be a clear, colourless liquid as assessed by inspection. Classifies according to the content: free from dissolved or colloidal ionic and organic contaminants, very low inorganic, organic or colloidal contaminants and suitable for laboratory wet chemistry work. Specifies the pH and conductivity measurement, the limit tests for oxidizable matter and for reactive silica, the measurement of absorbance and the determination of residue after evaporation at 110 °C.</abstract>
+            <status>
+              <stage>90</stage>
+              <substage>20</substage>
+            </status>
+            <copyright>
+              <from>1987</from>
+              <owner>
+                <organization>
+                  <name>ISO</name>
+                </organization>
+              </owner>
+            </copyright>
+            <place>Geneva</place>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO5725-1" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Accuracy (trueness and precision) of measurement methods and results</title>
+        <title type="title-part" format="text/plain" language="en" script="Latn">Part 1: General principles and definitions</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Accuracy (trueness and precision) of measurement methods and results — Part 1: General principles and definitions</title>
+        <uri type="src">https://www.iso.org/standard/11833.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:11833:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/01/18/11833.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 5725-1</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:5725:-1:ed-1</docidentifier>
+        <docnumber>5725</docnumber>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>1</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <status>
+          <stage>90</stage>
+          <substage>92</substage>
+        </status>
+        <copyright>
+          <from>1994</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 5725:1986</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 5725:1986</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO/DIS 5725-1</formattedref>
+            <docidentifier type="ISO" primary="true">ISO/DIS 5725-1</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="updates">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 5725-1:1994/Cor 1:1998</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 5725-1:1994/Cor 1:1998</docidentifier>
+            <date type="circulated">
+              <on>2022-04-14</on>
+            </date>
+          </bibitem>
+        </relation>
+        <relation type="instance">
+          <bibitem type="standard">
+            <fetched>2023-01-29</fetched>
+            <title type="title-main" format="text/plain" language="en" script="Latn">Accuracy (trueness and precision) of measurement methods and results</title>
+            <title type="title-part" format="text/plain" language="en" script="Latn">Part 1: General principles and definitions</title>
+            <title type="main" format="text/plain" language="en" script="Latn">Accuracy (trueness and precision) of measurement methods and results — Part 1: General principles and definitions</title>
+            <uri type="src">https://www.iso.org/standard/11833.html</uri>
+            <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:11833:en</uri>
+            <uri type="rss">https://www.iso.org/contents/data/standard/01/18/11833.detail.rss</uri>
+            <docidentifier type="ISO" primary="true">ISO 5725-1:1994</docidentifier>
+            <docidentifier type="URN">urn:iso:std:iso:5725:-1:ed-1</docidentifier>
+            <docnumber>5725</docnumber>
+            <date type="published">
+              <on>1994-12</on>
+            </date>
+            <contributor>
+              <role type="publisher"/>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+                <uri>www.iso.org</uri>
+              </organization>
+            </contributor>
+            <edition>1</edition>
+            <language>en</language>
+            <script>Latn</script>
+            <abstract format="text/plain" language="en" script="Latn">The purpose is to outline the general principles to be understood when assessing accuracy (trueness and precision) of measurement methods and results, and in applications, and to establish practical estimations of the various measures by experiment. Is concerned exclusively with measurement methods which yield measurements on a continuous scale and give a single value as the test result. May be applied to a very wide range of materials, including liquids, powders and solid objects, manufactured or naturally occurring, provided that due consideration is given to any heterogeneity of the material.</abstract>
+            <status>
+              <stage>90</stage>
+              <substage>92</substage>
+            </status>
+            <copyright>
+              <from>1994</from>
+              <owner>
+                <organization>
+                  <name>ISO</name>
+                </organization>
+              </owner>
+            </copyright>
+            <relation type="obsoletes">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO 5725:1986</formattedref>
+                <docidentifier type="ISO" primary="true">ISO 5725:1986</docidentifier>
+              </bibitem>
+            </relation>
+            <relation type="obsoletes">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO/DIS 5725-1</formattedref>
+                <docidentifier type="ISO" primary="true">ISO/DIS 5725-1</docidentifier>
+              </bibitem>
+            </relation>
+            <relation type="updates">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO 5725-1:1994/Cor 1:1998</formattedref>
+                <docidentifier type="ISO" primary="true">ISO 5725-1:1994/Cor 1:1998</docidentifier>
+                <date type="circulated">
+                  <on>2022-04-14</on>
+                </date>
+              </bibitem>
+            </relation>
+            <place>Geneva</place>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO5725-2" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Accuracy (trueness and precision) of measurement methods and results</title>
+        <title type="title-part" format="text/plain" language="en" script="Latn">Part 2: Basic method for the determination of repeatability and reproducibility of a standard measurement method</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Accuracy (trueness and precision) of measurement methods and results — Part 2: Basic method for the determination of repeatability and reproducibility of a standard measurement method</title>
+        <uri type="src">https://www.iso.org/standard/69419.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:69419:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/06/94/69419.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 5725-2</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:5725:-2:ed-2</docidentifier>
+        <docnumber>5725</docnumber>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>2</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <status>
+          <stage>60</stage>
+          <substage>60</substage>
+        </status>
+        <copyright>
+          <from>2019</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 5725-2:1994</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 5725-2:1994</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 5725-2:1994/Cor 1:2002</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 5725-2:1994/Cor 1:2002</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="instance">
+          <bibitem type="standard">
+            <fetched>2023-01-29</fetched>
+            <title type="title-main" format="text/plain" language="en" script="Latn">Accuracy (trueness and precision) of measurement methods and results</title>
+            <title type="title-part" format="text/plain" language="en" script="Latn">Part 2: Basic method for the determination of repeatability and reproducibility of a standard measurement method</title>
+            <title type="main" format="text/plain" language="en" script="Latn">Accuracy (trueness and precision) of measurement methods and results — Part 2: Basic method for the determination of repeatability and reproducibility of a standard measurement method</title>
+            <uri type="src">https://www.iso.org/standard/69419.html</uri>
+            <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:69419:en</uri>
+            <uri type="rss">https://www.iso.org/contents/data/standard/06/94/69419.detail.rss</uri>
+            <docidentifier type="ISO" primary="true">ISO 5725-2:2019</docidentifier>
+            <docidentifier type="URN">urn:iso:std:iso:5725:-2:ed-2</docidentifier>
+            <docnumber>5725</docnumber>
+            <date type="published">
+              <on>2019-12</on>
+            </date>
+            <contributor>
+              <role type="publisher"/>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+                <uri>www.iso.org</uri>
+              </organization>
+            </contributor>
+            <edition>2</edition>
+            <language>en</language>
+            <script>Latn</script>
+            <abstract format="text/plain" language="en" script="Latn">1.1 This document — amplifies the general principles for designing experiments for the numerical estimation of the precision of measurement methods by means of a collaborative interlaboratory experiment; — provides a detailed practical description of the basic method for routine use in estimating the precision of measurement methods; — provides guidance to all personnel concerned with designing, performing or analysing the results of the tests for estimating precision. NOTE Modifications to this basic method for particular purposes are given in other parts of ISO 5725. 1.2 It is concerned exclusively with measurement methods which yield measurements on a continuous scale and give a single value as the test result, although this single value can be the outcome of a calculation from a set of observations. 1.3 It assumes that in the design and performance of the precision experiment, all the principles as laid down in ISO 5725-1 are observed. The basic method uses the same number of test results in each laboratory, with each laboratory analysing the same levels of test sample; i.e. a balanced uniform-level experiment. The basic method applies to procedures that have been standardized and are in regular use in a number of laboratories. 1.4 The statistical model of ISO 5725-1:1994, Clause 5, is accepted as a suitable basis for the interpretation and analysis of the test results, the distribution of which is approximately normal. 1.5 The basic method, as described in this document, (usually) estimates the precision of a measurement method: a) when it is required to determine the repeatability and reproducibility standard deviations as defined in ISO 5725-1; b) when the materials to be used are homogeneous, or when the effects of heterogeneity can be included in the precision values; and c) when the use of a balanced uniform-level layout is acceptable. 1.6 The same approach can be used to make a preliminary estimate of precision for measurement methods which have not reached standardization or are not in routine use.</abstract>
+            <status>
+              <stage>60</stage>
+              <substage>60</substage>
+            </status>
+            <copyright>
+              <from>2019</from>
+              <owner>
+                <organization>
+                  <name>ISO</name>
+                </organization>
+              </owner>
+            </copyright>
+            <relation type="obsoletes">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO 5725-2:1994</formattedref>
+                <docidentifier type="ISO" primary="true">ISO 5725-2:1994</docidentifier>
+              </bibitem>
+            </relation>
+            <relation type="obsoletes">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO 5725-2:1994/Cor 1:2002</formattedref>
+                <docidentifier type="ISO" primary="true">ISO 5725-2:1994/Cor 1:2002</docidentifier>
+              </bibitem>
+            </relation>
+            <place>Geneva</place>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO6322-1" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses</title>
+        <title type="title-part" format="text/plain" language="en" script="Latn">Part 1: General recommendations for the keeping of cereals</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses — Part 1: General recommendations for the keeping of cereals</title>
+        <uri type="src">https://www.iso.org/standard/21396.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:21396:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/02/13/21396.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 6322-1</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:6322:-1:ed-2</docidentifier>
+        <docnumber>6322</docnumber>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>2</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <status>
+          <stage>90</stage>
+          <substage>93</substage>
+        </status>
+        <copyright>
+          <from>1996</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 6322-1:1981</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 6322-1:1981</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="updates">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO/CD 6322-1</formattedref>
+            <docidentifier type="ISO" primary="true">ISO/CD 6322-1</docidentifier>
+            <date type="circulated">
+              <on>2022-11-04</on>
+            </date>
+          </bibitem>
+        </relation>
+        <relation type="instance">
+          <bibitem type="standard">
+            <fetched>2023-01-29</fetched>
+            <title type="title-main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses</title>
+            <title type="title-part" format="text/plain" language="en" script="Latn">Part 1: General recommendations for the keeping of cereals</title>
+            <title type="main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses — Part 1: General recommendations for the keeping of cereals</title>
+            <uri type="src">https://www.iso.org/standard/21396.html</uri>
+            <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:21396:en</uri>
+            <uri type="rss">https://www.iso.org/contents/data/standard/02/13/21396.detail.rss</uri>
+            <docidentifier type="ISO" primary="true">ISO 6322-1:1996</docidentifier>
+            <docidentifier type="URN">urn:iso:std:iso:6322:-1:ed-2</docidentifier>
+            <docnumber>6322</docnumber>
+            <date type="published">
+              <on>1996-11</on>
+            </date>
+            <contributor>
+              <role type="publisher"/>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+                <uri>www.iso.org</uri>
+              </organization>
+            </contributor>
+            <edition>2</edition>
+            <language>en</language>
+            <script>Latn</script>
+            <abstract format="text/plain" language="en" script="Latn">Gives general guidance of keeping cereals. Other aspects of the storage of cereals and pulses are dealt with in ISO 6322-2 and ISAO 6322-3.</abstract>
+            <status>
+              <stage>90</stage>
+              <substage>93</substage>
+            </status>
+            <copyright>
+              <from>1996</from>
+              <owner>
+                <organization>
+                  <name>ISO</name>
+                </organization>
+              </owner>
+            </copyright>
+            <relation type="obsoletes">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO 6322-1:1981</formattedref>
+                <docidentifier type="ISO" primary="true">ISO 6322-1:1981</docidentifier>
+              </bibitem>
+            </relation>
+            <relation type="updates">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO/CD 6322-1</formattedref>
+                <docidentifier type="ISO" primary="true">ISO/CD 6322-1</docidentifier>
+                <date type="circulated">
+                  <on>2022-11-04</on>
+                </date>
+              </bibitem>
+            </relation>
+            <place>Geneva</place>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO6322-2" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses</title>
+        <title type="title-part" format="text/plain" language="en" script="Latn">Part 2: Practical recommendations</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses — Part 2: Practical recommendations</title>
+        <uri type="src">https://www.iso.org/standard/21395.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:21395:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/02/13/21395.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 6322-2</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:6322:-2:ed-2</docidentifier>
+        <docnumber>6322</docnumber>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>2</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <status>
+          <stage>90</stage>
+          <substage>93</substage>
+        </status>
+        <copyright>
+          <from>2000</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 6322-2:1981</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 6322-2:1981</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="instance">
+          <bibitem type="standard">
+            <fetched>2023-01-29</fetched>
+            <title type="title-main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses</title>
+            <title type="title-part" format="text/plain" language="en" script="Latn">Part 2: Practical recommendations</title>
+            <title type="main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses — Part 2: Practical recommendations</title>
+            <uri type="src">https://www.iso.org/standard/21395.html</uri>
+            <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:21395:en</uri>
+            <uri type="rss">https://www.iso.org/contents/data/standard/02/13/21395.detail.rss</uri>
+            <docidentifier type="ISO" primary="true">ISO 6322-2:2000</docidentifier>
+            <docidentifier type="URN">urn:iso:std:iso:6322:-2:ed-2</docidentifier>
+            <docnumber>6322</docnumber>
+            <date type="published">
+              <on>2000-02</on>
+            </date>
+            <contributor>
+              <role type="publisher"/>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+                <uri>www.iso.org</uri>
+              </organization>
+            </contributor>
+            <edition>2</edition>
+            <language>en</language>
+            <script>Latn</script>
+            <status>
+              <stage>90</stage>
+              <substage>93</substage>
+            </status>
+            <copyright>
+              <from>2000</from>
+              <owner>
+                <organization>
+                  <name>ISO</name>
+                </organization>
+              </owner>
+            </copyright>
+            <relation type="obsoletes">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO 6322-2:1981</formattedref>
+                <docidentifier type="ISO" primary="true">ISO 6322-2:1981</docidentifier>
+              </bibitem>
+            </relation>
+            <place>Geneva</place>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO6322-3" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses</title>
+        <title type="title-part" format="text/plain" language="en" script="Latn">Part 3: Control of attack by pests</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses — Part 3: Control of attack by pests</title>
+        <uri type="src">https://www.iso.org/standard/12614.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:12614:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/01/26/12614.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 6322-3</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:6322:-3:ed-2</docidentifier>
+        <docnumber>6322</docnumber>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>2</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <status>
+          <stage>90</stage>
+          <substage>93</substage>
+        </status>
+        <copyright>
+          <from>1989</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 6322-3:1981</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 6322-3:1981</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="instance">
+          <bibitem type="standard">
+            <fetched>2023-01-29</fetched>
+            <title type="title-main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses</title>
+            <title type="title-part" format="text/plain" language="en" script="Latn">Part 3: Control of attack by pests</title>
+            <title type="main" format="text/plain" language="en" script="Latn">Storage of cereals and pulses — Part 3: Control of attack by pests</title>
+            <uri type="src">https://www.iso.org/standard/12614.html</uri>
+            <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:12614:en</uri>
+            <uri type="rss">https://www.iso.org/contents/data/standard/01/26/12614.detail.rss</uri>
+            <docidentifier type="ISO" primary="true">ISO 6322-3:1989</docidentifier>
+            <docidentifier type="URN">urn:iso:std:iso:6322:-3:ed-2</docidentifier>
+            <docnumber>6322</docnumber>
+            <date type="published">
+              <on>1989-06</on>
+            </date>
+            <contributor>
+              <role type="publisher"/>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+                <uri>www.iso.org</uri>
+              </organization>
+            </contributor>
+            <edition>2</edition>
+            <language>en</language>
+            <script>Latn</script>
+            <abstract format="text/plain" language="en" script="Latn">Gives guidance in means of controlling attack by vertebrate and invertebrate pests. It shows onset of infestation, factors affecting insect and mite development, heating of grain caused by insects and mites, prevention and control of insect and mite infestation. An informative annex A gives limiting and optimum conditions for increase in populations of 23 insect and mite pests.</abstract>
+            <status>
+              <stage>90</stage>
+              <substage>93</substage>
+            </status>
+            <copyright>
+              <from>1989</from>
+              <owner>
+                <organization>
+                  <name>ISO</name>
+                </organization>
+              </owner>
+            </copyright>
+            <relation type="obsoletes">
+              <bibitem type="standard">
+                <formattedref format="text/plain">ISO 6322-3:1981</formattedref>
+                <docidentifier type="ISO" primary="true">ISO 6322-3:1981</docidentifier>
+              </bibitem>
+            </relation>
+            <place>Geneva</place>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO7301" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-intro" format="text/plain" language="en" script="Latn">Rice</title>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Specification</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Rice — Specification</title>
+        <uri type="src">https://www.iso.org/standard/50935.html</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/05/09/50935.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 7301:2011</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:7301:ed-3</docidentifier>
+        <docnumber>7301</docnumber>
+        <date type="published">
+          <on>2011-03</on>
+        </date>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>3</edition>
+        <note type="Unpublished-Status">
+          <p id="_142063a4-06f3-ac7d-f38c-cedccc6b6b9f">Cancelled and replaced by ISO 7301:2021.</p>
+        </note>
+        <language>en</language>
+        <script>Latn</script>
+        <abstract format="text/plain" language="en" script="Latn">ISO 7301:2011 gives the minimum specifications for rice (Oryza sativa L.) which is subject to international trade. It is applicable to the following types: husked rice and milled rice, parboiled or not, intended for direct human consumption. It is neither applicable to other products derived from rice, nor to waxy rice (glutinous rice).</abstract>
+        <status>
+          <stage>95</stage>
+          <substage>99</substage>
+        </status>
+        <copyright>
+          <from>2011</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <relation type="obsoletes">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 7301:2002</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 7301:2002</docidentifier>
+          </bibitem>
+        </relation>
+        <relation type="updates">
+          <bibitem type="standard">
+            <formattedref format="text/plain">ISO 7301:2021</formattedref>
+            <docidentifier type="ISO" primary="true">ISO 7301:2021</docidentifier>
+            <date type="circulated">
+              <on>2021-06-07</on>
+            </date>
+          </bibitem>
+        </relation>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="ISO14864" type="standard" schema-version="v1.2.1">
+        <fetched>2023-01-29</fetched>
+        <title type="title-intro" format="text/plain" language="en" script="Latn">Rice</title>
+        <title type="title-main" format="text/plain" language="en" script="Latn">Evaluation of gelatinization time of kernels during cooking</title>
+        <title type="main" format="text/plain" language="en" script="Latn">Rice — Evaluation of gelatinization time of kernels during cooking</title>
+        <uri type="src">https://www.iso.org/standard/25793.html</uri>
+        <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:25793:en</uri>
+        <uri type="rss">https://www.iso.org/contents/data/standard/02/57/25793.detail.rss</uri>
+        <docidentifier type="ISO" primary="true">ISO 14864:1998</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:14864:ed-1</docidentifier>
+        <docnumber>14864</docnumber>
+        <date type="published">
+          <on>1998-12</on>
+        </date>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Organization for Standardization</name>
+            <abbreviation>ISO</abbreviation>
+            <uri>www.iso.org</uri>
+          </organization>
+        </contributor>
+        <edition>1</edition>
+        <language>en</language>
+        <script>Latn</script>
+        <status>
+          <stage>90</stage>
+          <substage>93</substage>
+        </status>
+        <copyright>
+          <from>1998</from>
+          <owner>
+            <organization>
+              <name>ISO</name>
+            </organization>
+          </owner>
+        </copyright>
+        <place>Geneva</place>
+      </bibitem>
+      <bibitem id="IEC61010-2" type="standard">
+        <title format="text/plain">Safety requirements for electric equipment for measurement, control, and laboratory use — Part 2: Particular requirements for laboratory equipment for the heating of material</title>
+        <docidentifier type="IEC">IEC 61010-2:1998</docidentifier>
+        <docnumber>61010-2</docnumber>
+        <date type="published">
+          <on>1998</on>
+        </date>
+        <contributor>
+          <role type="publisher"/>
+          <organization>
+            <name>International Electrotechnical Commission</name>
+            <abbreviation>IEC</abbreviation>
+          </organization>
+        </contributor>
+      </bibitem>
+      <bibitem id="ref12">
+        <formattedref format="application/x-isodoc+xml">
+          <smallcap>Berner D.L., &amp; Brown J.</smallcap> Protein nitrogen combustion method collaborative study I. Comparison with Smalley total Kjeldahl nitrogen and combustion results. 
+          <em>J. Am. Oil Chem. Soc.</em> 1994, 
+          <strong>71</strong> (11) pp 1291-1293
+        </formattedref>
+        <docidentifier type="metanorma">[10]</docidentifier>
+      </bibitem>
+      <bibitem id="ref13">
+        <formattedref format="application/x-isodoc+xml">
+          <smallcap>Buckee G.K.</smallcap> Determination of total nitrogen in barley, malt and beer by Kjeldahl procedures and the Dumas combustion method — Collaborative trial. 
+          <em>J. Inst. Brew.</em> 1994, 
+          <strong>100</strong> (2) pp 57-64
+        </formattedref>
+        <docidentifier type="metanorma">[11]</docidentifier>
+      </bibitem>
+      <bibitem id="ref14">
+        <formattedref format="application/x-isodoc+xml">
+          <smallcap>Frister H.</smallcap>
+          <em>Direct determination of nitrogen content by Dumas analysis; Interlaboratory study on precision characteristics</em>. AOAC International, Europe Section 4th International Symposium, Nyon, Switzerland, 1994, 33 pp
+        </formattedref>
+        <docidentifier type="metanorma">[12]</docidentifier>
+      </bibitem>
+      <bibitem id="ref11">
+        <formattedref format="application/x-isodoc+xml">Nitrogen-ammonia-protein modified Kjeldahl method — Titanium oxide and copper sulfate catalyst. 
+        <em>Official Methods and Recommended Practices of the AOCS</em> (ed. Firestone, D.E.), AOCS Official Method Ba Ai 4-91, 1997, AOCS Press, Champaign, IL
+      </formattedref>
+      <docidentifier type="metanorma">[13]</docidentifier>
+    </bibitem>
+    <bibitem id="ref15">
+      <formattedref format="application/x-isodoc+xml">
+        <smallcap>Ranghino F.</smallcap> Evaluation of rice resistance to cooking, based on the gelatinization time of kernels. 
+        <em>Il Riso</em>. 1966, 
+        <strong>XV</strong> pp 117-127
+      </formattedref>
+      <docidentifier type="metanorma">[14]</docidentifier>
+    </bibitem>
+    <bibitem id="ref10">
+      <formattedref format="application/x-isodoc+xml">
+        <smallcap>Standard No I.C.C 167</smallcap>. 
+        <em>Determination of the protein content in cereal and cereal products for food and animal feeding stuffs according to the Dumas combustion method</em> (see 
+        <link target="http://www.icc.or.at"/>)
+      </formattedref>
+      <docidentifier type="metanorma">[15]</docidentifier>
+    </bibitem>
+    <bibitem id="ref16">
+      <formattedref format="application/x-isodoc+xml">
+        <smallcap>Tkachuk R.</smallcap> Nitrogen-to-protein conversion factors for cereals and oilseed meals. 
+        <em>Cereal Chem.</em> 1969, 
+        <strong>46</strong> (4) pp 419-423
+      </formattedref>
+      <docidentifier type="metanorma">[16]</docidentifier>
+    </bibitem>
+  </references>
+</bibliography>
+</iso-standard>

--- a/spec/fixtures/iso-sample/sections-en/00-foreword.adoc
+++ b/spec/fixtures/iso-sample/sections-en/00-foreword.adoc
@@ -1,0 +1,31 @@
+
+.Foreword
+ISO (the International Organization for Standardization)
+is a worldwide federation of national standards bodies (ISO member bodies). The work of preparing International Standards is normally carried out through ISO technical committees. Each member body interested in a subject for which a technical committee has been established has the right to be represented on that committee. International organizations, governmental and non-governmental, in liaison with ISO, also take part in the work. ISO collaborates closely with the International Electrotechnical Commission (IEC) on all matters of electrotechnical standardization.
+
+The procedures used to develop this document and those intended for its further maintenance are described in the ISO/IEC Directives, Part 1. In particular the different approval criteria needed for the different types of ISO documents should be noted. This document was drafted in accordance with the editorial rules of the ISO/IEC Directives, Part 2 (see www.iso.org/directives).
+
+Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. ISO shall not be held responsible for identifying any or all such patent rights. Details of any patent rights identified during the development of the document will be in the Introduction and/or on the ISO list of patent declarations received (see www.iso.org/patents).
+
+Any trade name used in this document is information given for the convenience of users and does not constitute an endorsement.
+
+For an explanation on the voluntary nature of standards, the meaning of ISO specific terms and expressions related to conformity assessment, as well as information about ISO's adherence to the World Trade Organization (WTO) principles in the Technical Barriers to Trade (TBT) see the following URL: www.iso.org/iso/foreword.html.
+
+This document was prepared by Technical Committee ISO/TC {technical-committee-number}, _{technical-committee}_, Subcommittee SC {subcommittee-number}, _{subcommittee}_.
+
+This second edition cancels and replaces the first edition (ISO {docnumber}-{partnumber}:2009), which has been technically revised.
+
+The main changes compared to the previous edition are:
+
+* updated normative references;
+* deletion of 4.3.
+
+A list of all parts in the ISO {docnumber} series can be found on the ISO website.
+
+[reviewer=ISO,date=2017-01-01,from=foreword,to=foreword]
+****
+A Foreword shall appear in each document. The generic text is shown here. It does not contain requirements, recommendations or permissions.
+
+For further information on the Foreword, see *ISO/IEC Directives, Part 2, 2016, Clause 12.*
+****
+

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,10 @@
+## Metanorma Parser
+
+### Todos
+
+- Parse the ascii doc
+
+### References
+
+- https://www.rubydoc.info/gems/asciidoctor/2.0.18
+- https://docs.asciidoctor.org/asciidoctor/latest/api/convert-files/


### PR DESCRIPTION
This commit adds the initial setup to parse any ascii doc document to  `Coradoc::Document`. This only initialize the `Bibdata` attributes for now and next step would be to go through the other attributes.