### PR TITLE
Ensure support for all metadata attributes

### DIFF
--- a/spec/coradoc/document/attribute_spec.rb
+++ b/spec/coradoc/document/attribute_spec.rb
@@ -11,5 +11,15 @@ RSpec.describe Coradoc::Document::Attribute do
       expect(attribute.key).to eq(key)
       expect(attribute.value).to eq(value)
     end
+
+    it "exposes comma separated values as an array" do
+      key = "comma-separted-values"
+      value = "html,pdf,xml, adoc"
+
+      attribute = Coradoc::Document::Attribute.new(key, value)
+
+      expect(attribute.key).to eq(key)
+      expect(attribute.value).to eq(value.split(",").map(&:strip))
+    end
   end
 end

--- a/spec/coradoc/parser/asciidoc/bibdata_spec.rb
+++ b/spec/coradoc/parser/asciidoc/bibdata_spec.rb
@@ -9,19 +9,27 @@ RSpec.describe "Coradoc::Asciidoc::Bibdata" do
         :version: '1.0'
         :oscal-version: 1.0.0
         :remarks: OSCAL from ISO27002:2022
+        :mn-output-extensions: xml,html,doc,html_alt
+        :title-main-fr: Spécification et méthodes d'essai
       DOC
 
-      ast = Asciidoc::BibdataTester.parse(bibdata)
+      ast = Asciidoc::BibdataTester.parse(bibdata).first
 
-      expect(ast.first[:bibdata].count).to eq(5)
-      expect(ast.first[:bibdata][0][:key]).to eq("published")
-      expect(ast.first[:bibdata][0][:value]).to eq("'2023-03-08T09:51:08+08:00'")
+      expect(ast[:bibdata].count).to eq(7)
+      expect(ast[:bibdata][0][:key]).to eq("published")
+      expect(ast[:bibdata][0][:value]).to eq("'2023-03-08T09:51:08+08:00'")
 
-      expect(ast.first[:bibdata][2][:key]).to eq("version")
-      expect(ast.first[:bibdata][2][:value]).to eq("'1.0'")
+      expect(ast[:bibdata][2][:key]).to eq("version")
+      expect(ast[:bibdata][2][:value]).to eq("'1.0'")
 
-      expect(ast.first[:bibdata][4][:key]).to eq("remarks")
-      expect(ast.first[:bibdata][4][:value]).to eq("OSCAL from ISO27002:2022")
+      expect(ast[:bibdata][4][:key]).to eq("remarks")
+      expect(ast[:bibdata][4][:value]).to eq("OSCAL from ISO27002:2022")
+
+      expect(ast[:bibdata][5][:key]).to eq("mn-output-extensions")
+      expect(ast[:bibdata][5][:value]).to eq("xml,html,doc,html_alt")
+
+      expect(ast[:bibdata][6][:key]).to eq("title-main-fr")
+      expect(ast[:bibdata][6][:value]).to eq("Spécification et méthodes d'essai")
     end
 
   end


### PR DESCRIPTION
In the authoring document, we are specifying what kind of attributes we do support in the metanorma. This commit adds some example cases to ensure we do support all of these cases.

Link: https://www.metanorma.org/author/topics/metadata/
