### PR TITLE
Add transformation to coradoc objects

### DIFF
--- a/lib/coradoc.rb
+++ b/lib/coradoc.rb
@@ -4,6 +4,7 @@ require "asciidoctor"
 require "coradoc/version"
 require "coradoc/document/base"
 require "coradoc/parser"
+require "coradoc/transformer"
 
 module Coradoc
   class Error < StandardError; end

--- a/lib/coradoc/document/admonition.rb
+++ b/lib/coradoc/document/admonition.rb
@@ -1,0 +1,11 @@
+module Coradoc
+  class Document::Admonition
+    attr_reader :type, :content, :line_break
+
+    def initialize(content, type, options = {})
+      @content = content
+      @type = type.downcase.to_sym
+      @line_break = options.fetch(:line_break, "")
+    end
+  end
+end

--- a/lib/coradoc/document/attribute.rb
+++ b/lib/coradoc/document/attribute.rb
@@ -1,0 +1,10 @@
+module Coradoc
+  class Document::Attribute
+    attr_reader :key, :value
+
+    def initialize(key, value)
+      @key = key
+      @value = value
+    end
+  end
+end

--- a/lib/coradoc/document/author.rb
+++ b/lib/coradoc/document/author.rb
@@ -1,0 +1,11 @@
+module Coradoc
+  class Document::Author
+    attr_reader :email, :last_name, :first_name
+
+    def initialize(first_name, last_name, email)
+      @email = email
+      @last_name = last_name
+      @first_name = first_name
+    end
+  end
+end

--- a/lib/coradoc/document/block.rb
+++ b/lib/coradoc/document/block.rb
@@ -1,0 +1,34 @@
+module Coradoc
+  class Document::Block
+    attr_reader :title, :lines, :attributes
+
+    def initialize(title, options = {})
+      @title = title
+      @lines = options.fetch(:lines, [])
+      @type_str = options.fetch(:type, nil)
+      @delimiter = options.fetch(:delimiter, "")
+      @attributes = options.fetch(:attributes, {})
+    end
+
+    def type
+      @type ||= defined_type || type_from_delimiter
+    end
+
+    private
+
+    def defined_type
+      if @type_str
+        @type_str.to_s.to_sym
+      end
+    end
+
+    def type_from_delimiter
+      case @delimiter
+      when "____" then :quote
+      when "****" then :side
+      when "----" then :source
+      when "====" then :example
+      else nil end
+    end
+  end
+end

--- a/lib/coradoc/document/header.rb
+++ b/lib/coradoc/document/header.rb
@@ -1,0 +1,11 @@
+module Coradoc
+  class Document::Header
+    attr_reader :title, :author, :revision
+
+    def initialize(title, options = {})
+      @title = title
+      @author = options.fetch(:author, nil)
+      @revision = options.fetch(:revision, nil)
+    end
+  end
+end

--- a/lib/coradoc/document/revision.rb
+++ b/lib/coradoc/document/revision.rb
@@ -1,0 +1,11 @@
+module Coradoc
+  class Document::Revision
+    attr_reader :number, :date, :remark
+
+    def initialize(number, options = {})
+      @number = number
+      @date = options.fetch(:date, nil)
+      @remark = options.fetch(:remark, nil)
+    end
+  end
+end

--- a/lib/coradoc/document/section.rb
+++ b/lib/coradoc/document/section.rb
@@ -1,0 +1,11 @@
+module Coradoc
+  class Document::Section
+    attr_reader :title, :blocks, :paragraphs
+
+    def initialize(title, options = {})
+      @title = title
+      @blocks = options.fetch(:blocks, [])
+      @paragraphs = options.fetch(:paragraphs, [])
+    end
+  end
+end

--- a/lib/coradoc/document/text_element.rb
+++ b/lib/coradoc/document/text_element.rb
@@ -1,0 +1,10 @@
+module Coradoc
+  class Document::TextElement
+    attr_reader :content, :line_break
+
+    def initialize(content, options = {})
+      @content = content
+      @line_break = options.fetch(:line_break, "")
+    end
+  end
+end

