### PR TITLE
feat: adding support for example blocks

### DIFF
--- a/lib/coradoc/parser/asciidoc/content.rb
+++ b/lib/coradoc/parser/asciidoc/content.rb
@@ -31,9 +31,11 @@ module Coradoc
 
         def example_block
           str("[example]") >> newline >>
-          str("====") >> newline >>
-          (str("====").absent? >> text.as(:text) >> endline).repeat(1) >>
-          str("====") >> line_ending
+          str("=").repeat(4).capture(:delimiter) >> newline >>
+          dynamic do |source, context|
+            (str(context.captures[:delimiter]).absent? >> text.as(:text) >> endline).repeat(1) >>
+            str(context.captures[:delimiter]) >> endline
+          end
         end
 
         def highlight

--- a/lib/coradoc/parser/asciidoc/content.rb
+++ b/lib/coradoc/parser/asciidoc/content.rb
@@ -20,12 +20,20 @@ module Coradoc
 
         def contents
           (
+            example_block.as(:example) |
             list.as(:list) |
             table.as(:table) |
             highlight.as(:highlight) |
             glossaries.as(:glossaries) |
             paragraph.as(:paragraph) | empty_line
           ).repeat(1)
+        end
+
+        def example_block
+          str("[example]") >> newline >>
+          str("====") >> newline >>
+          paragraph >>
+          str("====") >> line_ending
         end
 
         def highlight

--- a/lib/coradoc/parser/asciidoc/content.rb
+++ b/lib/coradoc/parser/asciidoc/content.rb
@@ -32,7 +32,7 @@ module Coradoc
         def example_block
           str("[example]") >> newline >>
           str("====") >> newline >>
-          paragraph >>
+          (str("====").absent? >> text.as(:text) >> endline).repeat(1) >>
           str("====") >> line_ending
         end
 

--- a/lib/coradoc/transformer.rb
+++ b/lib/coradoc/transformer.rb
@@ -87,6 +87,10 @@ module Coradoc
         Document::Section.new(title, id: id, contents: contents, sections: sections)
     end
 
+    rule(example: sequence(:example)) do
+      Document::Block.new("", delimiter: "====", lines: example)
+    end
+
     # rule(title: simple(:title), paragraphs: sequence(:paragraphs)) do
     #   Document::Section.new(title, paragraphs: paragraphs)
     # end

--- a/lib/coradoc/transformer.rb
+++ b/lib/coradoc/transformer.rb
@@ -88,7 +88,7 @@ module Coradoc
     end
 
     rule(example: sequence(:example)) do
-      Document::Block.new("", delimiter: "====", lines: example)
+      Document::Block.new("", type: "example", lines: example)
     end
 
     # rule(title: simple(:title), paragraphs: sequence(:paragraphs)) do

--- a/spec/coradoc/parser/asciidoc/content_spec.rb
+++ b/spec/coradoc/parser/asciidoc/content_spec.rb
@@ -15,6 +15,26 @@ RSpec.describe "Coradoc::Asciidoc::Content" do
       expect(lines[1][:text]).to eq("It can be distrubuted in multiple lines")
     end
 
+    it "parses content section with text and example block" do
+      content = <<~TEXT
+      This is the sample text for content
+      It can be distrubuted in multiple lines
+
+      [example]
+      ====
+      This is some example text
+      ====
+      TEXT
+
+      ast = Asciidoc::ContentTester.parse(content)
+      lines = ast.first[:paragraph]
+      example = ast.last[:example]
+
+      expect(lines[0][:text]).to eq("This is the sample text for content")
+      expect(lines[1][:text]).to eq("It can be distrubuted in multiple lines")
+      expect(example[0][:text]).to eq("This is some example text")
+    end
+
     it "parses content with glossaries" do
       content = <<~TEXT
       Clause:: 5.1

--- a/spec/coradoc/parser/asciidoc/content_spec.rb
+++ b/spec/coradoc/parser/asciidoc/content_spec.rb
@@ -24,15 +24,22 @@ RSpec.describe "Coradoc::Asciidoc::Content" do
       ====
       This is some example text
       ====
+
+      [example]
+      ======
+      This is another example text
+      ======
       TEXT
 
       ast = Asciidoc::ContentTester.parse(content)
       lines = ast.first[:paragraph]
-      example = ast.last[:example]
+      example1 = ast[1][:example]
+      example2 = ast[2][:example]
 
       expect(lines[0][:text]).to eq("This is the sample text for content")
       expect(lines[1][:text]).to eq("It can be distrubuted in multiple lines")
-      expect(example[0][:text]).to eq("This is some example text")
+      expect(example1[0][:text]).to eq("This is some example text")
+      expect(example2[0][:text]).to eq("This is another example text")
     end
 
     it "parses content with glossaries" do


### PR DESCRIPTION
Adding support for parsing and transforming example blocks.

closes #23 