### PR TITLE
Add support to parse top level elements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     coradoc (0.1.0)
       asciidoctor
+      parslet
       pry
 
 GEM
@@ -17,6 +18,7 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
+    parslet (2.0.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)

--- a/coradoc.gemspec
+++ b/coradoc.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "parslet"
   spec.add_dependency "asciidoctor"
   spec.add_runtime_dependency "pry"
 

--- a/lib/coradoc/parser.rb
+++ b/lib/coradoc/parser.rb
@@ -1,16 +1,178 @@
+require "parslet"
+require "parslet/convenience"
+
 module Coradoc
-  class Parser
-    def initialize(filename)
-      @filename = filename
+  class Parser < Parslet::Parser
+    root :document
+
+    # Basic Elements
+    rule(:space) { match('\s') }
+    rule(:space?) { spaces.maybe }
+    rule(:spaces) { space.repeat(1) }
+    rule(:empty_line) { match("^\n") }
+
+    rule(:endline) { newline | any.absent? }
+    rule(:newline) { match["\r\n"].repeat(1) }
+    rule(:line_ending) { match("[\n]") }
+
+    rule(:inline_element) { text }
+    rule(:text) { match("[^\n]").repeat(1) }
+    rule(:digits) { match("[0-9]").repeat(1) }
+    rule(:special_character) { match("^[*_:=-]") | str("[#") }
+
+    rule(:text_line) do
+      special_character.absent? >>
+      match("[^\n]").repeat(1).as(:text) >>
+      line_ending.as(:break)
+    end
+
+    # Document
+    rule(:document) do
+      (
+        bibdata.repeat(1).as(:bibdata) |
+        section.as(:section) |
+        block_with_title.as(:block) |
+        empty_line.repeat(1) |
+        any.as(:unparsed)
+      ).repeat(1).as(:document)
+    end
+
+    # Bibdata
+    rule(:bibdata) do
+      str(":") >> attribute_name.as(:key) >> str(":") >>
+      space? >> attribute_value.as(:value) >> endline
+    end
+
+    # Section
+    rule(:section) do
+      heading.as(:title) >>
+      (list.as(:list) |
+       blocks.as(:blocks) |
+       paragraphs.as(:paragraphs)).maybe
+    end
+
+    # Heading
+    rule(:heading) do
+      (anchor_name >> newline).maybe >>
+      match("=").repeat(1, 8).as(:level) >>
+      space? >> text.as(:text) >> endline.as(:break)
+    end
+
+    rule(:anchor_name) { str("[#") >> keyword.as(:name) >> str("]") }
+
+    # List
+    rule(:list) do
+      unnumbered_list.as(:unnumbered) |
+        definition_list.as(:definition) | numbered_list.as(:numbered)
+    end
+
+    rule(:numbered_list) { nlist_item.repeat(1) }
+    rule(:unnumbered_list) { ulist_item.repeat(1) }
+    rule(:definition_list) { dlist_item.repeat(1) }
+
+    rule(:nlist_item) { match("\.") >> space >> text_line }
+    rule(:ulist_item) { match("\\*") >> space >> text_line }
+    rule(:dlist_item) do
+      str("term") >> space >> digits >> str("::") >> space >> text_line
+    end
+
+    # Block
+    rule(:block) { simple_block | open_block }
+    rule(:attribute_name) { keyword }
+    rule(:attribute_value) { text | str("") }
+    rule(:keyword) { match("[a-zA-Z0-9_-]").repeat(1) }
+    rule(:blocks) { block.repeat(1) >> (newline >> block.repeat(1)).maybe }
+
+    rule(:block_title) { str(".") >> text.as(:title) >> line_ending }
+    rule(:block_type) { str("[") >> keyword.as(:type) >> str("]") >> newline }
+
+    rule(:block_attribute) do
+      str("[")  >> keyword.as(:key) >>
+      str("=") >> keyword.as(:value) >> str("]")
+    end
+
+    rule(:simple_block) do
+      block_attribute.as(:attributes) >> newline >>
+      text_line.repeat(1).as(:lines)
+    end
+
+    rule(:open_block) do
+      block_title >>
+      block_type >>
+      str("--").as(:delimiter) >> newline >>
+      text_line.repeat.as(:lines) >>
+      str("--") >> line_ending
+    end
+
+    rule(:example_block) do
+      block_title >>
+      block_type >>
+      str("====").as(:delimiter) >> newline >>
+      text_line.repeat(1).as(:lines) >>
+      str("====") >> newline
+    end
+
+    rule(:sidebar_block) do
+      block_title >>
+      block_type.maybe >>
+      str("****").as(:delimiter) >> newline >>
+      text_line.repeat(1).as(:lines) >>
+      str("****") >> newline
+    end
+
+    rule(:source_block) do
+      block_title >>
+      str("----").as(:delimiter) >> newline >>
+      text_line.repeat(1).as(:lines) >>
+      str("----") >> newline
+    end
+
+    rule(:quote_block) do
+      block_title >>
+      str("____").as(:delimiter) >> newline >>
+      text_line.repeat.as(:lines) >>
+      str("____") >> newline
+    end
+
+    rule(:block_with_title) do
+      example_block | quote_block |
+        sidebar_block | source_block | open_block |
+        (block_title >> text_line.repeat(1).as(:lines))
+    end
+
+    # Paragraph
+    rule(:paragraphs) do
+      paragraph >> (line_ending.repeat(1) >> paragraph).repeat.maybe
+    end
+
+    rule(:paragraph) { admonitions.repeat(1) | text_line.repeat(1) }
+
+
+    # Admonition
+    rule(:admonition_type) do
+      (str("NOTE") |
+       str("TIP") |
+       str("EDITOR") |
+       str("DANGER") |
+       str("CAUTION") |
+       str("WARNING") |
+       str("IMPORTANT")).as(:type)
+    end
+
+    rule(:admonitions) { admonition.as(:admonition).repeat(1) }
+    rule(:admonition) { inline_admonition | block_admonition }
+
+    rule(:inline_admonition) do
+      admonition_type >> str(":") >> space? >> text_line >> newline
+    end
+
+    rule(:block_admonition) do
+      str("[") >> admonition_type >> str("]") >> newline >> text_line >> newline
     end
 
     def self.parse(filename)
