### PR TITLE
Add support for id in paragraph section

### DIFF
--- a/lib/coradoc/document/paragraph.rb
+++ b/lib/coradoc/document/paragraph.rb
@@ -3,8 +3,9 @@ module Coradoc
     class Paragraph
       attr_reader :content
 
-      def initialize(content, _options = {})
+      def initialize(content, options = {})
         @content = content
+        @meta = options.fetch(:meta, nil)
       end
 
       def id

--- a/lib/coradoc/parser/asciidoc/content.rb
+++ b/lib/coradoc/parser/asciidoc/content.rb
@@ -5,7 +5,8 @@ module Coradoc
         include Coradoc::Parser::Asciidoc::Base
 
         def paragraph
-          text_line.repeat(1)
+          paragraph_meta.as(:meta).maybe >>
+            text_line.repeat(1).as(:lines)
         end
 
         def glossaries
@@ -126,6 +127,12 @@ module Coradoc
         def text_id
           str("[[") >> keyword.as(:id) >> str("]]") |
             str("[#") >> keyword.as(:id) >> str("]")
+        end
+
+        def paragraph_meta
+          str("[") >>
+            keyword.as(:key) >> str("=") >>
+            word.as(:value) >> str("]") >> newline
         end
 
         def glossary

--- a/lib/coradoc/transformer.rb
+++ b/lib/coradoc/transformer.rb
@@ -38,6 +38,12 @@ module Coradoc
       Document::TextElement.new(text, id: id, line_break: line_break)
     end
 