--- a/lib/coradoc/document/title.rb
+++ b/lib/coradoc/document/title.rb
@@ -1,0 +1,29 @@
+module Coradoc
+  class Document::Title
+    attr_reader :id, :content, :line_break
+
+    def initialize(content, level, options = {})
+      @level_str = level
+      @content = content
+      @id = options.fetch(:id, nil)
+      @line_break = options.fetch(:line_break, "")
+    end
+
+    def level
+      @level ||= level_from_string
+    end
+
+    private
+
+    attr_reader :level_str
+
+    def level_from_string
+      case @level_str.length
+      when 2 then :heading_two
+      when 3 then :heading_three
+      when 4 then :heading_four
+      else :unknown
+      end
+    end
+  end
+end

--- a/lib/coradoc/transformer.rb
+++ b/lib/coradoc/transformer.rb
@@ -1,0 +1,107 @@
+require "parslet"
+require "coradoc/document/title"
+require "coradoc/document/block"
+require "coradoc/document/section"
+require "coradoc/document/attribute"
+require "coradoc/document/admonition"
+require "coradoc/document/text_element"
+
+require "coradoc/document/author"
+require "coradoc/document/revision"
+require "coradoc/document/header"
+
+module Coradoc
+  class Transformer < Parslet::Transform
+    # Header
+    rule(
+      title: simple(:title),
+      author: simple(:author),
+      revision: simple(:revision)) do
+      Document::Header.new(title, author: author, revision: revision)
+    end
+
+    # Author
+    rule(
+      first_name: simple(:first_name),
+      last_name: simple(:last_name),
+      email: simple(:email)) do
+      Document::Author.new(first_name, last_name, email)
+    end
+
+    # Revision
+    rule(number: simple(:number), date: simple(:date), remark: simple(:remark)) do
+      Document::Revision.new(number, date: date, remark: remark)
+    end
+
+    # Text Element
+    rule(text: simple(:text), break: simple(:line_break)) do
+      Document::TextElement.new(text, line_break: line_break)
+    end
+
+    # Title Element
+    rule(
+      level: simple(:level),
+      text: simple(:text),
+      break: simple(:line_break)) do
+        Document::Title.new(text, level, line_break: line_break)
+    end
+
+    rule(
+      name: simple(:name),
+      level: simple(:level),
+      text: simple(:text),
+      break: simple(:line_break)) do
+        Document::Title.new(text, level, line_break: line_break, id: name)
+      end
+
+    # Section
+    rule(title: simple(:title)) { Document::Section.new(title) }
+
+    rule(title: simple(:title), paragraphs: sequence(:paragraphs)) do
+      Document::Section.new(title, paragraphs: paragraphs)
+    end
+
+    rule(title: simple(:title), blocks: sequence(:blocks)) do
+      Document::Section.new(title, blocks: blocks)
+    end
+
+    # Admonition
+    rule(admonition: simple(:admonition)) { admonition }
+    rule(type: simple(:type), text: simple(:text), break: simple(:line_break)) do
+      Document::Admonition.new(text, type.to_s, line_break: line_break)
+    end
+
+    # Block
+    rule(title: simple(:title), lines: sequence(:lines)) do
+      Document::Block.new(title, lines: lines)
+    end
+
+    rule(
+      title: simple(:title),
+      delimiter: simple(:delimiter),
+      lines: sequence(:lines)) do
+        Document::Block.new(title, lines: lines, delimiter: delimiter)
+      end
+
+    rule(
+      type: simple(:type),
+      title: simple(:title),
+      delimiter: simple(:delimiter),
+      lines: sequence(:lines)) do
+        Document::Block.new(title, lines: lines, delimiter: delimiter, type: type)
+      end
+
+    rule(attributes: simple(:attributes), lines: sequence(:lines)) do
+      Document::Block.new(nil, lines: lines, attributes: attributes)
+    end
+
+    # Attribute
+    rule(key: simple(:key), value: simple(:value)) do
+      Document::Attribute.new(key, value)
+    end
+
+    def self.transform(syntax_tree)
+      new.apply(syntax_tree)
+    end
+  end
+end