-      new(filename).parse
-    end
-
-    def parse
-      asciidoc = Asciidoctor.load_file(@filename, safe: :safe)
-      Coradoc::Document::Base.new(asciidoc)
+      content = File.read(filename)
+      new.parse_with_debug(content)
     end
   end
 end

--- a/spec/coradoc/parser_spec.rb
+++ b/spec/coradoc/parser_spec.rb
@@ -2,16 +2,318 @@ require "spec_helper"
 
 RSpec.describe Coradoc::Parser do
   describe ".parse" do
-    it "parses the document to metanorma document" do
-      sample_file = Coradoc.root_path.join(
-        "spec", "fixtures", "iso-sample", "rice-en.cd.sections.adoc",
-      )
+    it "parses the document using parselet" do
+      sample_file = Coradoc.root_path.join("spec", "fixtures", "sample.adoc")
 
-      document = Coradoc::Parser.parse(sample_file.to_s)
+      document = Coradoc::Parser.parse(sample_file)[:document]
 
-      expect(document.class).to be(Coradoc::Document::Base)
-      expect(document.bibdata.class).to be(Coradoc::Document::BibData)
-      expect(document.bibdata.docnumber).to eq("173012")
+      expect_docuemnt_to_match_title_section(document[0])
+      expect_document_to_match_bibdata(document[1])
+      expect_document_to_match_section_with_body(document[2])
+      expect_document_to_match_section_titles(document[3..10])
+      expect_document_to_match_inline_formatting(document[11])
+      expect_document_to_match_numbered_list_section(document[12])
+      expect_document_to_match_unnumbered_list_section(document[13])
+      expect_document_to_match_definition_list_section(document[14])
+      expect_document_to_match_basic_block_sections(document[16])
+      expect_document_to_match_the_top_lavel_block(document[17])
+      exepct_docuemnt_to_match_the_open_block_syntax(document[18])
+      expect_document_to_match_the_example_block_syntax(document[19])
+      expect_docuemnt_to_match_source_code_block_syntax(document[20])
+      expect_document_to_match_source_block_perimeter(document[21])
+      expect_document_to_mathc_sidebar_block_syntax(document[22])
+      expect_docuemnt_to_match_sidebar_block_perimeter(document[23])
+      expect_docuemnt_to_match_quote_open_block_syntax(document[24])
+      expect_document_to_match_quote_perimeter_block(document[25])
+      expect_document_to_match_differnt_admonition(document[26])
+      expect_document_to_match_section_with_anchor(document[28])
+      expect_document_to_match_section_with_links(document[29])
+
+      # let's see what's in there
+      pp document
     end
