### PR TITLE
Fix the parsing for header section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ relaton/
 
 .rubocop-https--*
 oscal.yml
+.pryrc

--- a/.pryrc.sample
+++ b/.pryrc.sample
@@ -1,0 +1,1 @@
+doc = Coradoc::Parser.parse("spec/fixtures/sample.adoc")

--- a/lib/coradoc/parser/asciidoc/base.rb
+++ b/lib/coradoc/parser/asciidoc/base.rb
@@ -26,31 +26,18 @@ module Coradoc
           match["\r\n"].repeat(1)
         end
 
-        # def line_break
-        #   match["\r\n"]
-        # end
-
         def keyword
           (match("[a-zA-Z0-9_-]") | str(".")).repeat(1)
         end
 
-        # def text_line
-        #   special_character.absent? >>
-        #   match("[^\n]").repeat(1).as(:text) >>
-        #   line_ending.as(:break)
-        # end
-
-        # rule(:space) { match('\s') }
-        # rule(:space?) { spaces.maybe }
-        # rule(:spaces) { space.repeat(1) }
         def empty_line
           match("^\n")
         end
-        #
 
-        #
-        # rule(:inline_element) { text }
-        # rule(:text) { match("[^\n]").repeat(1) }
+        def digit
+          match("[0-9]")
+        end
+
         def digits
           match("[0-9]").repeat(1)
         end
@@ -61,6 +48,14 @@ module Coradoc
 
         def words
           word >> (space? >> word).repeat
+        end
+
+        def rich_texts
+          rich_text >> (space? >> rich_text).repeat
+        end
+
+        def rich_text
+          (match("[a-zA-Z0-9_-]") | str(".") | str("*") | match("@")).repeat(1)
         end
 
         def email
@@ -77,6 +72,11 @@ module Coradoc
 
         def special_character
           match("^[*_:=-]") | str("[#") | str("[[")
+        end
+
+        def date
+          digit.repeat(2, 4) >> str("-") >>
+            digit.repeat(1, 2) >> str("-") >> digit.repeat(1, 2)
         end
       end
     end

--- a/lib/coradoc/parser/asciidoc/content.rb
+++ b/lib/coradoc/parser/asciidoc/content.rb
@@ -88,17 +88,12 @@ module Coradoc
             repeat(1).as(:cols) >> line_ending
         end
 
-        # Extended
-        def word
-          (match("[a-zA-Z0-9_-]") | str(".") | str("*") | match("@")).repeat(1)
-        end
-
         def empty_cell_content
           str("|").absent? >> literal_space.as(:text)
         end
 
         def cell_content
-          str("|").absent? >> literal_space? >> words.as(:text)
+          str("|").absent? >> literal_space? >> rich_texts.as(:text)
         end
 
         def literal_space

--- a/lib/coradoc/parser/asciidoc/header.rb
+++ b/lib/coradoc/parser/asciidoc/header.rb
@@ -6,23 +6,26 @@ module Coradoc
       module Header
         include Coradoc::Parser::Asciidoc::Base
 
-        # Header
         def header
-          match("=") >> space? >> text.as(:title) >> newline >>
-          author.maybe.as(:author) >> revision.maybe.as(:revision)
+          header_title >>
+          author.maybe.as(:author) >>
+          revision.maybe.as(:revision) >> newline.maybe
         end
 
-        # Author
+        def header_title
+          match("=") >> space? >> text.as(:title) >> newline
+        end
+
         def author
-          words.as(:first_name) >> str(",") >> space? >> words.as(:last_name) >>
-          space? >> str("<") >> email.as(:email) >> str(">") >> endline
+          words.as(:first_name) >> str(",") >>
+          space? >> words.as(:last_name) >>
+          space? >> str("<") >> email.as(:email) >> str(">") >> newline
         end
 
-        # Revision
         def revision
           (word >> (str(".") >> word).maybe).as(:number) >>
-          str(",") >> space? >> word.as(:date) >>
-          str(":") >> space? >> words.as(:remark) >> newline
+          str(",") >> space? >> date.as(:date ) >> str(":") >>
+          space? >> words.as(:remark) >> newline
         end
       end
     end

--- a/spec/coradoc/parser/asciidoc/header_spec.rb
+++ b/spec/coradoc/parser/asciidoc/header_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Coradoc::Asciidoc::Header" do
         = This is the title
         Given name, Last name <email@example.com>
         1.0, 2023-02-23: Version comment note
+        :string-attribute: this has to be a string
       TEXT
 
       ast = Asciidoc::HeaderTester.parse(header)


### PR DESCRIPTION
In recent changes, the parsing for header section seemed to be broken. This was caused by some changes on the words rules, so this commit fixes that.

This commit also tries to simplify the words rules, and it also bring all the rules in one place for better visibility.