--- a/spec/coradoc/document/admonition_spec.rb
+++ b/spec/coradoc/document/admonition_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Document::Admonition do
+  describe ".initialize" do
+    it "initializes and exposes admonition attributes" do
+      type = "NOTE"
+      text = "This is note type admonition"
+
+      admonition = Coradoc::Document::Admonition.new(text, type, line_break: "\n")
+
+      expect(admonition.content).to eq(text)
+      expect(admonition.line_break).to eq("\n")
+      expect(admonition.type).to eq(type.downcase.to_sym)
+    end
+  end
+end

--- a/spec/coradoc/document/attribute_spec.rb
+++ b/spec/coradoc/document/attribute_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Document::Attribute do
+  describe ".initialize" do
+    it "initializes and exposes attributes" do
+      key = "test-key"
+      value = "test-value"
+
+      attribute = Coradoc::Document::Attribute.new(key, value)
+
+      expect(attribute.key).to eq(key)
+      expect(attribute.value).to eq(value)
+    end
+  end
+end

--- a/spec/coradoc/document/author_spec.rb
+++ b/spec/coradoc/document/author_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Document::Author do
+  describe ".initialize" do
+    it "initializes and expsoses atributes" do
+      first_name = "John"
+      last_name = "Doe"
+      email = "john.doe@example.com"
+
+      author = Coradoc::Document::Author.new(first_name, last_name, email)
+
+      expect(author.email).to eq(email)
+      expect(author.last_name).to eq(last_name)
+      expect(author.first_name).to eq(first_name)
+    end
+  end
+end

--- a/spec/coradoc/document/block_spec.rb
+++ b/spec/coradoc/document/block_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Document::Block do
+  describe ".initialize" do
+    it "initializes and exposes attributes" do
+      type = "quote"
+      title = "This is a block title"
+
+      block = Coradoc::Document::Block.new(title, type: type)
+
+      expect(block.title).to eq(title)
+      expect(block.type).to eq(:quote)
+      expect(block.lines).to be_empty
+      expect(block.attributes).to eq({})
+    end
+  end
+
+  describe "#type" do
+    it "translates delimiter to proper types" do
+      title = "Block title"
+      delimiter = "____"
+
+      block = Coradoc::Document::Block.new(title, delimiter: delimiter)
+
+      expect(block.title).to eq(title)
+      expect(block.type).to eq(:quote)
+    end
+  end
+end

--- a/spec/coradoc/document/header_spec.rb
+++ b/spec/coradoc/document/header_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Document::Header do
+  describe ".initialize" do
+    it "initializes and exposes attributes" do
+      title = "This is test title"
+      revision = Coradoc::Document::Revision.new(1.0, date: "2023-01-01")
+      author = Coradoc::Document::Author.new("John", "Doe", "john@example.com")
+
+      header = Coradoc::Document::Header.new(
+        title, author: author, revision: revision
+      )
+
+      expect(header.title).to eq(title)
+      expect(header.author).to eq(author)
+      expect(header.revision).to eq(revision)
+    end
+  end
+end

--- a/spec/coradoc/document/revision_spec.rb
+++ b/spec/coradoc/document/revision_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Document::Revision do
+  describe ".initialize" do
+    it "initializes and exposes attributes" do
+      number = 1.0
+      remark = "Version comment note"
+      revision_date = "2023-02-23"
+
+      revision = Coradoc::Document::Revision.new(
+        number, date: revision_date, remark: remark
+      )
+
+      expect(revision.number).to eq(number)
+      expect(revision.remark).to eq(remark)
+      expect(revision.date).to eq(revision_date)
+    end
+  end
+end