+  end
+
+  #
+  # Note: Ignore this section for nos
+  #
+  # The following section it to make sure that incrementaal changes
+  # does not break any of the existing parsing machanisim, onece done
+  # then we will have proper test suite here.
+  #
+  def expect_document_to_match_section_with_links(doc)
+    section = doc[:section]
+
+    expect(section[:title][:text]).to eq("Links")
+    expect(section[:paragraphs][0][:text]).to eq(
+      "This renders as a URL: https://www.example.com."
+    )
+
+    expect(section[:paragraphs][1][:text]).to eq(
+      "This renders as a URL: https://www.example.com[Example.Com]."
+    )
+  end
+
+  def expect_document_to_match_section_with_anchor(doc)
+    section = doc[:section]
+
+    expect(section[:title][:level]).to eq("===")
+    expect(section[:title][:text]).to eq("Anchor")
+    expect(section[:title][:name]).to eq("this-is-an-anchor")
+
+    # We need to parsing for insline text
+    expect(section[:paragraphs].count).to eq(3)
+  end
+
+  def expect_document_to_match_differnt_admonition(doc)
+    section = doc[:section]
+    paragraphs = section[:paragraphs]
+
+    expect(section[:title][:text]).to eq("Admonitions")
+    expect(paragraphs[0][:text]).to eq("These are all admonition types.")
+
+    expect(paragraphs[1][:admonition][:type]).to eq("NOTE")
+    expect(paragraphs[2][:admonition][:type]).to eq("TIP")
+    expect(paragraphs[3][:admonition][:type]).to eq("WARNING")
+    expect(paragraphs[4][:admonition][:type]).to eq("CAUTION")
+    expect(paragraphs[5][:admonition][:type]).to eq("DANGER")
+    expect(paragraphs[6][:admonition][:type]).to eq("IMPORTANT")
+    expect(paragraphs[7][:admonition][:type]).to eq("EDITOR")
+    expect(paragraphs[8][:admonition][:type]).to eq("NOTE")
+    expect(paragraphs[9][:admonition][:type]).to eq("DANGER")
+
+    expect(paragraphs[1][:admonition][:text]).to eq("This is a note.")
+    expect(paragraphs[2][:admonition][:text]).to eq("This is a tip.")
+    expect(paragraphs[3][:admonition][:text]).to eq("This is a warning.")
+    expect(paragraphs[4][:admonition][:text]).to eq("This is a caution.")
+    expect(paragraphs[5][:admonition][:text]).to eq("This is a danger warning.")
+    expect(paragraphs[6][:admonition][:text]).to eq("This is an important note.")
+    expect(paragraphs[7][:admonition][:text]).to eq("This is an editor note.")
+
+    expect(paragraphs[8][:admonition][:text]).to eq(
+      "This is also a NOTE but in block syntax."
+    )
+
+    expect(paragraphs[9][:admonition][:text]).to eq(
+      "This is also a DANGER warning but in block syntax."
+    )
+  end
+
+  def expect_document_to_match_quote_perimeter_block(doc)
+    block = doc[:block]
+
+    expect(block[:lines].count).to eq(0)
+    expect(block[:delimiter]).to eq("____")
+    expect(block[:title]).to eq("Quote block (with block perimeter type)")
+  end
+
+  def expect_docuemnt_to_match_quote_open_block_syntax(doc)
+    block = doc[:block]
+
+    expect(block[:type]).to eq("quote")
+    expect(block[:lines].count).to eq(0)
+    expect(block[:delimiter]).to eq("--")
+  end
+
+  def expect_docuemnt_to_match_sidebar_block_perimeter(doc)
+    block = doc[:block]
+
+    expect(block[:delimiter]).to eq("****")
+    expect(block[:title]).to eq("Side blocks (with block perimeter type)")
+    expect(block[:lines][0][:text]).to eq("This renders in the side.")
+  end
+
+  def expect_document_to_mathc_sidebar_block_syntax(doc)
+    block = doc[:block]
+
+    expect(block[:type]).to eq("side")
+    expect(block[:delimiter]).to eq("****")
+    expect(block[:title]).to eq("Side blocks (open block syntax)")
+    expect(block[:lines][0][:text]).to eq("This renders in the side.")
+  end
+
+  def expect_document_to_match_source_block_perimeter(doc)
+    block = doc[:block]
+
+    expect(block[:delimiter]).to eq("----")
+    expect(block[:title]).to eq("Source block (with block perimeter type)")
+    expect(block[:lines][0][:text]).to eq("This renders in monospace.")
+  end
+
+  def expect_docuemnt_to_match_source_code_block_syntax(doc)
+    block = doc[:block]
+
+    expect(block[:type]).to eq("source")
+    expect(block[:delimiter]).to eq("--")
+    expect(block[:title]).to eq("Source block (open block syntax)")
+    expect(block[:lines][0][:text]).to eq("This renders in monospace.")
+  end
+
+  def expect_document_to_match_the_example_block_syntax(doc)
+    block = doc[:block]
+
+    expect(block[:type]).to eq("example")
+    expect(block[:delimiter]).to eq("====")
+    expect(block[:title]).to eq("Example block (with block perimeter type)")
+    expect(block[:lines][0][:text]).to eq("This renders as an example.")
+  end
+
+  def exepct_docuemnt_to_match_the_open_block_syntax(doc)
+    section = doc[:section]
+    blocks = section[:blocks]
+
+    expect(blocks.count).to eq(1)
+    expect(blocks[0][:delimiter]).to eq("--")
+    expect(blocks[0][:type]).to eq("example")
+    expect(blocks[0][:lines].count).to eq(1)
+
+    expect(section[:title][:text]).to eq("Basic block with perimeters")
+    expect(blocks[0][:title]).to eq("Example block (open block syntax)")
+    expect(blocks[0][:lines][0][:text]).to eq("This renders as an example.")
+  end
+
+  def expect_document_to_match_the_top_lavel_block(doc)
+    block = doc[:block]
+
+    expect(block[:title]).to eq("Caption title")
+    expect(block[:lines][0][:text]).to eq("This block should have a caption title.")
+  end
+
+  def expect_document_to_match_basic_block_sections(doc)
+    section = doc[:section]
+    blocks = section[:blocks]
+
+    expect(section[:title][:level]).to eq("===")
+    expect(section[:title][:text]).to eq("Basic block with no perimeters")
+
+    expect(blocks.count).to eq(2)
+    expect(blocks[0][:attributes]).to eq({ key: "id", value: "myblock"})
+    expect(blocks[0][:lines][0][:text]).to eq(
+      "This is my block with a defined ID."
+    )
+
+    expect(blocks[1][:attributes]).to eq({ key: "role", value: "source"})
+    expect(blocks[1][:lines][0][:text]).to eq(
+      "This should be rendered in source code format."
+    )
+  end
+
+  def expect_document_to_match_definition_list_section(doc)
+    section = doc[:section]
+    list = section[:list][:definition]
+
+    expect(section[:title][:level]).to eq("==")
+    expect(section[:title][:text]).to eq("Definition list")
+    expect(section[:list][:definition].count).to eq(6)
+
+    expect(list[0][:text]).to eq("definition list item 1")
+    expect(list[2][:text]).to eq("definition list item 3")
+    expect(list[4][:text]).to eq("definition list item 5")
+    expect(list[5][:text]).to eq("definition list item 15")
+  end
+
+  def expect_document_to_match_unnumbered_list_section(doc)
+    section = doc[:section]
+    list = section[:list][:unnumbered]
+
+    expect(section[:title][:level]).to eq("==")
+    expect(section[:title][:text]).to eq("Unnumbered list")
+    expect(section[:list][:unnumbered].count).to eq(5)
+
+    expect(list[0][:text]).to eq("Unnumbered list item 1")
+    expect(list[2][:text]).to eq("Unnumbered list item 3")
+    expect(list[4][:text]).to eq("Unnumbered list item 5")
+  end
+
+  def expect_document_to_match_numbered_list_section(doc)
+    section = doc[:section]
+    numbered_list = section[:list][:numbered]
+
+    expect(section[:title][:level]).to eq("==")
+    expect(section[:title][:text]).to eq("Numbered list")
+    expect(section[:list][:numbered].count).to eq(5)
+
+    expect(numbered_list[0][:text]).to eq("Numbered list item 1")
+    expect(numbered_list[2][:text]).to eq("Numbered list item 3")
+    expect(numbered_list[4][:text]).to eq("Numbered list item 5")
+  end
+
+  def expect_document_to_match_inline_formatting(doc)
+    section = doc[:section]
+
+    expect(section[:title][:level]).to eq("==")
+    expect(section[:title][:text]).to eq("Inline formatting")
+
+    expect(section[:paragraphs].count).to eq(9)
+    expect(section[:paragraphs][0][:text]).to eq("This is a *bold* statement.")
+
+    expect(section[:paragraphs][3][:text]).to eq(
+      "This is in __italics with double underscores__.")
+
+    expect(section[:paragraphs][6][:text]).to eq(
+      "This is [underscore]#underscored#.")
+
+    expect(section[:paragraphs][8][:text]).to eq(
+      "This is in [smallcaps]#smallcaps#.")
+  end
+
+  def expect_document_to_match_section_titles(doc)
+    expect(doc[0][:section][:title][:level]).to eq("==")
+    expect(doc[0][:section][:title][:text]).to eq("Level 1 clause heading")
+
+    expect(doc[1][:section][:title][:level]).to eq("===")
+    expect(doc[1][:section][:title][:text]).to eq("Level 2 clause heading")
+
+    expect(doc[3][:section][:title][:level]).to eq("=====")
+    expect(doc[3][:section][:title][:text]).to eq("Level 4 clause heading")
+
+    expect(doc[7][:section][:title][:level]).to eq("========")
+    expect(doc[7][:section][:title][:text]).to eq("Level 8 clause heading")
+  end
+
+  def expect_document_to_match_section_with_body(doc)
+    section = doc[:section]
+
+    expect(section[:title][:level]).to eq("==")
+    expect(section[:title][:text]).to eq("Attribute rendering")
+    expect(section[:paragraphs].count).to eq(2)
+
+    expect(section[:paragraphs][0][:text]).to eq(
+      'This ({string-attribute}) renders as "this has to be a string".')
+
+    expect(section[:paragraphs][1][:text]).to eq(
+      'This ({url-attribute}) renders as "https://example.com".')
+  end
+
+  def expect_document_to_match_bibdata(doc)
+    bibdata = doc[:bibdata]
+
+    # this is not correct btw, should be 10
+    expect(bibdata.count).to eq(9)
+
+    expect(bibdata[0][:key]).to eq("string-attribute")
+    expect(bibdata[0][:value]).to eq("this has to be a string")
+
+    expect(bibdata[3][:key]).to eq("number-attribute")
+    expect(bibdata[3][:value]).to eq("300")
+
+
+    expect(bibdata[6][:key]).to eq("uri-attribute")
+    expect(bibdata[6][:value]).to eq("https://example.com")
+  end
+
+  def expect_docuemnt_to_match_title_section(doc)
+    section = doc[:section]
+
+    expect(section[:title][:level]).to eq("=")
+    expect(section[:title][:text]).to eq("This is the title")
+    expect(section[:paragraphs].count).to eq(2)
+
+    expect(section[:paragraphs].first[:text]).to eq(
+      "Given name, Last name <email@example.com>")
+
+    expect(section[:paragraphs][1][:text]).to eq(
+      "1.0, 2023-02-23, Version comment note"
+    )
   end
 end

