### PR TITLE
Add support to parse block types

### DIFF
--- a/lib/coradoc/document/block.rb
+++ b/lib/coradoc/document/block.rb
@@ -1,34 +1,38 @@
 module Coradoc
-  class Document::Block
-    attr_reader :title, :lines, :attributes
+  module Document
+    class Block
+      attr_reader :title, :lines, :attributes
 
-    def initialize(title, options = {})
-      @title = title
-      @lines = options.fetch(:lines, [])
-      @type_str = options.fetch(:type, nil)
-      @delimiter = options.fetch(:delimiter, "")
-      @attributes = options.fetch(:attributes, {})
-    end
-
-    def type
-      @type ||= defined_type || type_from_delimiter
-    end
-
-    private
-
-    def defined_type
-      if @type_str
-        @type_str.to_s.to_sym
+      def initialize(title, options = {})
+        @title = title
+        @lines = options.fetch(:lines, [])
+        @type_str = options.fetch(:type, nil)
+        @delimiter = options.fetch(:delimiter, "")
+        @attributes = options.fetch(:attributes, {})
       end
-    end
 
-    def type_from_delimiter
-      case @delimiter
-      when "____" then :quote
-      when "****" then :side
-      when "----" then :source
-      when "====" then :example
-      else nil end
+      def type
+        @type ||= defined_type || type_from_delimiter
+      end
+
+      private
+
+      def defined_type
+        @type_str&.to_s&.to_sym
+      end
+
+      def type_from_delimiter
+        type_hash.fetch(@delimiter, nil)
+      end
+
+      def type_hash
+        @type_hash ||= {
+          "____" => :quote,
+          "****" => :side,
+          "----" => :source,
+          "====" => :example,
+        }
+      end
     end
   end
 end

--- a/lib/coradoc/document/section.rb
+++ b/lib/coradoc/document/section.rb
@@ -1,28 +1,30 @@
 module Coradoc
-  class Document::Section
-    attr_reader :id, :title, :contents, :sections
+  module Document
+    class Section
+      attr_reader :id, :title, :contents, :sections
 
-    def initialize(title, options = {})
-      @title = title
-      @id = options.fetch(:id, nil).to_s
-      @contents = options.fetch(:contents, [])
-      @sections = options.fetch(:sections, [])
-    end
-
-    def glossaries
-      @glossaries ||= extract_glossaries
-    end
-
-    def content
-      if contents.count == 1 && contents.first.is_a?(Coradoc::Document::Paragraph)
-        contents.first
+      def initialize(title, options = {})
+        @title = title
+        @id = options.fetch(:id, nil).to_s
+        @contents = options.fetch(:contents, [])
+        @sections = options.fetch(:sections, [])
       end
-    end
 
-    private
+      def glossaries
+        @glossaries ||= extract_glossaries
+      end
 
-    def extract_glossaries
-      contents.select {|c| c if c.is_a?(Coradoc::Document::Glossaries) }.first
+      def content
+        if contents.count == 1 && contents.first.is_a?(Coradoc::Document::Paragraph)
+          contents.first
+        end
+      end
+
+      private
+
+      def extract_glossaries
+        contents.select { |c| c if c.is_a?(Coradoc::Document::Glossaries) }.first
+      end
     end
   end
 end

--- a/lib/coradoc/parser/asciidoc/content.rb
+++ b/lib/coradoc/parser/asciidoc/content.rb
@@ -20,7 +20,7 @@ module Coradoc
 
         def contents
           (
-            example_block.as(:example) |
+            block.as(:block) |
             list.as(:list) |
             table.as(:table) |
             highlight.as(:highlight) |
@@ -29,13 +29,37 @@ module Coradoc
           ).repeat(1)
         end
 
+        def block
+          sidebar_block | example_block | source_block | quote_block
+        end
+
+        def source_block
+          block_style("-", 2)
+        end
+
+        def quote_block
+          block_style("_")
+        end
+
+        def sidebar_block
+          block_style("*")
+        end
+
         def example_block
-          str("[example]") >> newline >>
-          str("=").repeat(4).capture(:delimiter) >> newline >>
-          dynamic do |source, context|
-            (str(context.captures[:delimiter]).absent? >> text.as(:text) >> endline).repeat(1) >>
-            str(context.captures[:delimiter]) >> endline
-          end
+          block_style("=")
+        end
+
+        def block_style(delimiter="*", repeater = 4)
+          block_title.maybe >>
+          newline.maybe >>
+          block_type.maybe >>
+          str(delimiter).repeat(repeater).as(:delimiter) >> newline >>
+          text_line.repeat(1).as(:lines) >>
+          str(delimiter).repeat(repeater) >> newline
+        end
+
+        def block_type
+          str("[") >> keyword.as(:type) >> str("]") >> newline
         end
 
         def highlight

--- a/lib/coradoc/parser/asciidoc/section.rb
+++ b/lib/coradoc/parser/asciidoc/section.rb
@@ -10,14 +10,14 @@ module Coradoc
 
         def section_block(level = 2)
           section_id.maybe >>
-          section_title(level).as(:title) >>
-          contents.as(:contents).maybe
+            section_title(level).as(:title) >>
+            contents.as(:contents).maybe
         end
 
         # Section id
         def section_id
           (str("[[") >> keyword.as(:id) >> str("]]") |
-           str("[#") >> keyword.as(:id) >> str("]")) >> newline
+            str("[#") >> keyword.as(:id) >> str("]")) >> newline
         end
 
         # Heading

--- a/spec/coradoc/parser/asciidoc/section_spec.rb
+++ b/spec/coradoc/parser/asciidoc/section_spec.rb
@@ -150,6 +150,39 @@ RSpec.describe "Coradoc::Asciidoc::Section" do
       expect(list_items[1][:id]).to eq("list_item_id")
       expect(list_items[1][:text]).to eq("List item two")
     end
+
+    it "parses blocks with different types" do
+      section = <<~TEXT
+        === Basic block with perimeters
+
+        .Example block (open block syntax)
+        [example]
+        --
+        This renders as an example.
+        --
+
+        .Example block (with block perimeter type)
+        [example]
+        ====
+        This renders as an example.
+        ====
+
+        .Source block (with block perimeter type)
+        ----
+        Renders in monospace
+        ----
+      TEXT
+
+      ast = Asciidoc::SectionTester.parse(section)
+      section = ast.first
+      contents = section[:contents]
+
+      expect(contents.count).to eq(3)
+      expect(contents[0][:block][:type]).to eq("example")
+      expect(contents[1][:block][:delimiter]).to eq("====")
+      expect(section[:title][:text]).to eq("Basic block with perimeters")
+      expect(contents[2][:block][:lines][0][:text]).to eq("Renders in monospace")
+    end
   end
 
   module Asciidoc


### PR DESCRIPTION
This commit adds support to parse different types of blocks. So, now whenever there is a block in the content, then it should parse that as expected.

To simplify the process, this commit also extract the block style in a way then we can easily extend and test new block types.