--- a/spec/coradoc/document/section_spec.rb
+++ b/spec/coradoc/document/section_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Document::Section do
+  describe ".initialization" do
+    it "initializes and exposes attributes" do
+      text = Coradoc::Document::TextElement.new("Text", line_break: "\n")
+      title = Coradoc::Document::Title.new("Title", "==", line_break: "\n")
+
+      section = Coradoc::Document::Section.new(title, paragraphs: [text])
+
+      expect(section.title).to eq(title)
+      expect(section.blocks).to be_empty
+      expect(section.paragraphs.count).to eq(1)
+      expect(section.paragraphs.first).to eq(text)
+    end
+  end
+end

--- a/spec/coradoc/document/text_element_spec.rb
+++ b/spec/coradoc/document/text_element_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Document::TextElement do
+  describe ".initialize" do
+    it "initializes and exposes text element" do
+      content = "This is text content"
+
+      text = Coradoc::Document::TextElement.new(content, line_break: "\n")
+
+      expect(text.content).to eq(content)
+      expect(text.line_break).to eq("\n")
+    end
+  end
+end

--- a/spec/coradoc/document/title_spec.rb
+++ b/spec/coradoc/document/title_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Document::Title do
+  describe ".initialization" do
+    it "initializes instance and exposes attributes" do
+      title = Coradoc::Document::Title.new(
+        ast[:title],
+        ast[:level],
+        id: ast[:id],
+        line_break: ast[:line_break],
+      )
+
+      expect(title.id).to eq(ast[:id])
+      expect(title.level).to eq(:heading_two)
+      expect(title.content).to eq(ast[:title])
+      expect(title.line_break).to eq(ast[:line_break])
+    end
+  end
+
+  def ast
+    @ast ||= {
+      level: "==",
+      id: "dummy-id",
+      title: "Heading two",
+      line_break: "\n\n"
+    }
+  end
+end