--- a/spec/fixtures/sample.adoc
+++ b/spec/fixtures/sample.adoc
@@ -1,0 +1,185 @@
+= This is the title
+Given name, Last name <email@example.com>
+1.0, 2023-02-23, Version comment note
+:string-attribute: this has to be a string
+:name_1: name of the first contributor in an array
+:name_2: name of the second contributor in an array
+:number-attribute: 300
+:boolean-attribute: true
+:url-attribute: https://example.com
+:uri-attribute: https://example.com
+:flag-without-value:
+:array-semicolon-value: this;is;separated;by;semicolons
+:array-comma-value: this,is,separated,by,semicolons
+
+== Attribute rendering
+
+This ({string-attribute}) renders as "this has to be a string".
+
+This ({url-attribute}) renders as "https://example.com".
+
+
+== Level 1 clause heading
+
+=== Level 2 clause heading
+
+==== Level 3 clause heading
+
+===== Level 4 clause heading
+
+===== Level 5 clause heading
+
+====== Level 6 clause heading
+
+======= Level 7 clause heading
+
+======== Level 8 clause heading
+
+== Inline formatting
+
+This is a *bold* statement.
+
+This is **bold using double** asterisks.
+
+This is in _italics_.
+
+This is in __italics with double underscores__.
+
+This is in `monospace`.
+
+This is in ```monospace with triple backticks```.
+
+This is [underscore]#underscored#.
+
+This is in [strikethrough]#strikethrough#.
+
+This is in [smallcaps]#smallcaps#.
+
+
+
+== Numbered list
+
+. Numbered list item 1
+. Numbered list item 2
+. Numbered list item 3
+. Numbered list item 4
+. Numbered list item 5
+
+== Unnumbered list
+
+* Unnumbered list item 1
+* Unnumbered list item 2
+* Unnumbered list item 3
+* Unnumbered list item 4
+* Unnumbered list item 5
+
+== Definition list
+
+term 1:: definition list item 1
+term 2:: definition list item 2
+term 3:: definition list item 3
+term 4:: definition list item 4
+term 5:: definition list item 5
+term 15:: definition list item 15
+
+== Blocks
+
+=== Basic block with no perimeters
+
+[id=myblock]
+This is my block with a defined ID.
+
+[role=source]
+This should be rendered in source code format.
+
+.Caption title
+This block should have a caption title.
+
+=== Basic block with perimeters
+
+.Example block (open block syntax)
+[example]
+--
+This renders as an example.
+--
+
+.Example block (with block perimeter type)
+[example]
+====
+This renders as an example.
+====
+
+.Source block (open block syntax)
+[source]
+--
+This renders in monospace.
+--
+
+.Source block (with block perimeter type)
+----
+This renders in monospace.
+----
+
+.Side blocks (open block syntax)
+[side]
+****
+This renders in the side.
+****
+
+.Side blocks (with block perimeter type)
+****
+This renders in the side.
+****
+
+.Quote block (open block syntax)
+[quote]
+--
+--
+
+.Quote block (with block perimeter type)
+____
+____
+
+
+== Admonitions
+
+These are all admonition types.
+
+NOTE: This is a note.
+
+TIP: This is a tip.
+
+WARNING: This is a warning.
+
+CAUTION: This is a caution.
+
+DANGER: This is a danger warning.
+
+IMPORTANT: This is an important note.
+
+EDITOR: This is an editor note.
+
+[NOTE]
+This is also a NOTE but in block syntax.
+
+[DANGER]
+This is also a DANGER warning but in block syntax.
+
+
+== Cross references
+
+[#this-is-an-anchor]
+=== Anchor
+
+This (<<this-is-an-anchor>>) should render "X.Y" and link back to "Anchor".
+
+This (<<this-is-an-anchor,title>>) should render "title" and link back to "Anchor".
+
+This (<<this-is-an-anchor,:title>>) should render "Anchor" and link back to "Anchor".
+
+== Links
+
+This renders as a URL: https://www.example.com.
+
+This renders as a URL: https://www.example.com[Example.Com].
+


### PR DESCRIPTION
This commit adds support to parse the top element elements in a AsciiDoc document. This usages parslet, and define the top level elements grammar using PEG. This commit includes the grammar for following:

* List
* Block
* Bibdata
* Heading
* Section
* Paragraph
* Admonition

Beside these, it also includes the sub-elements in each of those element.
This doesn't include the parsing for inline attributes in each line yet, but that will follow next.