### PR TITLE
Add support to parse document header

### DIFF
--- a/spec/coradoc/parser_spec.rb
+++ b/spec/coradoc/parser_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Coradoc::Parser do
 
       document = Coradoc::Parser.parse(sample_file)[:document]
 
-      expect_docuemnt_to_match_title_section(document[0])
+      pp document
+
+      expect_document_to_match_header(document[0])
       expect_document_to_match_bibdata(document[1])
       expect_document_to_match_section_with_body(document[2])
       expect_document_to_match_section_titles(document[3..10])
@@ -302,18 +304,16 @@ RSpec.describe Coradoc::Parser do
     expect(bibdata[6][:value]).to eq("https://example.com")
   end
 
-  def expect_docuemnt_to_match_title_section(doc)
-    section = doc[:section]
+  def expect_document_to_match_header(doc)
+    header= doc[:header]
 
-    expect(section[:title][:level]).to eq("=")
-    expect(section[:title][:text]).to eq("This is the title")
-    expect(section[:paragraphs].count).to eq(2)
+    expect(header[:title]).to eq("This is the title")
+    expect(header[:author][:first_name]).to eq("Given name")
+    expect(header[:author][:last_name]).to eq("Last name")
+    expect(header[:author][:email]).to eq("email@example.com")
 
-    expect(section[:paragraphs].first[:text]).to eq(
-      "Given name, Last name <email@example.com>")
-
-    expect(section[:paragraphs][1][:text]).to eq(
-      "1.0, 2023-02-23, Version comment note"
-    )
+    expect(header[:revision][:number]).to eq("1.0")
+    expect(header[:revision][:date]).to eq("2023-02-23")
+    expect(header[:revision][:remark]).to eq("Version comment note")
   end
 end

--- a/spec/fixtures/sample.adoc
+++ b/spec/fixtures/sample.adoc
@@ -1,6 +1,6 @@
 = This is the title
 Given name, Last name <email@example.com>
-1.0, 2023-02-23, Version comment note
+1.0, 2023-02-23: Version comment note
 :string-attribute: this has to be a string
 :name_1: name of the first contributor in an array
 :name_2: name of the second contributor in an array


### PR DESCRIPTION
This commit adds support to parse a document header. This includes the tile, author details and revision details.
This also adjust the revision text to match the format that was recommended by AsciiDoc.

Reference: https://docs.asciidoctor.org/asciidoc/latest/document/revision-line/