### PR TITLE
[DO-NOT-MERGE] Toolset for combining coradoc & reverse_adoc

### DIFF
--- a/migration/README_reverse_adoc_post_migration.adoc
+++ b/migration/README_reverse_adoc_post_migration.adoc
@@ -1,0 +1,6 @@
+# AsciiDoc from HTML and Microsoft Word: reverse_adoc
+
+This repository has been merged into Coradoc. See:
+
+* https://github.com/metanorma/coradoc/
+* https://github.com/metanorma/coradoc/tree/main/lib/coradoc/reverse_adoc

--- a/migration/migration.sh
+++ b/migration/migration.sh
@@ -27,7 +27,7 @@ pushd reverse_adoc
   sed -i 's|require "reverse_adoc|require "coradoc/reverse_adoc|g' exe/* `find spec/ -name \*.rb`
   sed -i 's/ReverseAdoc/Coradoc::ReverseAdoc/g' exe/* `find lib/ spec/ -name \*.rb`
   sed -i 's|"spec/assets/|"spec/reverse_adoc/assets/|g' `find spec/ -name \*.rb`
-  sed -i 's|require_relative "reverse_adoc/version"|require_relative "coradoc"|g' lib/coradoc/reverse_adoc.rb
+  sed -i 's|require_relative "reverse_adoc/version"|require_relative "../coradoc"|g' lib/coradoc/reverse_adoc.rb
   sed -i 's|"spec", "support"|"spec", "reverse_adoc", "support"|g' spec/reverse_adoc/spec_helper.rb
 
   git add .
@@ -39,7 +39,7 @@ pushd reverse_adoc
   git rm Gemfile
   git rm Rakefile # Needs merge
   git rm .gitignore # Needs merge
-  git rm .github/workflows/rake.yml # Needs merge: generic-rake.yml vs libreoffice-rake.yml
+  git rm .github/workflows/rake.yml
   git rm .github/workflows/release.yml
 
   git commit -m 'Merger: Remove files that are not applicable anymore'
@@ -59,9 +59,14 @@ pushd coradoc
   git add coradoc.gemspec
   git commit -m 'Merger: Combine gemspec files'
 
-  echo 'require "reverse_adoc/spec_helper"' >> spec/spec_helper.rb
+  git rm spec/reverse_adoc/spec_helper.rb
+  cp ../spec_helper_coradoc.rb spec/spec_helper.rb
   git add spec/spec_helper.rb
   git commit -m 'Merger: Combine spec helpers'
+
+  sed -i 's/generic-rake.yml/libreoffice-rake.yml/g' .github/workflows/rake.yml
+  git add .github/workflows/rake.yml
+  git commit -m 'Merger: Combine GitHub Actions'
 popd
 
 pushd reverse_adoc_post_migration
@@ -70,4 +75,10 @@ pushd reverse_adoc_post_migration
   cp ../reverse_adoc_post_migration.gemspec reverse_adoc.gemspec
   git add README.adoc reverse_adoc.gemspec
   git commit -m 'Merger: Replace reverse_adoc with a stub gem'
+popd
+
+# Ensure everything works correctly
+pushd coradoc
+  bundle install
+  bundle exec rake
 popd

--- a/migration/migration.sh
+++ b/migration/migration.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euxo pipefail # Abort on error
+
+GH_PREFIX="$1"
+
+rm -rf coradoc reverse_adoc reverse_adoc_post_migration
+
+# The resulting repository.
+git clone $GH_PREFIX/metanorma/coradoc/ coradoc
+# The reverse_adoc repo will need to have been amended - it will need to have no
+# duplicate files to the Coradoc repo, so that we could merge both cleanly.
+git clone $GH_PREFIX/metanorma/reverse_adoc/ reverse_adoc
+# Post migration repo, to preserve the Gem name and provide a smooth upgrade path.
+git clone $GH_PREFIX/metanorma/reverse_adoc/ reverse_adoc_post_migration
+
+pushd reverse_adoc
+  mkdir lib/coradoc
+  git mv lib/reverse_adoc* lib/coradoc/
+  ALL_SPEC_FILES=`ls -d spec/*` # So that we skip spec/reverse_adoc from this calculation
+  mkdir -p spec/reverse_adoc
+  git mv $ALL_SPEC_FILES spec/reverse_adoc/
+  git mv README.adoc LICENSE.txt lib/coradoc/reverse_adoc/
+
+  git commit -m 'Merger: Move reverse_adoc files to not conflict with Coradoc files'
+
+  sed -i 's|require "reverse_adoc|require "coradoc/reverse_adoc|g' exe/* `find spec/ -name \*.rb`
+  sed -i 's/ReverseAdoc/Coradoc::ReverseAdoc/g' exe/* `find lib/ spec/ -name \*.rb`
+  sed -i 's|"spec/assets/|"spec/reverse_adoc/assets/|g' `find spec/ -name \*.rb`
+  sed -i 's|require_relative "reverse_adoc/version"|require_relative "coradoc"|g' lib/coradoc/reverse_adoc.rb
+  sed -i 's|"spec", "support"|"spec", "reverse_adoc", "support"|g' spec/reverse_adoc/spec_helper.rb
+
+  git add .
+  git commit -m 'Merger: Rename ReverseAdoc to Coradoc::ReverseAdoc'
+
+  git rm lib/coradoc/reverse_adoc/version.rb
+  git rm .rubocop.yml
+  git rm .hound.yml
+  git rm Gemfile
+  git rm Rakefile # Needs merge
+  git rm .gitignore # Needs merge
+  git rm .github/workflows/rake.yml # Needs merge: generic-rake.yml vs libreoffice-rake.yml
+  git rm .github/workflows/release.yml
+
+  git commit -m 'Merger: Remove files that are not applicable anymore'
+popd
+
+pushd coradoc
+  git fetch ../reverse_adoc
+  git merge --allow-unrelated-histories FETCH_HEAD -m 'Merger: Merge reverse_adoc repository into coradoc'
+
+  cat *.gemspec  | grep dependency | sed -r 's/ s\./ spec./' | sort | uniq | grep -v coradoc > ../combined_dependencies
+  cat coradoc.gemspec | grep -v dependency | grep -Ev '^end' > ../new_gemspec
+  cat ../combined_dependencies >> ../new_gemspec
+  echo end >> ../new_gemspec
+
+  git rm reverse_adoc.gemspec
+  mv ../new_gemspec coradoc.gemspec
+  git add coradoc.gemspec
+  git commit -m 'Merger: Combine gemspec files'
+
+  echo 'require "reverse_adoc/spec_helper"' >> spec/spec_helper.rb
+  git add spec/spec_helper.rb
+  git commit -m 'Merger: Combine spec helpers'
+popd
+
+pushd reverse_adoc_post_migration
+  find -type f | grep -Fv 'release.yml' | grep -Fv '.git/' | xargs git rm
+  cp ../README_reverse_adoc_post_migration.adoc README.adoc
+  cp ../reverse_adoc_post_migration.gemspec reverse_adoc.gemspec
+  git add README.adoc reverse_adoc.gemspec
+  git commit -m 'Merger: Replace reverse_adoc with a stub gem'
+popd

--- a/migration/migration.sh
+++ b/migration/migration.sh
@@ -25,7 +25,7 @@ pushd reverse_adoc
   git commit -m 'Merger: Move reverse_adoc files to not conflict with Coradoc files'
 
   sed -i 's|require "reverse_adoc|require "coradoc/reverse_adoc|g' exe/* `find spec/ -name \*.rb`
-  sed -i 's/ReverseAdoc/Coradoc::ReverseAdoc/g' exe/* `find lib/ spec/ -name \*.rb`
+  sed -i 's/ReverseAdoc/Coradoc::ReverseAdoc/g' exe/* `find lib/ spec/ -name \*.rb` lib/coradoc/reverse_adoc/README.adoc
   sed -i 's|"spec/assets/|"spec/reverse_adoc/assets/|g' `find spec/ -name \*.rb`
   sed -i 's|require_relative "reverse_adoc/version"|require_relative "../coradoc"|g' lib/coradoc/reverse_adoc.rb
   sed -i 's|"spec", "support"|"spec", "reverse_adoc", "support"|g' spec/reverse_adoc/spec_helper.rb
@@ -37,8 +37,8 @@ pushd reverse_adoc
   git rm .rubocop.yml
   git rm .hound.yml
   git rm Gemfile
-  git rm Rakefile # Needs merge
-  git rm .gitignore # Needs merge
+  git rm Rakefile # Needs manual merge
+  git rm .gitignore # Needs manual merge
   git rm .github/workflows/rake.yml
   git rm .github/workflows/release.yml
 

--- a/migration/reverse_adoc_post_migration.gemspec
+++ b/migration/reverse_adoc_post_migration.gemspec
@@ -1,0 +1,27 @@
+# -*- encoding: utf-8 -*-
+
+$:.push File.expand_path("lib", __dir__)
+require "reverse_adoc/version"
+
+Gem::Specification.new do |s|
+  s.name        = "reverse_adoc"
+  s.version     = "2.0.0"
+  s.authors       = ["Ribose Inc."]
+  s.email         = ["open.source@ribose.com"]
+
+  s.homepage    = "http://github.com/metanorma/reverse_adoc"
+  s.summary     = "Generate AsciiDoc from HTML and Microsoft Word via CLI or library."
+  s.description = "Generate AsciiDoc from HTML and Microsoft Word via CLI or library."
+  s.license       = "BSD-2-Clause"
+
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- exe/*`.split("\n").map do |f|
+    File.basename(f)
+  end
+  s.bindir        = "exe"
+  s.require_paths = ["lib"]
+  s.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+
+  s.add_dependency "coradoc", ">= 0.3"
+end

--- a/migration/spec_helper_coradoc.rb
+++ b/migration/spec_helper_coradoc.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "simplecov"
+require "coradoc"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  SimpleCov.profiles.define "gem" do
+    add_filter "/spec/"
+    add_filter "/autotest/"
+    add_group "Libraries", "/lib/"
+  end
+  SimpleCov.start "gem"
+
+  # ReverseAdoc:
+  config.after(:each) do
+    Coradoc::ReverseAdoc.instance_variable_set(:@config, nil)
+  end
+end
+
+# ReverseAdoc:
+require "coradoc/reverse_adoc"
+require "coradoc/reverse_adoc/html_converter"
+require "word-to-markdown"
+
+Dir[File.join("spec", "reverse_adoc", "support", "**", "*.rb")]
+  .each { |f| require File.join(".", f) }
+
+def node_for(html)
+  Nokogiri::HTML.parse(html).root.child.child
+end


### PR DESCRIPTION
This PR is NOT intended to be merged. It is merely a showcase of our current work at merging reverse_adoc into coradoc. A request for comments of sorts.

We will proceed with this merger once all remaining pull requests in reverse_adoc repository have been merged.

The approach is to use a migration script to:
1. Modify reverse_adoc, to create a repository in a state of no files having a duplicate name with coradoc repo
2. Rename ReverseAdoc class to Coradoc::ReverseAdoc
3. Git merge reverse_adoc into coradoc
4. Merge other contents manually
5. Finally, change reverse_adoc repository into a stub repo, so that users of reverse_adoc will have a clean path to update.

This approach will preserve git history for both repositories, merging them together.

Ref: #51

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