--- a/spec/coradoc/transformer_spec.rb
+++ b/spec/coradoc/transformer_spec.rb
@@ -1,0 +1,128 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Transformer do
+  describe ".transform" do
+    it "transform the abstract syntax tree to base document" do
+      sample_file = Coradoc.root_path.join("spec", "fixtures", "sample.adoc")
+      syntax_tree = Coradoc::Parser.parse(sample_file)
+
+      transformed = Coradoc::Transformer.transform(syntax_tree)
+      transformed_doc = transformed[:document]
+
+      # pp syntax_tree[:document][16]
+      # pp transformed_doc[0..1]
+      pp transformed_doc[14]
+
+      expect_it_to_extract_document_header(transformed_doc[0])
+
+      expect_it_to_extract_section_with_title(transformed_doc[15])
+      expect_it_to_extract_basic_block_from_ast(transformed_doc[16])
+      expect_it_to_extract_caption_title_from_ast(transformed_doc[17])
+      expect_it_to_extract_title_with_block_from_ast(transformed_doc[18])
+      expect_it_to_extract_block_from_ast(transformed_doc[19], :example)
+      expect_it_to_extract_block_from_ast(transformed_doc[20], :source)
+      expect_it_to_extract_block_from_ast(transformed_doc[21], :source)
+      expect_it_to_extract_block_from_ast(transformed_doc[22], :side)
+      expect_it_to_extract_block_from_ast(transformed_doc[23], :side)
+      expect_it_to_extract_block_from_ast(transformed_doc[24], :quote)
+      expect_it_to_extract_block_from_ast(transformed_doc[25], :quote)
+      expect_it_to_extract_admonition_type_ast(transformed_doc[26])
+      expect_it_to_extract_empty_section_ast(transformed_doc[27])
+      expect_it_to_extract_anchor_section_ast(transformed_doc[28])
+      expect_it_to_extract_link_section_ast(transformed_doc[29])
+    end
+  end
+
+  def expect_it_to_extract_document_header(doc)
+    header = doc[:header]
+
+    expect(header.title).to eq("This is the title")
+    expect(header.class).to eq(Coradoc::Document::Header)
+    expect(header.author.class).to eq(Coradoc::Document::Author)
+    expect(header.revision.class).to eq(Coradoc::Document::Revision)
+  end
+
+  def expect_it_to_extract_section_with_title(doc)
+    section = doc[:section]
+
+    expect(section.class).to eq(Coradoc::Document::Section)
+    expect(section.title.class).to eq(Coradoc::Document::Title)
+  end
+
+  def expect_it_to_extract_basic_block_from_ast(doc)
+    section = doc[:section]
+
+    expect(section.title.class).to eq(Coradoc::Document::Title)
+    expect(section.blocks.first.class).to eq(Coradoc::Document::Block)
+    expect(section.blocks.first.attributes.class).to eq(Coradoc::Document::Attribute)
+  end
+
+  def expect_it_to_extract_caption_title_from_ast(doc)
+    block = doc[:block]
+
+    expect(block.type).to be_nil
+    expect(block.title).to eq("Caption title")
+    expect(block.lines.first.class).to eq(Coradoc::Document::TextElement)
+  end
+
+  def expect_it_to_extract_title_with_block_from_ast(doc)
+    section = doc[:section]
+
+    expect(section.blocks.first.type).to eq(:example)
+    expect(section.title.class).to eq(Coradoc::Document::Title)
+    expect(section.blocks.first.class).to eq(Coradoc::Document::Block)
+  end
+
+  def expect_it_to_extract_block_from_ast(doc, type)
+    block = doc[:block]
+
+    expect(block.type).to eq(type)
+    expect(block.lines).not_to be_nil
+    expect(block.class).to eq(Coradoc::Document::Block)
+  end
+
+  def expect_it_to_extract_admonition_type_ast(transformed_doc)
+    section = transformed_doc[:section]
+
+    expect(section.paragraphs.count).to eq(10)
+    expect(section.paragraphs[1].type).to eq(:note)
+    expect(section.paragraphs[1].content).to eq("This is a note.")
+
+    expect(section.title.class).to eq(Coradoc::Document::Title)
+    expect(section.paragraphs[1].class).to eq(Coradoc::Document::Admonition)
+    expect(section.paragraphs[9].class).to eq(Coradoc::Document::Admonition)
+    expect(section.paragraphs.first.class).to eq(Coradoc::Document::TextElement)
+  end
+
+  def expect_it_to_extract_empty_section_ast(transformed_doc)
+    section = transformed_doc[:section]
+
+    expect(section.paragraphs).to be_empty
+    expect(section.class).to eq(Coradoc::Document::Section)
+    expect(section.title.class).to eq(Coradoc::Document::Title)
+  end
+
+  def expect_it_to_extract_anchor_section_ast(transformed_doc)
+    section = transformed_doc[:section]
+
+    expect(section.paragraphs.count).to eq(3)
+    expect(section.title.level).to eq(:heading_three)
+    expect(section.title.id).to eq("this-is-an-anchor")
+    expect(section.class).to eq(Coradoc::Document::Section)
+    expect(section.title.class).to eq(Coradoc::Document::Title)
+  end
+
+  def expect_it_to_extract_link_section_ast(transformed_doc)
+    section = transformed_doc[:section]
+
+    expect(section.paragraphs.count).to eq(2)
+    expect(section.title.content).to eq("Links")
+    expect(section.paragraphs.first.content).to eq(
+      "This renders as a URL: https://www.example.com."
+    )
+
+    expect(section.class).to eq(Coradoc::Document::Section)
+    expect(section.title.class).to eq(Coradoc::Document::Title)
+  end
+end
+


### PR DESCRIPTION
This commit adds some transformation from abstract syntax tree to coradoc objects. This transformation includes the following:

* Title
* Block
* Author
* Header
* Section
* Revision
* Attribute
* Admonition
* Text Elements