+    # Paragraph
+    rule(paragraph: simple(:paragraph)) { paragraph }
+    rule(lines: sequence(:lines)) { Document::Paragraph.new(lines) }
+    rule(meta: simple(:meta), lines: sequence(:lines)) do
+      Document::Paragraph.new(lines, meta: meta)
+    end
 
     # Title Element
     rule(
@@ -55,10 +61,6 @@ module Coradoc
         Document::Title.new(text, level, line_break: line_break, id: name)
     end
 
-    # Paragraph
-    rule(paragraph: sequence(:paragraph)) do
-      Document::Paragraph.new(paragraph)
-    end
 
     # Section
     # rule(title: simple(:title)) { Document::Section.new(title) }

--- a/spec/coradoc/parser/asciidoc/content_spec.rb
+++ b/spec/coradoc/parser/asciidoc/content_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Coradoc::Asciidoc::Content" do
       TEXT
 
       ast = Asciidoc::ContentTester.parse(content)
-      lines = ast.first[:paragraph]
+      lines = ast.first[:paragraph][:lines]
 
       expect(lines[0][:text]).to eq("This is are the sample text for content")
       expect(lines[1][:text]).to eq("It can be distrubuted in multiple lines")
@@ -154,7 +154,7 @@ RSpec.describe "Coradoc::Asciidoc::Content" do
 
       ast = Asciidoc::ContentTester.parse(content)
       glossaries = ast.first[:glossaries]
-      lines = ast[1][:paragraph]
+      lines = ast[1][:paragraph][:lines]
 
       expect(glossaries[0][:key]).to eq("Clause")
       expect(glossaries[0][:value]).to eq("5.1")
@@ -176,9 +176,9 @@ RSpec.describe "Coradoc::Asciidoc::Content" do
       TEXT
 
       ast = Asciidoc::ContentTester.parse(content)
-      paragraph_one = ast[0][:paragraph]
-      paragraph_two = ast[1][:paragraph]
-      paragraph_three = ast[2][:paragraph]
+      paragraph_one = ast[0][:paragraph][:lines]
+      paragraph_two = ast[1][:paragraph][:lines]
+      paragraph_three = ast[2][:paragraph][:lines]
 
       expect(paragraph_one[0][:id]).to eq("id_1.1_part_1")
       expect(paragraph_one[0][:text]).to eq("This is the content with id")
@@ -187,6 +187,23 @@ RSpec.describe "Coradoc::Asciidoc::Content" do
       expect(paragraph_two[0][:id]).to eq("guidance_5.1_part_1")
       expect(paragraph_three[0][:id]).to eq("guidance_5.1_part_2")
       expect(paragraph_two[0][:text]).to eq("At highest level organization")
+    end
+
+    context "paragraph" do
+      it "parses paragraph with id" do
+        content = <<~TEXT
+          [id=myblock]
+          This is my block with a defined ID.
+          this is going to be the next line
+        TEXT
+
+        ast = Asciidoc::ContentTester.parse(content)
+        paragraph = ast[0][:paragraph]
+
+        expect(paragraph[:meta][:key]).to eq("id")
+        expect(paragraph[:meta][:value]).to eq("myblock")
+        expect(paragraph[:lines][0][:text]).to eq("This is my block with a defined ID.")
+      end
     end
 
     it "parses list embeded in the content" do
@@ -237,7 +254,7 @@ RSpec.describe "Coradoc::Asciidoc::Content" do
 
       expect(ast[0][:highlight][:id]).to eq("scls_5-9")
       expect(ast[0][:highlight][:text]).to eq("Ownership")
-      expect(ast[1][:paragraph][0][:text]).to eq("This is a pragraph block")
+      expect(ast[1][:paragraph][:lines][0][:text]).to eq("This is a pragraph block")
     end
   end
 end

--- a/spec/coradoc/parser/asciidoc/section_spec.rb
+++ b/spec/coradoc/parser/asciidoc/section_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe "Coradoc::Asciidoc::Section" do
       TEXT
 
       ast = Asciidoc::SectionTester.parse(section)
+      paragraph = ast.first[:contents][0][:paragraph]
 
       expect(ast.first[:title][:level]).to eq("==")
       expect(ast.first[:title][:text]).to eq("Section title")
-      expect(ast.first[:contents][0][:paragraph][0][:text]).to eq("Section content")
+      expect(paragraph[:lines][0][:text]).to eq("Section content")
     end
 
     it "it parses section id, title and body" do
@@ -23,11 +24,12 @@ RSpec.describe "Coradoc::Asciidoc::Section" do
       TEXT
 
       ast = Asciidoc::SectionTester.parse(section)
+      paragraph = ast.first[:contents][0][:paragraph]
 
       expect(ast.first[:id]).to eq("section_id")
       expect(ast.first[:title][:level]).to eq("==")
       expect(ast.first[:title][:text]).to eq("Section title")
-      expect(ast.first[:contents][0][:paragraph][0][:text]).to eq("Section content")
+      expect(paragraph[:lines][0][:text]).to eq("Section content")
     end
 
     it "it parses legacy section id" do
@@ -121,9 +123,9 @@ RSpec.describe "Coradoc::Asciidoc::Section" do
       expect(ast.first[:id]).to eq("section_id")
       expect(ast.first[:title][:level]).to eq("==")
       expect(ast.first[:title][:text]).to eq("Section title")
-      expect(contents[0][:paragraph][0][:text]).to eq("Section content")
-      expect(contents[1][:paragraph][0][:id]).to eq("inline_id")
-      expect(contents[1][:paragraph][0][:text]).to eq("This is inline id")
+      expect(contents[0][:paragraph][:lines][0][:text]).to eq("Section content")
+      expect(contents[1][:paragraph][:lines][0][:id]).to eq("inline_id")
+      expect(contents[1][:paragraph][:lines][0][:text]).to eq("This is inline id")
 
       sub_sections = ast.first[:sections]
       expect(sub_sections[0][:id]).to eq("section_id_two")

--- a/spec/coradoc/parser_spec.rb
+++ b/spec/coradoc/parser_spec.rb
@@ -39,15 +39,15 @@ RSpec.describe Coradoc::Parser do
 
       guidance = clause_5_1[:sections][2]
       expect(guidance[:contents].count).to eq(16)
-      expect(guidance[:contents][0][:paragraph][0][:id]).to eq("guidance_5.1_part_1")
-      expect(guidance[:contents][1][:paragraph][0][:id]).to eq("guidance_5.1_part_2")
+      expect(guidance[:contents][0][:paragraph][:lines][0][:id]).to eq("guidance_5.1_part_1")
+      expect(guidance[:contents][1][:paragraph][:lines][0][:id]).to eq("guidance_5.1_part_2")
 
       list_one_items = guidance[:contents][2][:list][:unnumbered]
       expect(list_one_items.count).to eq(3)
       expect(list_one_items[0][:text]).not_to be_nil
       expect(list_one_items[0][:id]).to eq("guidance_5.1_part_2_1")
 
-      expect(guidance[:contents][3][:paragraph][0][:id]).not_to be_nil
+      expect(guidance[:contents][3][:paragraph][:lines][0][:id]).not_to be_nil
       expect(guidance[:contents][4][:list][:unnumbered].count).to eq(7)
       expect(guidance[:contents][8][:list][:unnumbered].count).to eq(12)
       expect(guidance[:contents][10][:list][:unnumbered].count).to eq(6)


### PR DESCRIPTION
This commit adds support for `id` and other attributes as meta for the `paragraph` element. This commit also restructures the paragraph elements to be more descriptive.

This might require some adjustment to the existing content we might be using in any of those library.