### PR TITLE
Reverse_adoc: Trim positional atributes

### DIFF
--- a/lib/coradoc/element/attribute_list.rb
+++ b/lib/coradoc/element/attribute_list.rb
@@ -44,6 +44,8 @@ module Coradoc
             @rejected_positional << [i, value]
           end
         end
+
+        @positional.pop while !@positional.empty? && @positional.last.nil?
       end
 
       def validate_named(validators)
@@ -62,7 +64,7 @@ module Coradoc
         return "[]" if [@positional, @named].all?(:empty?)
 
         adoc = +""
-        if @positional.any?
+        if !@positional.empty?
           adoc << @positional.map { |p| [nil, ""].include?(p) ? '""' : p }.join(",")
         end
         adoc << "," if @positional.any? && @named.any?

--- a/lib/coradoc/reverse_adoc/converters/img.rb
+++ b/lib/coradoc/reverse_adoc/converters/img.rb
@@ -80,7 +80,7 @@ module Coradoc::ReverseAdoc
         if alt # && !alt.to_s.empty?
           attributes.add_positional(alt)
         elsif width || height
-          attributes.add_positional("")
+          attributes.add_positional(nil)
         end
         attributes.add_named("title", title) if title && !title.empty?
         attributes.add_positional(width) if width

--- a/spec/reverse_adoc/lib/reverse_adoc/converters/img_spec.rb
+++ b/spec/reverse_adoc/lib/reverse_adoc/converters/img_spec.rb
@@ -22,4 +22,9 @@ describe Coradoc::ReverseAdoc::Converters::Img do
     node = node_for("<img id='A' src='example.jpg' width='30' height='40'/>")
     expect(converter.convert(node)).to include "[[A]]\nimage::example.jpg[\"\",30,40]"
   end
+
+  it "converts image with invalid set of attributes" do
+    node = node_for("<img src='example.jpg' width='-30' height=''/>")
+    expect(converter.convert(node)).to include "image::example.jpg[]"
+  end
 end


### PR DESCRIPTION
The problem was with invalid attributes for images

This fixes #70 

This changes the resulting AsciiDoc of the incoming document the following way:

```diff
diff -Naur _prev/sections/section-01.adoc _curr/sections/section-01.adoc
--- _prev/sections/section-01.adoc      2024-05-30 22:52:54.793143900 +0200
+++ _curr/sections/section-01.adoc      2024-05-30 22:52:31.491152275 +0200
@@ -43,7 +43,7 @@
 
 各都市での拡張製品仕様書の作成に必要なテンプレートの一式は、3D都市モデル標準製品仕様書HTML版ウェブページ（ link:plateaudocument[https://www.mlit.go.jp/plateaudocument/]）より入手できる。
 
-image::images/001.webp["","","",title=" 図 1-1　本書の位置づけ"]
+image::images/001.webp[title=" 図 1-1　本書の位置づけ"]
 
 [[toc1_03]]
 === 　製品の範囲
diff -Naur _prev/sections/section-04.adoc _curr/sections/section-04.adoc
--- _prev/sections/section-04.adoc      2024-05-30 22:52:54.793143900 +0200
+++ _curr/sections/section-04.adoc      2024-05-30 22:52:31.491152275 +0200
@@ -41,7 +41,7 @@
 
 3D都市モデル応用スキーマは、CityGML及びi-URを引用する。さらに、CityGMLはGMLを引用し、i-URはCityGML及びGMLを引用している。
 
-image::images/002.svg["","",""]
+image::images/002.svg[]
 
 　
 
@@ -51,7 +51,7 @@
 
 　
 
-image::images/003.svg["","",""]
+image::images/003.svg[]
 
 　
 
@@ -138,19 +138,19 @@
 .表 4-4　応用スキーマクラス図の表記
 |===
 ^h| 表記 ^h| 意味
-a| image::images/004.webp["",200,""]
+a| image::images/004.webp["",200]
 | クラス。 クラスは3段の箱により記述する。 1段目の箱には、ステレオタイプ（クラスの種類）とクラス名を記述する。クラス名には、表 4-3に示す接頭辞を付ける。 2段目の箱には、クラスの属性を記述する。 3段目の箱は使用しない。 クラスの属性は、属性名、属性の型、属性の多重度から構成する。 属性の型は、属性が取る値の種類を指定する。xs:string（文字列型）のような基本的な型やgml:Solidのような幾何オブジェクト、あるいは、応用スキーマで定義した別のクラスを指定できる。 基本的な型は、4.1.5に定義を示す。 応用スキーマクラス図では、属性名の前に「＋」の記号が表示される。 これはUMLクラス図において、他のクラスからその属性を表示し、使用できるかどうか（可視性）を示す。 ただし、応用スキーマクラス図では可視性を使用しないため、無視してよい。 属性の多重度は、その属性が繰り返し出現可能な回数を指定する。 [a..b]のように指定し、a及びbは、a<=j<=b となる任意の整数 j を意味する。[a..a]は、[a]と同じとみなす。以下のような記載方法がある。 [0..1] ：0又は1 [0..*] ：0 以上 [1..*] ：1 以上 [m]　：m [m..n] ：m 以上 n [m,n] ：m 又は n なお、属性の多重度を省略することもできる。省略された場合は、1となる。
 
-a| image::images/005.webp["",200,""]
+a| image::images/005.webp["",200]
 | 継承。 元となるクラス（上位クラス）の特性を受け継ぐ新しいクラス（下位クラス）との関係を意味する。継承を実装する場合、下位クラスのインスタンス（データ）は，自分自身に定義された属性や関連役割だけではなく、上位クラスに定義された属性や関連役割もつ。 △が付く側（Class1）が元となるクラスである。 なお、後述する関連とは異なり、上位のクラスと下位のクラスのインスタンスは、互いへの参照はもたない。あくまで、下位のクラスのインスタンスが、上位のクラスに定義された属性等を記述するデータ構造をもつことだけを意味する。
 
-a| image::images/006.webp["",200,""]
+a| image::images/006.webp["",200]
 | 関連。 二つのクラス間に関係性があることを意味する。 関連役割名は、この関連における役割を示す。また、関連には多重度を指定できる。多重度は、相手のクラス1に対して関連する自分の数を記載する。 多重度の記法は、属性の多重度と同じである。また、多重度が省略された場合は1となる。 関連を実装する場合、関連役割名をつけた属性として、他方のクラスのインスタンスへの参照をもたせる。 関連には向きをつけることができる。向きは矢印により記述する。関連に向きが付けられた場合、参照は片方向となる。すなわち、例図の場合にはClass1のインスタンスがClass2のインスタンスへの参照ともつが、Class2のインスタンスはClass1のインスタンスへの参照をもたない。 CityGMLでは、都市オブジェクトと幾何オブジェクトとの間に関連が定義されている。これにより、都市オブジェクトは幾何オブジェクトへの参照をもつことができる。例えば、道路の幾何オブジェクトとして面を作成した場合に、その面を航路の幾何オブジェクトとして参照することができる。
 
-a| image::images/007.webp["",200,""]
+a| image::images/007.webp["",200]
 | 集成。 二つのクラス間に全体と部分という関係がある関連である。全体となるクラス側に白いひし形を記述する。 関連役割名は、この関連における役割を示す。また、関連には多重度を指定できる。多重度は、相手のクラス1に対して関連する自分の数を記載する。 多重度の記法は、属性の多重度と同じである。また、多重度が省略された場合は1となる。また、向きをつけることができる。 集成を実装する場合、関連役割名をつけた属性として、他方のクラスのインスタンスへの参照をもたせる、又は、部品となるクラスのインスタンスを、全体となるクラスのインスタンスの内部に記述する。 なお、標準製品仕様書では、集成の実装は、部品となるクラスのインスタンスを、全体となるクラスのインスタンスの内部に記述することを原則とする。部品となるクラスは、他のクラスのインスタンスから参照してもよい。 CityGMLでは、uro:Building（建築物）とuro:WallSurface（外壁面）との間に集成関連が定義されている。このとき、建築物が全体となり外壁面はその部品となる。
 
-a| image::images/008.webp["",200,""]
+a| image::images/008.webp["",200]
 | 合成。 二つのクラス間に全体と部分という関係がさらに強固な関連である。全体となるクラス側に黒いひし形を記述する。合成は、全体となるクラスが無くなった場合に、部分となるクラスも無くなる関係に用いる。 関連役割名や多重度の表記は、集成と同様である。 合成を実装する場合、部品となるクラスのインスタンスを、全体となるクラスのインスタンスの内部に記述する。
 
 |===
@@ -349,8 +349,8 @@
 .表 4-7　建築物モデル（LOD0）の取得イメージ
 |===
 2+^| LOD0
-a| image::images/009.webp["",300,""]
-a| image::images/010.webp["",300,""]
+a| image::images/009.webp["",300]
+a| image::images/010.webp["",300]
 
 ^| RoofEdge ^| FootPrint
 
@@ -392,7 +392,7 @@
 .表 4-8　建築物モデル（LOD1）の取得イメージ
 |===
 ^h| LOD1
-a| image::images/011.webp["",300,""]
+a| image::images/011.webp["",300]
 
 |===
 
@@ -497,7 +497,7 @@
 
 建築物モデル（LOD2）に含むべき地物は、建築物の以下に示す部分をいう。
 
-image::images/012.webp["","","",title=" 図 4-1　建築物モデル（LOD2）に含むべき地物"]
+image::images/012.webp[title=" 図 4-1　建築物モデル（LOD2）に含むべき地物"]
 
 　
 
@@ -508,15 +508,15 @@
 |===
 ^h| LOD ^h| LOD2.0 ^h| LOD2.1 ^h| LOD2.2
 ^h| 取得例
-^a| image::images/013.webp["",200,""]
-a| image::images/014.webp["",220,""]
-a| image::images/015.webp["",220,""]
+^a| image::images/013.webp["",200]
+a| image::images/014.webp["",220]
+a| image::images/015.webp["",220]
 
 ^h| 説明 | 屋根の主要な外形が再現される。LOD2.0では付属物は取得しないため、バルコニーも屋根として取得する。 なお、LOD2では屋根面は詳細化されるが壁面は詳細化されないため、バルコニーの下部も建築物の一部として表現される。 | 小屋根のうち規模が大きいものが再現される。LOD2.0では切妻屋根として表現されたが、LOD2.1の条件を満たしたため、小屋根として表現された。 また、LOD2.1の条件を満たすバルコニーが、付属物として区分される。 | 小屋根のうち規模の小さいものが再現される。LOD2.1では無視された屋根窓の屋根がLOD2.2の条件を満たしたため、この屋根形状が表現された。 また、LOD2.2の条件を満たす屋根上の煙突が付属物として、さらに区分される。
 
 |===
 
-image::images/016.webp["","",""]
+image::images/016.webp[]
 
 　
 
@@ -540,7 +540,7 @@
 屋根の棟及び谷で区切ることにより、屋根の傾斜や向きを再現する。 +
 屋根の棟及び谷は、以下を指す。
 
-image::images/017.webp["",150,""]
+image::images/017.webp["",150]
 
 曲面の場合は、データセットが採用する地図情報レベルの水平及び高さの誤差の標準偏差に収まるよう平面に分割する。
 
@@ -839,7 +839,7 @@
 
 建築物モデル（LOD3）では、建築物モデル（LOD2）に含むべき地物に加え、開口部（窓及び扉）が追加される。また、建築物の側面が詳細化されるが、屋根の外周と外壁面との距離や壁面の大きさにより、各LODにおいて表現される内容が異なる（図 4-2）。
 
-image::images/018.webp["","","",title=" 図 4-2　建築物モデル（LOD3）に含むべき地物と取得基準"]
+image::images/018.webp[title=" 図 4-2　建築物モデル（LOD3）に含むべき地物と取得基準"]
 
 　
 
@@ -850,19 +850,19 @@
 |===
 h| ^h| 取得イメージ ^h| 説明
 h| LOD3.0
-a| image::images/019.webp["",450,""]
+a| image::images/019.webp["",450]
 | 屋根のうち短辺3m以上の屋根面が表現される。 付属物のうち、短辺3m以上の規模の大きな付属物が再現される。 LOD3では壁面が詳細化されるため、LOD2では表現されない付属物の下部の形状も表現される。 また、外壁面に設けられた短辺1m以上の開口部（窓、扉）が再現される。 なお、上図の場合、軒裏は3m以内であったため、表現されなかった。 下図に3m以上の軒を表現した例を示す。LOD3.0において軒を表現する建築物として、寺社や城といった特殊な建築物あるいは倉庫等の規模が大きな建築物が該当する。
 
 h| LOD3.1
-a| image::images/020.webp["",430,""]
+a| image::images/020.webp["",430]
 | 短辺の実長1m以上かつ上方からの正射影の面積3m2以上の屋根面が表現される。 この結果、左図の例では、LOD3.0では切妻屋根として表現されたが、LOD3.1の条件を満たしたため、入母屋屋根として表現された。 また、この例図では、軒裏の距離が1m以上あったため、表現された。 開口部及び屋外付属物の表現は、LOD3.0と同様の表現となる。
 
 h| LOD3.2
-a| image::images/021.webp["",400,""]
+a| image::images/021.webp["",400]
 | LOD3.2ではさらに詳細な表現が可能となり、短辺の実長1m 以上又は上方からの正射影の面積1m2 以上の屋根が再現される。 左図の例では、屋根に設けられた小屋根がこの条件に該当し、再現されている。 また、LOD3.2では、短辺が実長1m以上又は上方又は側方からの正射影の面積1m2以上の屋外付属物が表現される。 左図の例では、屋根上の煙突と外壁面に設けられた庇がこの条件を満たしたため屋外付属物として表現された。 LOD3.2では、面積1m2以上の窓や扉も表現されるため、この条件に該当する窓が追加された。
 
 h| LOD3.3
-a| image::images/022.webp["",400,""]
+a| image::images/022.webp["",400]
 | LOD3.3では、短辺の実長が1m未満の細かな屋根の形状が表現される。 左図の例では、LOD3.1及びLOD3.2では1枚の屋根面として表現されていたが、LOD3.3では傾斜の異なる2枚の屋根面として区分された。 また、軒裏のうち、屋根の外周との距離が1m未満の狭い軒裏も表現された。 さらに、LOD3.3の条件を満たす1m未満の小さな開口部や付属物が追加された。
 
 |===
@@ -888,7 +888,7 @@
 a| 
 • 屋根の棟及び谷で区切ることにより、屋根の傾斜や向きを再現する。屋根の棟及び谷は、以下を指す。
 
-image::images/023.webp["",150,""]
+image::images/023.webp["",150]
 
 • 曲面の場合は、データセットが採用する地図情報レベルの水平及び高さの誤差の標準偏差に収まるよう平面に分割する。
 
@@ -921,7 +921,7 @@
 | 幅3m以上の軒裏
 a| • 屋根の外周と、地表と外壁面との交線により囲まれた面を取得する。 +
 • 高さは、各頂点の高さとする。
-a| image::images/024.webp["",150,""]
+a| image::images/024.webp["",150]
 
 | LOD3.0 | ■ | BuildingPart | Solid | 1棟の建築物を、属性の異なる複数の部分に分ける場合に必須とする。 | • 屋根面（RoofSurface）、外壁面（WallSurface）、底面（GroundSurface）、閉鎖面（ClosureSurface）、扉（Door）及び窓（Window）を境界面とする立体を作成する。 | 
 | LOD3.0 | ■ | ClosureSurface | MultiSurface | BuildingPartを作成する場合に必須とする。 | • BuildingPartと連続するBuildingPartとの境界線により囲まれた面を取得する。 | 
@@ -1308,7 +1308,7 @@
 
 建築物モデル（LOD4）に含むべき地物を、図 4-3に示す。
 
-image::images/025.webp["","","",title=" 図 4-3　建築物モデル（LOD4）に含むべき地物"]
+image::images/025.webp[title=" 図 4-3　建築物モデル（LOD4）に含むべき地物"]
 
 　
 
@@ -1321,7 +1321,7 @@
 | LOD4.0
 a| 
 
-image::images/026.webp["",750,""]
+image::images/026.webp["",750]
 
 LOD4.0は建築物の外形（上図1）に加え、建築物の内部を表現する。このとき、建築物の内部は部屋（bldg:Room）に区切られ、各部屋の形状は立体として表現する（上図2）。また、部屋の立体の境界面は、天井面（bldg:CeilingSurface）、内壁面（bldg:InteriorWallSurface）、床面（bldg:FloorSurface）又は閉鎖面（bldg:ClosureSurface）のいずれかに区分する（上図３）。さらに、各部屋の天井面、内壁面又は床面に存在する扉（bldg:Door）及び窓（bldg:Window）を区分する（上図４）。 +
 閉鎖面は、境界面となる内壁面や天井面、床面はないが、建築確認申請では部屋となっている空間を区切る場合に仮想的な境界面として使用する。 +
@@ -1332,7 +1332,7 @@
 | LOD4.1
 a| 
 
-image::images/027.webp["",600,""]
+image::images/027.webp["",600]
 
 LOD4.1ではLOD4.0に、屋内の付属物（bldg:IntBuildingInstallation）として、階段、スロープ、輸送設備（エスカレータ、エレベータ及び動く歩道）、柱及びデッキ・ステージが追加される。 +
 上図の例では、LOD4.0に加えて、階段、踊り場、エレベータ、柱が付属物として追加された。
@@ -1340,7 +1340,7 @@
 | LOD4.2
 a| 
 
-image::images/028.webp["",600,""]
+image::images/028.webp["",600]
 
 LOD4.2ではLOD4.1に屋内の付属物（bldg:IntBuildingInstallation）として、手すり、パネル及び梁が付属物として追加される。 +
 また、机やいすなどの移動可能な家具（bldg:BuildingFurniture）が追加される。 +
@@ -1371,7 +1371,7 @@
 • 屋根の棟及び谷で区切ることにより、屋根の傾斜や向きを再現する。 +
 屋根の棟及び谷は、以下を指す。
 
-image::images/029.webp["",150,""]
+image::images/029.webp["",150]
 
 •曲面の場合は、データセットが採用する地図情報レベルの水平及び高さの誤差の標準偏差に収まるよう平面に分割する。
 
@@ -1754,7 +1754,7 @@
 
 ===== (1)　Buiding（CityGML）
 
-image::images/030.svg["","",""]
+image::images/030.svg[]
 
 ===== (2)　Urban Object（i-UR）
 
@@ -1762,20 +1762,20 @@
 
 建築物モデルに付与する詳細な属性のためのデータ型を定義する。
 
-image::images/031.svg["","",""]
+image::images/031.svg[]
 
 ===== 2)　施設管理のための拡張属性
 
 建築物モデルに付与する詳細な属性のうち、施設管理のための属性のデータ型を定義する。 +
 uro::FacilityAttributeは抽象クラスであり、これを継承する具象クラスを、4.25に定義する。
 
-image::images/032.svg["","",""]
+image::images/032.svg[]
 
 ===== 3)　数値地形図のための拡張属性
 
 以下に示すクラスは、数値地形図データとの互換性を保つために、地図情報レベル2500数値地形図データ作成のための標準製品仕様書（案）に定義された属性を建築物の属性として付与することを可能にするためのデータ型である。
 
-image::images/033.svg["","",""]
+image::images/033.svg[]
 
 ===== 4)　建築物モデル（LOD4）の拡張属性
 
@@ -1784,37 +1784,37 @@
 [none]
 ** ①　bldg:_AbstractBuildingの下位型に付与する属性
 
-image::images/034.svg["","",""]
+image::images/034.svg[]
 
 [none]
 ** ②　bldg:Roomの下位型に付与する属性
 
-image::images/035.svg["","",""]
+image::images/035.svg[]
 
 [none]
 ** ③　bldg:_BoundarySurfaceの下位型に付与する属性
 
-image::images/036.svg["","",""]
+image::images/036.svg[]
 
 [none]
 ** ④　bldg:_Openingの下位型に付与する属性
 
-image::images/037.svg["","",""]
+image::images/037.svg[]
 
 [none]
 ** ⑤　bldg:BuildingInstallation及びbldg:IntBuildingInstallationに付与する属性
 
-image::images/038.svg["","",""]
+image::images/038.svg[]
 
 [none]
 ** ⑥　bldg:BuildingFurnitureに付与する属性
 
-image::images/039.svg["","",""]
+image::images/039.svg[]
 
 [none]
 ** ⑦　3次元屋内地理空間データに対応する属性
 
-image::images/040.svg["","",""]
+image::images/040.svg[]
 
 [[toc4_02_03]]
 ==== 　建築物の応用スキーマ文書
@@ -1829,7 +1829,7 @@
 2+a| 
 居住その他の目的をもって構築された建築物。 普通建物、堅ろう建物、普通無壁舎及び堅ろう無壁舎に区分する。 普通建物とは、3階未満の建物及び3階以上の木造等で建築された建物をいう。 堅ろう建物とは、鉄筋コンクリート等で建築された建物で、地上3階以上又は3階相当以上の高さのものやスタンドを備えた競技場をいう。 普通無壁舎とは、側壁のない建物、温室及び工場内の建物類似の構築物で、3階未満のものをいう。 堅ろう無壁舎とは、鉄筋コンクリート等で建築された側壁のない建物及び建物類似の構築物で、地上3階以上又は3階相当以上の高さのものをいう。 （作業規程の準則　付録７　公共測量標準図式）
 
-image::images/041.webp["",600,"",title=" 図　bldg:Buildingの例"]
+image::images/041.webp["",600,title=" 図　bldg:Buildingの例"]
 
 LOD0からLOD3 までは、建築物の屋外の形状を表現する。 +
 LOD4では、建築物の屋外の形状に加え、屋内の形状を表現する。
@@ -1882,7 +1882,7 @@
 a| 
 建築物の外周の上方からの正射影を取得し、地上から一律の高さを与えて立ち上げた立体。
 
-image::images/042.webp["",200,"",title=" 図　LOD1立体イメージ"]
+image::images/042.webp["",200,title=" 図　LOD1立体イメージ"]
 
 一律の高さは中央値を原則とする。
 
@@ -1891,7 +1891,7 @@
 a| 
 建築物の主要構造の外形を示す立体であり、屋根面（RoofSurface）、外壁面（WallSurface）及び底面（GroundSurface）を境界面とする。
 
-image::images/043.webp["",250,"",title=" 図　LOD2立体イメージ"]
+image::images/043.webp["",250,title=" 図　LOD2立体イメージ"]
 
 建築物をbldg:BuildingPartの集まりとして記述する場合、この空間属性は空となる。
 
@@ -1903,7 +1903,7 @@
 a| 
 建築物の詳細な形状を示す立体であり、屋根面（RoofSurface）、外壁面（WallSurface）、底面（GroundSurface）及び開口部の面（境界面の内空として作成されている場合）を境界面とする。
 
-image::images/044.webp["",250,"",title=" 図　LOD3立体イメージ"]
+image::images/044.webp["",250,title=" 図　LOD3立体イメージ"]
 
 建築物をbldg:BuildingPartの集まりとして記述する場合、この空間属性は空となる。
 
@@ -1989,7 +1989,7 @@
 この地物型を使用する場合、一つの建築物には、複数の建築物部分が存在しなければならない。 +
 また、一棟の建築物を構成する建築物部分は同じ建築物を構成する他の建築物部分と接していなければならない。
 
-image::images/045.webp["",500,""]
+image::images/045.webp["",500]
 
 この地物型は、LOD2、LOD3及びLOD４の建築物を記述する際に使用可能であるが、ユースケースにより、建築物と建築物部分を区分する必要がない場合には、建築物部分として分けず、一体的な建築物としてよい。
 
@@ -2078,7 +2078,7 @@
 2+a| 
 壁、間仕切り、床、天井などで仕切られ、生活の場などに用いられる、建物内部の隔てられた空間の区画（部屋）。
 
-image::images/046.webp["",300,"",title=" 図　bldg:Roomの例"]
+image::images/046.webp["",300,title=" 図　bldg:Roomの例"]
 
 bldg:Roomは、bldg:Buildingに含まれる地物として記述する。 +
 このとき、bldg:Roomは、複数の地物の集まりとして表現する。bldg:Roomに含まれる地物とは、以下である。 +
@@ -2165,7 +2165,7 @@
 2+a| 
 主に建築物の上部を覆う構造物。
 
-image::images/047.webp["",300,"",title=" 図　bldg:RoofSurfaceの例"]
+image::images/047.webp["",300,title=" 図　bldg:RoofSurfaceの例"]
 
 h| 上位の型 2+| bldg:_BoundarySurface
 h| ステレオタイプ 2+| << FeatureType >>
@@ -2213,7 +2213,7 @@
 2+a| 
 建築物の外周を構成する壁面（外壁）。
 
-image::images/048.webp["",300,"",title=" 図　bldg:WallSurfaceの例"]
+image::images/048.webp["",300,title=" 図　bldg:WallSurfaceの例"]
 
 カーテンウォールはbldg:WallSurfaceにより表現する。カーテンウォールとは、建築物の外側に配置され、建築物を囲む非耐荷重の壁である。 +
 [参考 ISO 6707-1:2020 Buildings and civil engineering works — Vocabulary — Part 1: General terms]
@@ -2264,7 +2264,7 @@
 建築物の立体形状の底面。 +
 建築物の底面又は建築物の壁面と地形との交線を境界とする面を取得する。
 
-image::images/049.webp["",450,"",title=" 図　bldg:GroundSurface"]
+image::images/049.webp["",450,title=" 図　bldg:GroundSurface"]
 
 h| 上位の型 2+| bldg:_BoundarySurface
 h| ステレオタイプ 2+| << FeatureType >>
@@ -2316,7 +2316,7 @@
 2+a| 
 建築物の外側を覆う部分であり、天井としての機能を有する部分。
 
-image::images/050.webp["",400,"",title=" 図　bldg:OuterCeilingSurfaceの例"]
+image::images/050.webp["",400,title=" 図　bldg:OuterCeilingSurfaceの例"]
 
 ユースケースで屋外の天井と壁面との区分が必要な場合に、bldg:OuterCeilingSurfaceを使用する。 +
 ユースケースで屋外の天井と壁面との区分が不要な場合には、この型は使用せず、bldg:WallSurfaceを使用する。
@@ -2374,7 +2374,7 @@
 2+a| 
 建築物の外側を覆う部分であり、通行可能な床面としての機能を有する部分。例えば、屋上や通路として利用されている面が該当する。
 
-image::images/051.webp["",400,"",title=" 図　OuterFloorSurfaceの例"]
+image::images/051.webp["",400,title=" 図　OuterFloorSurfaceの例"]
 
 ユースケースで通行可能な床面と屋根面の区分が必要な場合に、bldg:OuterFloorSurfaceを使用する。 +
 ユースケースで通行可能な床面と屋根面との区分が不要な場合には、この型は使用せず、bldg:RoofSurfaceを使用する。
@@ -2436,14 +2436,14 @@
 建築物の立体又は部屋の立体を構成するために設ける仮想的な面。 +
 1棟の建築物を、主題属性の異なる複数の部分に分ける場合に、その境界面として使用する。
 
-image::images/052.webp["",450,"",title=" 図　LOD2又はLOD3でのbldg:ClosureSurfaceの例"]
+image::images/052.webp["",450,title=" 図　LOD2又はLOD3でのbldg:ClosureSurfaceの例"]
 
 2+a| 
 屋内においては、境界面となる内壁面や天井面、床面はないが、建築確認申請では部屋となっている空間を区切る場合に、部屋の境界面として便宜上設けられた仮想的な面をさす。
 
-image::images/053.webp["",500,"",title=" 図　LOD4でのbldg:ClosureSurfaceの例"]
+image::images/053.webp["",500,title=" 図　LOD4でのbldg:ClosureSurfaceの例"]
 
-2+a| image::images/054.webp["",500,"",title=" 図　LOD4でのbldg:ClosureSurfaceを非表示にした例"]
+2+a| image::images/054.webp["",500,title=" 図　LOD4でのbldg:ClosureSurfaceを非表示にした例"]
 
 h| 上位の型 2+| bldg:_BoundarySurface
 h| ステレオタイプ 2+| << FeatureType >>
@@ -2495,7 +2495,7 @@
 2+a| 
 建築物の内側に向いた壁や仕切り。部屋（bldg:Room）の立体を構成する垂直方向の境界面となる。
 
-image::images/055.webp["",500,"",title=" 図　bldg:InteriorWallSurfaceの例"]
+image::images/055.webp["",500,title=" 図　bldg:InteriorWallSurfaceの例"]
 
 CityGMLでは、壁は面として表現し、1つの壁は、内側の面と外側の面の2つの面として表現する。 例えば、屋外と屋内を仕切る壁があった場合、屋外に面する壁の面は、bldg:WallSurace（外壁面）として表現し、屋内に面する壁の面は、bldg:InteriorWallSurface（内壁面）として表現する。このとき、bldg:WallSurfaceと、bldg:InteriorSurfaceとの間（壁の厚みに相当する空間）には何も存在しない。 bldg:InteriorWallSurfaceの法線ベクトルは、建築物の内側を向く。
 
@@ -2548,7 +2548,7 @@
 2+a| 
 部屋など構造物内部の上側の面（天井）。部屋（bldg:Room）の境界面となる。
 
-image::images/056.webp["",500,"",title=" 図　bldg:CeilingSurfaceの例"]
+image::images/056.webp["",500,title=" 図　bldg:CeilingSurfaceの例"]
 
 bldg:CeilingSurfaceの法線ベクトルは下向き（部屋の内側に向く方向が正）となる。
 
@@ -2602,7 +2602,7 @@
 2+a| 
 建物の内部空間の各階下面に位置する水平で平らな板状の構造物（床面）。部屋（bldg:Room）の境界面となる。
 
-image::images/057.webp["",400,"",title=" 図　bldg:FloorSurfaceの例"]
+image::images/057.webp["",400,title=" 図　bldg:FloorSurfaceの例"]
 
 bldg:FloorSurfaceの法線ベクトルは上向き（部屋の内側に向く方向が正）となる。
 
@@ -2656,7 +2656,7 @@
 2+a| 
 採光、通風、換気、眺望などの目的のため、建築物の屋根又は壁、部屋の天井、壁、床に設けられた開口部のうち、人や物の出入りを目的としないもの。
 
-image::images/058.webp["",500,"",title=" 図 bldg:Windowの例"]
+image::images/058.webp["",500,title=" 図 bldg:Windowの例"]
 
 CityGMLでは、窓を面として表現し、1つの窓を外側と内側の2つのbldg:Windowのオブジェクトとして表現する。例えば、屋内と屋外をつなぐ窓があった場合、 外側となるbldg:Windowは、建築物の外壁（bldg:WallSurface）等の境界面に含まれる。 内側となるbldg:Windowは、部屋の壁面（bldg:InteriorWallSurface）等の境界面に含まれる。 このとき、屋外の境界面（bldg:WallSurface、bldg:GroundSurface、bldg:OuterFloorSurface、bldg:OuterCeilingSurface）に設けられた開口部は、常にその法線ベクトルが建築物の外側を向く。部屋の境界面（bldg:InteriorWallSurface、bldg:FloorSurface、bldg:CeilingSurface）に設けられた開口部は、常にその法線ベクトルが部屋の内側を向く。
 
@@ -2713,7 +2713,7 @@
 2+a| 
 採光、通風、換気、眺望、通行などの目的のため、建築物の屋根、天井、壁、床などに設けられた開口部のうち、人や物の出入りを目的とするもの。
 
-image::images/059.webp["",500,"",title=" 図　bldg:Doorの例"]
+image::images/059.webp["",500,title=" 図　bldg:Doorの例"]
 
 CityGMLでは、扉を面として表現し、1つの扉を外側と内側の2つのbldg:Doorのオブジェクトとして表現する。例えば、屋内と屋外をつなぐ窓があった場合、 外側となるbldg:Doorは、建築物の外壁（bldg:WallSurface）等の境界面に含まれる。 内側となるbldg:Doorは、部屋の壁面（bldg:InteriorWallSurface）等の境界面に含まれる。 このとき、屋外の境界面（bldg:WallSurface、bldg:GroundSurface、bldg:OuterFloorSurface、bldg:OuterCeilingSurface）に設けられた開口部は、常にその法線ベクトルが建築物の外側を向く。部屋の境界面（bldg:InteriorWallSurface、bldg:FloorSurface、bldg:CeilingSurface）に設けられた開口部は、常にその法線ベクトルが部屋の内側を向く。
 
@@ -2768,7 +2768,7 @@
 2+a| 
 建築物の外側（屋外）に設置され、建築物の外観を特徴づける設備。 建築物の付帯的な設備であり、主要な部分であってはならない。また、建築物（bldg:Building）と接していなければならない。 建築物の屋外付属物には以下を含む。ただし、全て屋外に設置され、建築物と接するもののみを対象とする。 バルコニー、ポーチ、アーケード、テラス、サンテラス、回廊、エントランスホール、ダクト、装飾的な柱、デッキ、屋根飾り、出窓、ドーマー、（建築物の一部としての）煙突、看板、換気口、（建築物の一部としての）塔、階段、カーポート、物置、アンテナ、外階段や歩道に設けられた屋根、手すり、スロープ、パネル（内装・外装の仕上げ等で利用される板材）、エレベータ、エスカレータ、動く歩道など。
 
-image::images/060.webp["",500,"",title=" 図　bldg:BuildingInstallationの例"]
+image::images/060.webp["",500,title=" 図　bldg:BuildingInstallationの例"]
 
 （左：屋根面に設置された建築物の屋外付属物　右：壁面に設置された建築物の屋外付属物） +
 ユースケースの要求に応じて、取得対象とする建築物の屋外付属物を限定してもよく、また、建築物の屋外付属物として取得せず建築物の一部として取得してもよい。
@@ -2804,7 +2804,7 @@
 a| 
 建築物の屋外付属物のLOD2の形状。 屋外付属物の外形（外側から見える形）を構成する面を取得し、面の各頂点に屋外付属物の高さを与える。各面は、データセットが採用する地図情報レベルの水平及び高さの誤差の標準偏差に収まるよう取得する。 gml:MultiSurfaceを使用することを基本とする。 容積の算出等ユースケースで必要な場合は、gml:Solidを使用する。
 
-image::images/061.webp["",200,"",title=" 図　bldg:BuildingInstallationの取得例（屋外階段）"]
+image::images/061.webp["",200,title=" 図　bldg:BuildingInstallationの取得例（屋外階段）"]
 
 | bldg:lod3Geometry | gml:_Geometry [0..1] | 建築物の屋外付属物のLOD3の形状。 屋外付属物の外形（外側から見える形）を構成する面を取得し、面の各頂点に屋外付属物の高さを与える。各面は、データセットが採用する地図情報レベルの水平及び高さの誤差の標準偏差に収まるよう取得する。 gml:MultiSurfaceを使用することを基本とする。容積の算出等ユースケースで必要な場合は、gml:Solidを使用する。
 | bldg:lod4Geometry | gml:_Geometry [0..1] | 建築物の屋外付属物のLOD4の外形。 屋外付属物の外形（外側から見える形）を構成する面を取得し、面の各頂点に屋外付属物の高さを与える。各面は、データセットが採用する地図情報レベルの水平及び高さの誤差の標準偏差に収まるよう取得する。 gml:MultiSurfaceにより記述することを基本とする。容積の算出等ユースケースで必要な場合は、gml:Solidを使用する。
@@ -2814,7 +2814,7 @@
 建築物の屋外付属物を構成する外壁、屋根等の境界面への参照。建築物の屋外付属物の境界面が建築物（bldg:Building）の境界面となる場合にのみ作成する。 +
 例えば、下図（平面図）のように建築物に建築物の屋外付属物があった場合、この建築物の屋外付属物を含む空間（gml:Solid）をBuildingとしたい場合は、建築物の屋外付属物の境界面を壁面（bldg:WallSurface）とする。
 
-image::images/062.webp["",250,""]
+image::images/062.webp["",250]
 
 建築物の空間に建築物の屋外付属物を含まない場合は、建築物の屋外付属物を構成する面を、境界面（bldg:_BoundarySurface）に区別する必要はない。
 
@@ -2840,7 +2840,7 @@
 建築物の内側に設置された、恒久的に存在する固定的な設備（屋内付属物）。 +
 屋内付属物は、建築物の付帯的な設備であり、主要な部分であってはならない。また、屋内付属物は、建築物（bldg:Building）又は部屋（bldg:Room）と接していなければならない。
 
-image::images/063.webp["",500,"",title=" 図　bldg:IntBuildingInstallationの例（階段、手すり）"]
+image::images/063.webp["",500,title=" 図　bldg:IntBuildingInstallationの例（階段、手すり）"]
 
 LOD4では、この屋内付属物を含む建築物に適用されたLOD4の細分に従い、以下を取得する。 +
 LOD4.0：屋内付属物を取得しない（bldg:IntBuildingInstallationは取得しない）。 +
@@ -2887,7 +2887,7 @@
 屋内付属物を構成する内壁、天井等の境界面への参照。屋内付属物の境界面が部屋（bldg:Room）の境界面となる場合にのみ作成する。 +
 例えば、下図（平面図）のように部屋内に屋内付属物があった場合、この屋内付属物を除く空間（gml:Solid）をRoomとしたい場合は、屋内付属物の境界面を壁面（bldg:InteriorWallSurface）とする。
 
-image::images/064.webp["",250,""]
+image::images/064.webp["",250]
 
 ただし、部屋の空間から屋内付属物を除く必要が無い場合は、屋内付属物の形状を構成する面を、境界面（bldg:_BoundarySurface）にする必要はない。 +
 また、ユースケースによりエレベータの出入口を、エレベータの扉を使って表現する必要がある場合は、bldg:boundedBy関連役割により、エレベータの扉が存在する境界面を壁面（bldg:InteriorWallSurface）として区分し、この壁面に扉（bldg:Door）を作成することでエレベータの扉を表現可能となる。
@@ -2927,7 +2927,7 @@
  +
 bldg:IntBuildingInstallationが、建築物内部に設置された恒久的かつ固定的な設備であることと対照的に、bldg:BuildingFurnitureは椅子やテーブルのような、動かすことができる備品である。
 
-image::images/065.webp["",400,"",title=" 図　bldg:BuildingFurnitureの例（机、椅子）"]
+image::images/065.webp["",400,title=" 図　bldg:BuildingFurnitureの例（机、椅子）"]
 
 LOD4.2の場合にのみ取得する。 +
 ただし、ユースケースの要求に応じて、取得対象とする家具を限定してよい。
@@ -3216,7 +3216,7 @@
 2+a| 
 洪水浸水想定区域内に存在する建築物に、浸水想定区域がもつ属性を与えるための属性型。 同一の浸水想定区域図において、複数の区域に建築物が跨って存在する場合は、同一浸水ランクを持つ浸水ランクのメッシュを一つの区域とし、その区域と建築物が重なる面積が最も大きい浸水ランクの値を採用する。（面積が等しい場合は、より危険な区域を採用する） 浸水深は採用した浸水ランクを持つ浸水深のメッシュのうち、建築物と重なる面積が最も大きいメッシュの浸水深を採用する。（同じ浸水深を持つメッシュは面積算出の際に合算する） 浸水継続時間は採用した浸水深のメッシュと重なる浸水継続時間のメッシュの浸水継続時間を採用する。複数の浸水継続時間のメッシュが重なる場合は最も大きい浸水継続時間の値を採用する。 浸水深の有効桁数は、「浸水想定区域図データ電子化ガイドライン（第4版）」に従い、浸水深の有効桁数は、小数点以下 3 桁まで登録可能とするが、小数点以下 2 桁でもよいとする。 面積の有効桁数は、小数点2桁（3桁目で四捨五入）とする。
 
-image::images/066.webp["",400,""]
+image::images/066.webp["",400]
 
 h| 上位の型 2+| uro:BuildingFloodingRiskAttribute
 h| ステレオタイプ 2+| << DataType >>
@@ -3887,7 +3887,7 @@
 a| 
 北方角との差を2次元ベクトルで設定する。角度表現のラジアン又は度の設定は、MVD-IfcProject.UnitsInContext（短径設定情報）を参照。北が0時の方向であれば値は(0,1)。
 
-image::images/067.webp["",400,""]
+image::images/067.webp["",400]
 
 |===
 
@@ -6126,8 +6126,8 @@
 |===
 h| 2+^h| LOD0
 h| 取得例
-a| image::images/068.webp["",300,""]
-a| image::images/069.webp["",300,""]
+a| image::images/068.webp["",300]
+a| image::images/069.webp["",300]
 
 h| 説明 | 左右両側の道路縁から等距離となる点をつないだ線分を取得する。 | 道路縁を取得する。
 
@@ -6187,7 +6187,7 @@
 |===
 h| ^h| LOD1
 h| 取得例
-a| image::images/070.webp["",750,""]
+a| image::images/070.webp["",750]
 
 h| 説明 | 道路縁により囲まれた範囲を面として取得し、以下の場所で区切る。 • 車道交差部（十字路、丁字路、その他二つ以上の道路が交わる部分）で区切る。 • 道路構造（トンネル、橋梁）が変化する場所 • 位置正確度や取得方法が変わる場所 高さは0とする。
 
@@ -6239,7 +6239,7 @@
 |===
 h| ^h| LOD2
 h| 取得例
-a| image::images/071.webp["",800,""]
+a| image::images/071.webp["",800]
 
 h| 説明 | 道路縁により囲まれた範囲を面として取得し、面を以下に区分する。 • 車道部 • 車道交差部 • 歩道部 • 島 高さは0とする。
 
@@ -6294,12 +6294,12 @@
 隅切りとは、道路構造令第27条第2項に示された、道路が同一平面で交差し、又は接続する場合に隅角部を切り取り、適当な見とおしができる構造としたものをいう。 +
 また、建築基準法施行規則第144条の4第1項第2号に示される隅切りを含む。
 
-image::images/072.webp["",180,""]
+image::images/072.webp["",180]
 
 | • 車道交差部（隅切りが無い場合）
 a| • 交差する道路の道路縁が接する点を結ぶ線に囲まれた車道部を取得する。 +
 • 高さは0とする。
-a| image::images/073.webp["",180,""]
+a| image::images/073.webp["",180]
 
 | • 歩道部
 a| • 歩道部の境界をつないだ面を取得する。 +
@@ -6388,10 +6388,10 @@
 歩道部のうち、植栽を区分する。
 | LOD3.2の区分を細分する。細分はユースケースに応じて決定する。
 
-^a| image::images/074.webp["",140,""]
-^a| image::images/075.webp["",200,""]
-^a| image::images/076.webp["",210,""]
-^a| image::images/077.webp["",230,""]
+^a| image::images/074.webp["",140]
+^a| image::images/075.webp["",200]
+^a| image::images/076.webp["",210]
+^a| image::images/077.webp["",230]
 
 |===
 
@@ -6409,47 +6409,47 @@
  +
 立体交差が表現できる。
 
-image::images/078.webp["",250,""]
+image::images/078.webp["",250]
 
 a| 
 道路の横断方向に存在する15㎝以上の高さの差を取得する。 +
 ①高さの差が15㎝以上の段は、段の形状を取得する。
 
-image::images/079.webp["",280,""]
+image::images/079.webp["",280]
 
 a| 
 道路の横断方向に存在する2㎝以上の高さの差を取得する。 +
  +
 ①高さの差が2㎝以上の段は、段の形状を取得する。
 
-image::images/080.webp["",280,""]
+image::images/080.webp["",280]
 
 a| 
 ②高さの差が15㎝以上のスロープは、スロープの形状を取得する。
 
-image::images/081.webp["",280,""]
+image::images/081.webp["",280]
 
 a| 
 ②高さの差が2㎝以上のスロープは、スロープの形状を取得する。
 
-image::images/082.webp["",280,""]
+image::images/082.webp["",280]
 
 .2+a| 
 ③高さの差が15㎝未満の段が複数あり、合計15㎝以上の高さの差がある場合は、スロープとして取得する。
 
-image::images/083.webp["",280,""]
+image::images/083.webp["",280]
 
 歩道と車道との間や車道と島との間に存在する縁石による段を表現できる。
 
 a| 
 ③高さの差が2㎝未満の段が複数あり、合計2㎝以上の高さの差がある場合は、スロープとして取得する。
 
-image::images/084.webp["",280,""]
+image::images/084.webp["",280]
 
 a| 
 歩道に設けられた車道への切り下げ部に存在する段が表現できる。
 
-image::images/085.webp["",280,""]
+image::images/085.webp["",280]
 
 |===
 
@@ -6489,7 +6489,7 @@
 | • 車道交差部（隅切りが無い場合）
 a| • 交差する道路の道路縁が接する点を結ぶ線に囲まれた車道部を取得する。 +
 • 高さは車道の路面高さとする。
-a| image::images/086.webp["",200,""]
+a| image::images/086.webp["",200]
 
 | • 歩道部
 a| • 歩道部の境界をつないだ面を取得する。 +
@@ -6636,7 +6636,7 @@
 a| 
 高さの差を表現する面は、歩道部の一部として取得する。
 
-image::images/087.webp["",200,""]
+image::images/087.webp["",200]
 
 .2+| LOD3.2
 .2+| ●
@@ -6718,7 +6718,7 @@
 a| 
 高さの差を表現する面は、歩道部の一部として取得する。
 
-image::images/088.webp["",200,""]
+image::images/088.webp["",200]
 
 .2+| LOD3.3
 .2+| ●
@@ -6800,7 +6800,7 @@
 a| 
 高さの差を表現する面は、歩道部の一部として取得する。
 
-image::images/089.webp["",200,""]
+image::images/089.webp["",200]
 
 | LOD3.4
 | 〇
@@ -6906,21 +6906,21 @@
 
 これらは、道路を構成する歩道や車道のような通行可能な領域（tran:TrafficArea）と、道路における路肩のように、これを補助する役割をもつ領域（tran:AuxiliaryTrafficArea）の集まりとして構成できる。
 
-image::images/090.svg["","",""]
+image::images/090.svg[]
 
 ===== (2)　Urban Object（i-UR）
 
 ===== 1)　tran:Roadの拡張属性
 
-image::images/091.svg["","",""]
+image::images/091.svg[]
 
 ===== 2)　tran:TrafficAreaの拡張属性
 
-image::images/092.svg["","",""]
+image::images/092.svg[]
 
 ===== 3)　tran:TransportationObject及びtran:TransportationComplexの拡張属性
 
-image::images/093.svg["","",""]
+image::images/093.svg[]
 
 [[toc4_03_03]]
 ==== 　交通（道路）モデルの応用スキーマ文書
@@ -6936,11 +6936,11 @@
 一般交通の用に供する場所。道路法第3条に示された道路の種類及び建築基準法第42条の定義を含む。 道路の延長方向は、以下の場所で区切る。 • 車道交差部（十字路、丁字路、その他二つ以上の道路が交わる部分） • 道路構造の変化点（トンネル、橋梁） • 位置正確度（地図情報レベル）や取得方法 +
 tran:Roadに含まれるtran:TrafficArea及びtran:AuxiliaryTrafficAreaは、同一路線に含まれなければならない。 同一のLODにおいて、連続する道路の境界は一致しなければならない。
 
-image::images/094.webp["",300,"",title=" 図　LOD1における道路の取得例"]
+image::images/094.webp["",300,title=" 図　LOD1における道路の取得例"]
 
-2+a| image::images/095.webp["",600,"",title=" 図　LOD2における道路の取得例"]
+2+a| image::images/095.webp["",600,title=" 図　LOD2における道路の取得例"]
 
-2+a| image::images/096.webp["",600,"",title=" 図　LOD3における道路の取得例"]
+2+a| image::images/096.webp["",600,title=" 図　LOD3における道路の取得例"]
 
 h| 上位の型 2+| tran:TrafficComplex
 h| ステレオタイプ 2+| << FeatureType >>
@@ -7012,22 +7012,22 @@
  +
 • LOD2及びLOD3.0の場合は、車道部として、車両の利用が想定された車線や路肩その他一体的な舗装がされた全ての道路の部分を対象とする。また、歩道部として、歩道及び歩道上に設置された植栽の範囲を対象とする。
 
-image::images/097.webp["",700,"",title=" 図　LOD2及びLOD3.0におけるtran:TrafficAreaの例"]
+image::images/097.webp["",700,title=" 図　LOD2及びLOD3.0におけるtran:TrafficAreaの例"]
 
 2+a| 
 • LOD3.1の場合は、LOD3.0の車道部のうち、車線を細分する。
 
-image::images/098.webp["",700,"",title=" 図　LOD3.1におけるtran:TrafficAreaの例"]
+image::images/098.webp["",700,title=" 図　LOD3.1におけるtran:TrafficAreaの例"]
 
 2+a| 
 • LOD3.2及びLOD3.3の場合は、LOD3.1の歩道部から歩道上の植栽を除いた範囲を歩道部とする。
 
-image::images/099.webp["",700,"",title=" 図　LOD3.2及びLOD3.3におけるtran:TrafficAreaの例"]
+image::images/099.webp["",700,title=" 図　LOD3.2及びLOD3.3におけるtran:TrafficAreaの例"]
 
 2+a| 
 • LOD3.4の場合は、コードリストの区分に従う。
 
-image::images/100.webp["",700,"",title=" 図　LOD3.4におけるtran:TrafficAreaの例"]
+image::images/100.webp["",700,title=" 図　LOD3.4におけるtran:TrafficAreaの例"]
 
 1つの道路オブジェクトに含まれる交通領域は、属性の変化が無い限り、区分しない。
 
@@ -7097,17 +7097,17 @@
 道路を構成する領域のうち、交通領域の機能を補助するために設けられた領域。 +
 • LOD2、LOD3.0及びLOD3.1の場合は、道路内の島状の施設（交通島及び分離帯、路面電車停車所）を対象とする。
 
-image::images/101.webp["",700,"",title=" 図　LOD2、LOD3.0及びLOD3.1での道路のtran:AuxiliaryTrafficAreaの取得例"]
+image::images/101.webp["",700,title=" 図　LOD2、LOD3.0及びLOD3.1での道路のtran:AuxiliaryTrafficAreaの取得例"]
 
 2+a| 
 • LOD3.2及びLOD3.3の場合は、上記に加え、歩道部に設置された植栽を対象とする。
 
-image::images/102.webp["",700,"",title=" 図　LOD3.2及びLOD3.3での道路のtran:AuxiliaryTrafficAreaの取得例"]
+image::images/102.webp["",700,title=" 図　LOD3.2及びLOD3.3での道路のtran:AuxiliaryTrafficAreaの取得例"]
 
 2+a| 
 • LOD3.4に場合は、tran:functionにより指定されるコードリストの区分に従う。
 
-image::images/103.webp["",700,"",title=" 図　LOD3.4での道路のtran:AuxiliaryTrafficAreaの取得例"]
+image::images/103.webp["",700,title=" 図　LOD3.4での道路のtran:AuxiliaryTrafficAreaの取得例"]
 
 1つの道路オブジェクトに含まれる交通補助領域は、属性の変化が無い限り、延長方向では区分しない（例：延長方向に連続する分離帯を細分しない）。
 
@@ -7780,16 +7780,16 @@
 |===
 h| 5+^h| LOD0
 h| 取得例
-5+^a| image::images/104.webp["",150,""]
+5+^a| image::images/104.webp["",150]
 
 h| 説明 5+| 中心線を取得する。
 h| 5+^h| LOD0
 h| 取得例
-^a| image::images/105.webp["",150,""]
-^a| image::images/106.webp["",150,""]
-^a| image::images/107.webp["",150,""]
-^a| image::images/108.webp["",150,""]
-^a| image::images/109.webp["",150,""]
+^a| image::images/105.webp["",150]
+^a| image::images/106.webp["",150]
+^a| image::images/107.webp["",150]
+^a| image::images/108.webp["",150]
+^a| image::images/109.webp["",150]
 
 h| 説明 | 普通鉄道、地下鉄地上部、路面鉄道は、地図情報レベル2500ではレールの中心線を取得し、地図情報レベル500及び1000ではレールを取得する。 | モノレールは、地図情報レベル500及び1000では中心線を取得する。 | 特殊軌道の場合は、地図情報レベル2500では中心線を取得し、地図情報レベル500及び1000ではレールを取得する。 | 索道の場合は、中心線を取得する。 | 建設中の鉄道、トンネル内の鉄道、地下鉄地下部の場合は、地図情報レベル500及び1000ではレールを取得する。
 
@@ -7863,8 +7863,8 @@
 |===
 h| 2+^h| LOD1
 h| 取得例
-^a| image::images/110.webp["",370,""]
-^a| image::images/111.webp["",350,""]
+^a| image::images/110.webp["",370]
+^a| image::images/111.webp["",350]
 
 h| 説明
 a| 普通鉄道、地下鉄、路面鉄道及び特殊軌道の場合は、レールの内側の領域を面として取得する。 +
@@ -7880,7 +7880,7 @@
 
 h| 2+^h| LOD1
 h| 取得例
-^a| image::images/112.webp["",350,""]
+^a| image::images/112.webp["",350]
 | 
 
 h| 説明 | 索道の場合は、起点及び終点が同一となる索道のケーブルに囲まれた範囲を面として取得する。高さは0とする。 | 
@@ -7950,7 +7950,7 @@
 
 **** 〇：任意（ユースケースに応じて要否を決定してよい）
 
-image::images/113.webp["","","",title=" 図 4-4　線路の構造"]
+image::images/113.webp[title=" 図 4-4　線路の構造"]
 
 　
 
@@ -7971,7 +7971,7 @@
 |===
 h| ^h| LOD2
 h| 取得例
-a| image::images/114.webp["",500,""]
+a| image::images/114.webp["",500]
 
 h| 説明 | 軌道中心線、レールに囲まれた範囲※、及び道床を取得する。高さは0とする。 軌道中心線の形状はLOD0と同様であり、レールに囲まれた範囲の形状はLOD1と同様であるが、LOD2とは地物型が異なる。 LOD0が路線ごとに一つの地物であったことに対し、LOD2は、軌道ごとに一つの地物（tran:TrafficArea）となる。 なお、軌道中心線及びレールに囲まれた範囲は、それぞれ一つの地物（tran:TrafficArea）とする。 道床は外周により囲まれた範囲をtran:TrafficAreaとして取得する。道床はレールに囲まれた範囲を包含する。 いずれも高さは0とする。 ※軌道中心線が直線である区間では、レールに囲まれた範囲の幅は軌間と一致する。 軌間とは、軌道中心線が直線である区間におけるレール面上から下方の所定距離以内における左右レール頭部間の最短距離である。 [JIS E1001:2001　鉄道-線路用語]
 
@@ -8095,9 +8095,9 @@
 |===
 h| ^h| LOD3.0 ^h| LOD3.1 ^h| LOD3.2
 h| 取得例
-^a| image::images/115.webp["",200,""]
-^a| image::images/116.webp["",250,""]
-^a| image::images/117.webp["",250,""]
+^a| image::images/115.webp["",200]
+^a| image::images/116.webp["",250]
+^a| image::images/117.webp["",250]
 
 h| 説明
 | 軌道中心線、レールに囲まれた範囲及び道床を面として取得する。
@@ -8114,9 +8114,9 @@
 |===
 h| ^h| LOD3.0 ^h| LOD3.1 ^h| LOD3.2
 h| 取得例
-^a| image::images/118.webp["",150,""]
-^a| image::images/119.webp["",180,""]
-^a| image::images/120.webp["",180,""]
+^a| image::images/118.webp["",150]
+^a| image::images/119.webp["",180]
+^a| image::images/120.webp["",180]
 
 h| 説明
 | 軌道中心線の各点に標高を与える。 道床に軌道中心線の高さを与える。 軌道中心線の高さは、レール面の高さとする。
@@ -8124,14 +8124,14 @@
 軌道中心線の各点に標高を与える。 +
 レールの横断方向に存在する15㎝以上の高さの差を取得する。
 
-image::images/121.webp["",220,""]
+image::images/121.webp["",220]
 
 a| 
 軌道中心線の各点に標高を与える。 +
 レールの横断方向に存在する15㎝未満の高さの差を取得する。 +
 高さの差を取得する閾値は、ユースケースの必要に応じて定めることができる。
 
-image::images/122.webp["",220,""]
+image::images/122.webp["",220]
 
 |===
 
@@ -8161,7 +8161,7 @@
 | MultiSurface
 | • レールに囲まれた範囲
 | • 左右レールの内側を境界とする面を取得する。 • 各頂点に軌道中心線上の高さを与える。
-a| image::images/123.webp["",150,""]
+a| image::images/123.webp["",150]
 
 | LOD3.0 | ● | TrafficArea | MultiSurface | • 道床 | • 外周の正射影を取得し、外周の各頂点に、軌道中心線上の高さを与える。 | 
 | LOD3.0 | | AuxiliaryTrafficArea | | | | 
@@ -8194,7 +8194,7 @@
 | MultiSurface
 | • レールに囲まれた範囲
 | • 左右レールの内側を境界とする面を取得する。 • 各頂点に軌道の高さを与える。
-a| image::images/124.webp["",150,""]
+a| image::images/124.webp["",150]
 
 | LOD3.1
 | ●
@@ -8235,7 +8235,7 @@
 | MultiSurface
 | • レールに囲まれた範囲
 | • 左右レールの内側を境界とする面を取得する。 • 各頂点に軌道の高さを与える。
-a| image::images/125.webp["",150,""]
+a| image::images/125.webp["",150]
 
 | LOD3.2 | ● | TrafficArea | MultiSurface | • 道床 | • 外周を取得し、勾配が変化する場所で区切る。 • 外周の各頂点に、水平位置に対応する標高を与える | 15㎝未満の高さの差を取得する。 取得の下限値はユースケースに応じて定める。
 | LOD3.2 | ● | AuxiliaryTrafficArea | MultiSurface | • 鉄道用地のうち、道床を除く部分 | • 外周を取得し、勾配が変化する場所で区切る。 • 外周の各頂点に、水平位置に対応する標高を与える。 | 15㎝未満の高さの差を取得する。 取得の下限値はユースケースに応じて定める。
@@ -8295,7 +8295,7 @@
 
 ===== 1)　tran:Railwayの拡張属性
 
-image::images/126.svg["","",""]
+image::images/126.svg[]
 
 ===== 2)　tran:TransportationObject及びtran:TransportationComplexの拡張属性
 
@@ -8314,13 +8314,13 @@
 2+a| 
 鉄道とは、人と物を迅速かつ大量に輸送するため、レールを敷いた専用の通路を用い、その上を車両が円滑に行き来できるように整備された一切の設備とシステムの集合体である。[一般社団法人日本民営鉄道協会] 標準製品仕様書では、鉄道事業法及び軌道法に基づいて敷設された線路を指し、以下を含む。 • 普通鉄道：鉄道事業法又は軌道法に基づいて運行されている鉄道で、特殊軌道及び索道を除いたもの[公共測量標準図式] • 地下鉄：地方公共団体及び東京地下鉄（株）等が管理する地下高速鉄道[公共測量標準図式] • 路面電車：道路上に線路を敷設した鉄道で、主として路面上から直接乗り降りできる車両が運行される鉄道[公共測量標準図式] • モノレール：車両が一本の軌道桁に跨座し、又は懸垂して走行するもの • 特殊鉄道：鋼索鉄道、普通鉄道と接続しない工場等特定の地区内の軌道及び採鉱（石）地と工場等を結ぶ専用軌道[公共測量標準図式] • 索道：空中ケーブル、スキーリフト、ベルトコンベヤー及びこれらに類するもの[公共測量標準図式] なお、線路とは、列車又は車両を走らせるための通路であって，軌道及びこれを支持するために必要な路盤，構造物を包含する地帯をいう。[JIS E1001:2001 鉄道―線路用語。 鉄道は路線単位で作成し、鉄道の延長方向は、以下の場所で区切る。 • 軌道が分岐又は合流する地点 • 構造の変化点（トンネル、橋梁） • 市区町村界 • 位置正確度（地図情報レベル）や取得方法が変わる場所 tran:Railwayに含まれるtran:TrafficArea及びtran:AuxiliaryTrafficAreaは、同一路線に含まれなければならない。また、同一のLODにおいて、連続する鉄道の境界は一致しなければならない。
 
-image::images/127.webp["",350,"",title=" 図　LOD0における鉄道の取得例"]
+image::images/127.webp["",350,title=" 図　LOD0における鉄道の取得例"]
 
-2+a| image::images/128.webp["",370,"",title=" 図　LOD1における鉄道の取得例"]
+2+a| image::images/128.webp["",370,title=" 図　LOD1における鉄道の取得例"]
 
-2+a| image::images/129.webp["",650,"",title=" 図　LOD2における鉄道の取得例"]
+2+a| image::images/129.webp["",650,title=" 図　LOD2における鉄道の取得例"]
 
-2+a| image::images/130.webp["",650,"",title=" 図　LOD3における鉄道の取得例"]
+2+a| image::images/130.webp["",650,title=" 図　LOD3における鉄道の取得例"]
 
 h| 上位の型 2+| tran:TrafficComplex
 h| ステレオタイプ 2+| << FeatureType >>
@@ -8395,22 +8395,22 @@
 軌道。軌道とは、施工基面上の道床（スラブを含む）、軌きょう（レールとまくらぎとを，はしご状に組み立てたもの。）及び直接これらに付帯する施設。[JIS E1001 鉄道―線路用語] +
 • LOD2の場合は、軌道中心線に加え、道床の外周に囲まれた範囲を取得する。高さは0とする。
 
-image::images/131.webp["",500,"",title=" 図　LOD2における鉄道のtran:TrafficAreaの例"]
+image::images/131.webp["",500,title=" 図　LOD2における鉄道のtran:TrafficAreaの例"]
 
 2+a| 
 • LOD3.0の場合は軌道中心線に加え、道床の外周に囲まれた範囲を取得する。軌道中心線の各頂点には、軌道中心線上の勾配変化点の標高に基づき、高さを与える。また、道床の高さは、軌道中心線上の高さとする。
 
-image::images/132.webp["",500,"",title=" 図　LOD3.0における鉄道のtran:TrafficAreaの例"]
+image::images/132.webp["",500,title=" 図　LOD3.0における鉄道のtran:TrafficAreaの例"]
 
 2+a| 
 • LOD3.1の場合は、LOD3.0の軌道中心線、道床に加え、レールを取得する。高さはそれぞれの水平位置における標高とする。15㎝以上の高さの差を取得する。
 
-image::images/133.webp["",500,"",title=" 図　LOD3.1における鉄道のtran:TrafficAreaの例"]
+image::images/133.webp["",500,title=" 図　LOD3.1における鉄道のtran:TrafficAreaの例"]
 
 2+a| 
 • LOD3.2の場合は、LOD3.1の軌道中心線、道床及びレールの範囲を取得する。高さはそれぞれの水平位置における標高とする。15㎝未満の高さの差を取得する。
 
-image::images/134.webp["",500,"",title=" 図　LOD3.2におけるtran:TrafficAreaの例"]
+image::images/134.webp["",500,title=" 図　LOD3.2におけるtran:TrafficAreaの例"]
 
 1つの鉄道オブジェクトに含まれる交通領域は、属性の変化が無い限り、延長方向では区分しない。 +
 LOD3では、軌道中心線の平面線形が変化する位置（円曲線及び緩和曲線の開始地点及び終了地点）で区切る。
@@ -8458,12 +8458,12 @@
 2+a| 
 鉄道用地のうち、道床を除く範囲。 • LOD2の場合は取得しない。（tran:TrafficAreaのみを取得する。） • LOD3.0の場合は取得しない。（tran:TrafficAreaのみを取得する。） • LOD3.1の場合は、鉄道敷地界及び道床の外周に囲まれた範囲を取得する。高さはそれぞれの水平位置における標高とする。15㎝以上の高さの差を取得する。
 
-image::images/135.webp["",500,"",title=" 図　LOD3.1におけるtran:AuxiliaryTrafficAreaの例"]
+image::images/135.webp["",500,title=" 図　LOD3.1におけるtran:AuxiliaryTrafficAreaの例"]
 
 2+a| 
 • LOD3.2の場合は、鉄道敷地界及び道床の外周に囲まれた範囲を取得する。高さはそれぞれの水平位置における標高とする。15㎝未満の高さの差を取得する。
 
-image::images/136.webp["",500,"",title=" 図　LOD3.2におけるtran:AuxiliaryTrafficAreaの例"]
+image::images/136.webp["",500,title=" 図　LOD3.2におけるtran:AuxiliaryTrafficAreaの例"]
 
 1つの鉄道オブジェクトに含まれる交通補助領域は、属性の変化が無い限り、延長方向では区分しない。
 
@@ -8967,8 +8967,8 @@
 |===
 h| 2+^h| LOD0
 h| 取得例
-a| image::images/137.webp["",300,""]
-a| image::images/138.webp["",300,""]
+a| image::images/137.webp["",300]
+a| image::images/138.webp["",300]
 
 h| 説明 | 左右両側の徒歩道縁から等距離となる点をつないだ線分を取得する。 | 徒歩道縁線を取得する。
 
@@ -9028,7 +9028,7 @@
 |===
 h| ^h| LOD1
 h| 取得例
-^a| image::images/139.webp["",750,""]
+^a| image::images/139.webp["",750]
 
 h| 説明
 a| 徒歩道縁により囲まれた範囲を面として取得し、以下の場所で区切る。 +
@@ -9088,7 +9088,7 @@
 |===
 h| ^h| LOD2
 h| 取得例
-a| image::images/140.webp["",600,""]
+a| image::images/140.webp["",600]
 
 h| 説明
 a| 徒歩道縁により囲まれた範囲を面として取得し、面を以下に区分する。 +
@@ -9143,12 +9143,12 @@
 a| 
 隅切りとは、道路構造令第27条第2項に示された、道路が同一平面で交差し、又は接続する場合に隅角部を切り取り、適当な見とおしができる構造としたものをいう。また、建築基準法施行規則第144条の4第1項第2号に示される隅切りを含む。
 
-image::images/141.webp["",200,""]
+image::images/141.webp["",200]
 
 | • 車道交差部（隅切りが無い場合）
 a| • 交差する道路の道路縁が接する点を結ぶ線に囲まれた車道部を取得する。 +
 • 高さは0とする。
-a| image::images/142.webp["",200,""]
+a| image::images/142.webp["",200]
 
 | • 歩道部
 a| • 歩道部の境界をつないだ面を取得する。 +
@@ -9239,10 +9239,10 @@
 歩道部のうち、植栽を区分する。
 | LOD3.2の区分を細分する。細分はユースケースに応じて決定する。
 
-^a| image::images/143.webp["",150,""]
-^a| image::images/144.webp["",210,""]
-^a| image::images/145.webp["",220,""]
-^a| image::images/146.webp["",240,""]
+^a| image::images/143.webp["",150]
+^a| image::images/144.webp["",210]
+^a| image::images/145.webp["",220]
+^a| image::images/146.webp["",240]
 
 |===
 
@@ -9260,48 +9260,48 @@
  +
 立体交差が表現できる。
 
-image::images/147.webp["",200,""]
+image::images/147.webp["",200]
 
 a| 
 徒歩道の横断方向に存在する15㎝以上の高さの差を取得する。 +
  +
 ①2㎝以上の段は、段の形状を取得する。
 
-image::images/148.webp["",250,""]
+image::images/148.webp["",250]
 
 a| 
 徒歩道の横断方向に存在する2㎝以上の高さの差を取得する。 +
  +
 ①15㎝以上の段は、段の形状を取得する。
 
-image::images/149.webp["",250,""]
+image::images/149.webp["",250]
 
 a| 
 ②15㎝以上のスロープは、スロープの形状を取得する。
 
-image::images/150.webp["",250,""]
+image::images/150.webp["",250]
 
 a| 
 ②2㎝以上のスロープは、スロープの形状を取得する。
 
-image::images/151.webp["",250,""]
+image::images/151.webp["",250]
 
 .2+a| 
 ③高さの差が15㎝未満の段が複数あり、合計15㎝以上の高さの差がある場合は、スロープとして取得する。
 
-image::images/152.webp["",250,""]
+image::images/152.webp["",250]
 
 歩道と車道との間や車道と島との間に存在する縁石による段を表現できる。
 
 a| 
 ③高さの差が2㎝未満の段が複数あり、合計2㎝以上の高さの差がある場合は、スロープとして取得する。
 
-image::images/153.webp["",250,""]
+image::images/153.webp["",250]
 
 a| 
 歩道に設けられた切り下げ部に存在する段が表現できる。
 
-image::images/154.webp["",240,""]
+image::images/154.webp["",240]
 
 |===
 
@@ -9491,7 +9491,7 @@
 a| 
 高さの差を表現する面は、歩道部の一部として取得する。
 
-image::images/155.webp["",200,""]
+image::images/155.webp["",200]
 
 .2+| LOD3.2
 .2+| ●
@@ -9574,7 +9574,7 @@
 a| 
 高さの差を表現する面は、歩道部の一部として取得する。
 
-image::images/156.webp["",200,""]
+image::images/156.webp["",200]
 
 .2+| LOD3.3
 .2+| ●
@@ -9658,7 +9658,7 @@
 a| 
 高さの差を表現する面は、歩道部の一部として取得する。
 
-image::images/157.webp["",200,""]
+image::images/157.webp["",200]
 
 | LOD3.4
 | 〇
@@ -9768,7 +9768,7 @@
 
 ===== 1) tran:Trackの拡張属性
 
-image::images/158.svg["","",""]
+image::images/158.svg[]
 
 　
 
@@ -9786,21 +9786,21 @@
 2+a| 
 • LOD0における徒歩道の取得例
 
-image::images/159.webp["",180,""]
+image::images/159.webp["",180]
 
 ネットワークで取得する場合は、徒歩道の中心線とする。徒歩道が道路と接する場合、道路中心線まで伸ばす。
 
 2+a| 
 • LOD1における徒歩道の取得例
 
-image::images/160.webp["",180,""]
+image::images/160.webp["",180]
 
 徒歩道のLOD1（面）は、徒歩道の境界に囲まれた範囲とする。徒歩道が道路と接する場合、その境界線は道路（tran:Road）の境界線と一致しなければならない。
 
 2+a| 
 • LOD2における徒歩道の取得例
 
-image::images/161.webp["",250,""]
+image::images/161.webp["",250]
 
 徒歩道のLOD2は、LOD1（面）をtran:TrafficArea（車道、車道交差部、歩道）及びtran:AuxiliaryTrafficArea（島）に区分する。このとき、隣接するtran:TrafficArea及びtran:AuxiliaryTrafficAreaの面の境界線は座標が一致していなければならない。 +
 また、徒歩道が道路と接続する場合、接続する境界線は一致しなければならない。 +
@@ -9811,13 +9811,13 @@
 徒歩道のLOD3は、LOD2と同様に徒歩道の面をtran:TrafficArea及びtran:AuxiliaryTrafficAreaに区分する。このとき、それぞれの面は高さをもつ。また、LOD2よりもさらに細かい種類にtran:TrafficArea及びtran:AuxiliaryTrafficAreaを分けることができる。「高さの表現」及び「広場内の表現」の組み合わせにより、LOD3.0、LOD3.1、LOD3.2、LOD3.3及び LOD3.4に分かれるが、標準製品仕様は、原則としてLOD3.0とする。 +
 LOD3.0では、徒歩道の横断方向に一律の高さ（車道の高さ）を付し、高さの差は表現しない。
 
-image::images/162.webp["",580,""]
+image::images/162.webp["",580]
 
 2+a| 
 徒歩道に車道が無い場合は歩道の高さとする。 +
 段の表現を行わないため、徒歩道に階段が存在する場合、階段の段は表現されず、最下段と最上段を結ぶ一定の斜度をもった面として表現される。
 
-image::images/163.webp["",450,""]
+image::images/163.webp["",450]
 
 LOD2と同様、道路と接続する場合は、境界線が一致していなければならない。
 
@@ -10103,12 +10103,12 @@
 a| 
 駅前広場
 
-image::images/164.webp["",350,""]
+image::images/164.webp["",350]
 
 a| 
 駅前広場
 
-image::images/165.webp["",340,""]
+image::images/165.webp["",340]
 
 h| 説明
 a| 広場内において、車道の両側（歩道、安全地帯及び分離帯）から等距離の点をつなぐ線分を、広場の中心線とする。 +
@@ -10120,13 +10120,13 @@
 h| 取得例
 ^a| 
 
-image::images/166.webp["",370,""]
+image::images/166.webp["",370]
 
 自動車ターミナル
 
 ^a| 
 
-image::images/167.webp["",350,""]
+image::images/167.webp["",350]
 
 自動車ターミナル
 
@@ -10140,13 +10140,13 @@
 h| 取得例
 ^a| 
 
-image::images/168.webp["",460,""]
+image::images/168.webp["",460]
 
 交通広場
 
 ^a| 
 
-image::images/169.webp["",460,""]
+image::images/169.webp["",460]
 
 交通広場
 
@@ -10208,7 +10208,7 @@
 |===
 h| LOD ^h| LOD1
 h| 取得例
-a| image::images/170.webp["",500,""]
+a| image::images/170.webp["",500]
 
 h| 説明
 a| 交通（広場）モデル（LOD1）の形状を示す面は、都市計画で定められた区域とする。 +
@@ -10258,7 +10258,7 @@
 |===
 h| LOD ^h| LOD2
 h| 取得例
-a| image::images/171.webp["",500,""]
+a| image::images/171.webp["",500]
 
 h| 説明
 a| 都市計画において定められた広場の区域（交通（広場）モデル（LOD1））を以下に区分する。 • 車道部 • 車道交差部 • 歩道部 • 島 高さは0とする。 +
@@ -10391,10 +10391,10 @@
 歩道部のうち、植栽を区分する。
 | LOD3.2の区分を細分する。細分はユースケースに応じて決定する。
 
-^a| image::images/172.webp["",150,""]
-^a| image::images/173.webp["",210,""]
-^a| image::images/174.webp["",220,""]
-^a| image::images/175.webp["",250,""]
+^a| image::images/172.webp["",150]
+^a| image::images/173.webp["",210]
+^a| image::images/174.webp["",220]
+^a| image::images/175.webp["",250]
 
 |===
 
@@ -10411,48 +10411,48 @@
 徒歩道内（車道、歩道、分離帯）の高さは、横断方向に同一（全て車道の高さ）となる。 +
 立体交差が表現できる。
 
-image::images/176.webp["",270,""]
+image::images/176.webp["",270]
 
 a| 
 徒歩道の横断方向に存在する15㎝以上の高さの差を取得する。 +
  +
 ①15㎝以上の段は、段の形状を取得する。
 
-image::images/177.webp["",270,""]
+image::images/177.webp["",270]
 
 a| 
 徒歩道の横断方向に存在する2㎝以上の高さの差を取得する。 +
  +
 ①2㎝以上の段は、段の形状を取得する。
 
-image::images/178.webp["",270,""]
+image::images/178.webp["",270]
 
 a| 
 ②15㎝以上のスロープは、スロープの形状を取得する。
 
-image::images/179.webp["",270,""]
+image::images/179.webp["",270]
 
 a| 
 ②2㎝以上のスロープは、スロープの形状を取得する。
 
-image::images/180.webp["",270,""]
+image::images/180.webp["",270]
 
 .2+a| 
 ③高さの差が15㎝未満の段が複数あり、合計15㎝以上の高さの差がある場合は、スロープとして取得する。
 
-image::images/181.webp["",270,""]
+image::images/181.webp["",270]
 
 歩道と車道との間や車道と島との間に存在する縁石による段を表現できる。
 
 a| 
 ③高さの差が2㎝未満の段が複数あり、合計2㎝以上の高さの差がある場合は、スロープとして取得する。
 
-image::images/182.webp["",270,""]
+image::images/182.webp["",270]
 
 a| 
 歩道に設けられた切り下げ部に存在する段が表現できる。
 
-image::images/183.webp["",300,""]
+image::images/183.webp["",300]
 
 |===
 
@@ -10897,7 +10897,7 @@
 
 ===== (2)　Urban Object（i-UR）
 
-image::images/184.svg["","",""]
+image::images/184.svg[]
 
 　
 
@@ -10923,21 +10923,21 @@
 2+a| 
 • LOD0における広場の取得例
 
-image::images/185.webp["",380,""]
+image::images/185.webp["",380]
 
 ネットワークで取得する場合は、広場の中心線とする。広場の中心線は、これに接する道路の中心線まで伸ばす。
 
 2+a| 
 • LOD1における広場の取得例
 
-image::images/186.webp["",450,""]
+image::images/186.webp["",450]
 
 広場のLOD1（面）は、都市計画図書の計画図に示された、都市計画の区域とする。
 
 2+a| 
 • LOD2における広場の取得例
 
-image::images/187.webp["",450,""]
+image::images/187.webp["",450]
 
 広場のLOD2は、LOD1（面）をtran:TrafficArea（車道部、車道交差部、歩道部）及びtran:AuxiliaryTrafficArea（島）に区分する。このとき、隣接するの面の境界線は、座標が一致していなければならない。 +
 また、広場の面が道路の面と重なる場合、重なる範囲に存在するtran:TrafficArea（車道、車道交差部、歩道）及びtran:AuxiliaryTrafficArea（島）は、道路の構成要素であり、かつ、広場の構成要素となる。
@@ -10947,7 +10947,7 @@
 広場のLOD3は、LOD2と同様に、広場の面をtran:TrafficArea及びtran:AuxiliaryTrafficAreaに区分する。このとき、それぞれの面は高さをもつ。また、LOD2よりもさらに細かい種類にtran:TrafficArea及びtran:AuxiliaryTrafficAreaを分けることができる。「高さの表現」及び「広場内の表現」の組み合わせにより、LOD3.0、LOD3.1、LOD3.2、LOD3.3及び LOD3.4に分かれるが、標準製品仕様は、原則としてLOD3.0とする。 +
 LOD3.0では、広場の高さは車道の高さとし、段の表現は行わない。歩道及び島には、車道の高さを与えるが、歩道及び島の面を構成する境界線上の各点に、これと接する車道の高さを付与する。高さが異なる車道に囲まれた歩道や島の面は、傾きをもった面となる。 +
 
-image::images/188.webp["",500,""]
+image::images/188.webp["",500]
 
 LOD2と同様、隣接する道路の境界線と一致していなければならず、広場の区域と道路の区域とが重なる場合は、この範囲に存在するtran:TrafficArea（車道、車道交差部、歩道）及びtran:AuxiliaryTrafficArea（島）を広場と道路が共有しなければならない。
 
@@ -11355,7 +11355,7 @@
 |===
 h| ^h| LOD0
 h| 取得例
-a| image::images/189.webp["",220,""]
+a| image::images/189.webp["",220]
 
 h| 説明 | 航路の区域の中心線を取得する。
 
@@ -11402,7 +11402,7 @@
 |===
 h| ^h| LOD1
 h| 取得例
-a| image::images/190.webp["",250,""]
+a| image::images/190.webp["",250]
 
 h| 説明
 a| 法令により指定された航路の区域を取得する。 +
@@ -11452,7 +11452,7 @@
 |===
 h| ^h| LOD2
 h| 取得例
-a| image::images/191.webp["",250,""]
+a| image::images/191.webp["",250]
 
 h| 説明
 a| 航路の境界線をつないだ面を取得する。 +
@@ -11517,7 +11517,7 @@
 
 ===== (1)　Urban Object（i-UR）
 
-image::images/192.svg["","",""]
+image::images/192.svg[]
 
 [[toc4_07_03]]
 ==== 　交通（航路）モデルの応用スキーマ文書
@@ -11532,7 +11532,7 @@
 2+a| 
 航路とは、船舶の通路として法令で定める海域である。標準製品仕様書では、原則として、以下に示す港則法や海上交通安全法によって規定される航路（法定航路）を対象とする。 • 港則法施行規則第8条 • 海上交通安全法第2条 法定航路とは、港則法における特定港、及び特定港以外の港では海上交通安全法によって規定された航路をいう。[国土数値情報　航路データ] なお、ユースケースの必要に応じて港湾法によって規定される開発保全航路を航路に含むことができる。 開発保全航路とは、港湾法の規定による港湾区域及び河川法に規定する河川区域以外の水域における船舶の交通を確保するため、開発及び保全に関する工事を必要とする航路をいう。[国土数値情報　航路データ] 航路の延長方向は、以下の場所で区切る。 • 航路が交差する部分（二つ以上の航路が交わる部分）
 
-image::images/193.webp["",350,""]
+image::images/193.webp["",350]
 
 tran:Waterwayに含まれるtran:TrafficAreaは、同一航路でなければならない。 +
 同一のLODにおいて、連続する航路の境界は一致しなければならない。
@@ -11598,7 +11598,7 @@
 法令により指定された進行方向に区切った航路の部分。 +
 高さは0とする。
 
-image::images/194.webp["",250,"",title=" 図　LOD2における航路のtran:TrafficAreaの例"]
+image::images/194.webp["",250,title=" 図　LOD2における航路のtran:TrafficAreaの例"]
 
 h| 上位の型 2+| tran:_TransportationObject
 h| ステレオタイプ 2+| << FeatureType >>
@@ -11771,7 +11771,7 @@
 |===
 h| ^h| LOD1
 h| 取得例
-a| image::images/195.webp["",800,""]
+a| image::images/195.webp["",800]
 
 h| 説明
 a| 都市計画基礎調査の土地利用現況において作成された面に一致する。 +
@@ -11833,11 +11833,11 @@
 
 ===== (1)　LandUse（CityGML）
 
-image::images/196.svg["","",""]
+image::images/196.svg[]
 
 ===== (2)　Urban Object （i-UR）
 
-image::images/197.svg["","",""]
+image::images/197.svg[]
 
 [[toc4_08_03]]
 ==== 　土地利用モデルの応用スキーマ文書
@@ -12056,7 +12056,7 @@
 |===
 h| ^h| LOD1
 h| 取得例
-a| image::images/198.webp["",400,""]
+a| image::images/198.webp["",400]
 
 h| 説明
 a| 洪水浸水想定区域、津波浸水想定、高潮浸水想定区域、及び内水浸水想定区域の浸水面を取得する。 +
@@ -12106,7 +12106,7 @@
 |===
 h| ^h| LOD1
 h| 取得例
-a| image::images/199.webp["",300,""]
+a| image::images/199.webp["",300]
 
 h| 説明
 a| 土砂災害警戒区域及び土砂災害特別警戒区域に指定された範囲を取得する。 +
@@ -12174,7 +12174,7 @@
 
 災害リスク（浸水）モデル（LOD1）で表現する浸水面の記述には、CityGMLのWaterBodyを使用する。
 
-image::images/200.svg["","",""]
+image::images/200.svg[]
 
 　
 
@@ -12182,7 +12182,7 @@
 
 ===== 1)　洪水浸水想定区域、雨水出水浸水想定区域、高潮浸水想定区域、津波浸水想定
 
-image::images/201.svg["","",""]
+image::images/201.svg[]
 
 　
 
@@ -12190,13 +12190,13 @@
 
 橋梁等の地物に、災害リスク属性を付与するためのデータ型である。
 
-image::images/202.svg["","",""]
+image::images/202.svg[]
 
 ===== (3)　Urban Function（i-UR）
 
 災害リスク（土砂災害）モデルは、urf::SedimentDisasterProneAreaを使用して記述する。
 
-image::images/203.svg["","",""]
+image::images/203.svg[]
 
 [[toc4_09_03]]
 ==== 　災害リスクモデルの応用スキーマ文書
@@ -12213,7 +12213,7 @@
 標準製品仕様では、「wtr:WaterBody」を用いて、洪水浸水想定区域、津波浸水想定、高潮浸水想定区域、及び内水浸水想定区域（以下、浸水想定区域等と呼ぶ）の浸水面を記述する。 +
 浸水面を構成する図形の頂点の高さは、標高に水位を加えた高さとする。
 
-image::images/204.webp["",400,"",title=" 　　　　　　　　図　wtr:WaterBodyの例（PlateauView上でbldg:BuildingのLOD1モデルと重畳表示）"]
+image::images/204.webp["",400,title=" 　　　　　　　　図　wtr:WaterBodyの例（PlateauView上でbldg:BuildingのLOD1モデルと重畳表示）"]
 
 h| 上位の型 2+| wtr:_WaterObject
 h| ステレオタイプ 2+| << FeatureType >>
@@ -12363,7 +12363,7 @@
 洪水浸水想定区域内に存在する構造物に、浸水想定区域がもつ属性を与えるための属性型。 +
 同一の浸水想定区域図において、複数の区域に一つ構造物が跨って存在する場合は、同一浸水ランクを持つ浸水ランクのメッシュを一つの区域とし、その区域と構造物が重なる面積が最も大きい浸水ランクの値を採用する。（面積が等しい場合は、より危険な区域を採用する） 浸水深は採用した浸水ランクを持つ浸水深のメッシュのうち、構造物と重なる面積が最も大きいメッシュの浸水深を採用する。（同じ浸水深を持つメッシュは面積算出の際に合算する） 浸水継続時間は採用した浸水深のメッシュと重なる浸水継続時間のメッシュの浸水継続時間を採用する。複数の浸水継続時間のメッシュが重なる場合は最も大きい浸水継続時間の値を採用する。
 
-image::images/205.webp["",400,""]
+image::images/205.webp["",400]
 
 h| 上位の型 2+| uro: FloodingRiskAttribute
 h| ステレオタイプ 2+| << DataType >>
@@ -12774,7 +12774,7 @@
 |===
 ^h| ^h| LOD1
 ^h| 取得例
-a| image::images/206.webp["",600,""]
+a| image::images/206.webp["",600]
 
 ^h| 説明 | 区域の境界により囲まれた面を取得する。 高さは0とする。
 
@@ -12946,83 +12946,83 @@
 
 ===== (2)　都市計画決定情報の概要
 
-image::images/207.svg["","",""]
+image::images/207.svg[]
 
 ===== (3) 都市計画区域、準都市計画区域
 
-image::images/208.svg["","",""]
+image::images/208.svg[]
 
 ===== (4) 区域区分
 
-image::images/209.svg["","",""]
+image::images/209.svg[]
 
 ===== (5) 地域地区及び用途地域
 
-image::images/210.svg["","",""]
+image::images/210.svg[]
 
 ===== (6) 促進区域
 
-image::images/211.svg["","",""]
+image::images/211.svg[]
 
 ===== (7) 遊休土地転換利用促進地区
 
-image::images/212.svg["","",""]
+image::images/212.svg[]
 
 ===== (8) 被災市街地復興推進地域
 
-image::images/213.svg["","",""]
+image::images/213.svg[]
 
 ===== (9) 都市施設
 
-image::images/214.svg["","",""]
+image::images/214.svg[]
 
 ===== (10) 交通施設
 
-image::images/215.svg["","",""]
+image::images/215.svg[]
 
 ===== (11) 公共空地
 
-image::images/216.svg["","",""]
+image::images/216.svg[]
 
 ===== (12) 供給施設及び処理施設
 
-image::images/217.svg["","",""]
+image::images/217.svg[]
 
 ===== (13) 水路
 
-image::images/218.svg["","",""]
+image::images/218.svg[]
 
 ===== (14) 教育文化施設
 
-image::images/219.svg["","",""]
+image::images/219.svg[]
 
 ===== (15) 医療施設及び社会福祉施設
 
-image::images/220.svg["","",""]
+image::images/220.svg[]
 
 ===== (16) 市場、と畜場、火葬場
 
-image::images/221.svg["","",""]
+image::images/221.svg[]
 
 ===== (17) 市街地開発事業
 
-image::images/222.svg["","",""]
+image::images/222.svg[]
 
 ===== (18) 市街地開発事業等予定区域
 
-image::images/223.svg["","",""]
+image::images/223.svg[]
 
 ===== (19) 地区計画等
 
-image::images/224.svg["","",""]
+image::images/224.svg[]
 
 ===== (20) 立体的な範囲、区域界
 
-image::images/225.svg["","",""]
+image::images/225.svg[]
 
 ===== (21) 立地適正化計画
 
-image::images/226.svg["","",""]
+image::images/226.svg[]
 
 [[toc4_10_03]]
 ==== 　都市計画決定情報モデルの応用スキーマ文書
@@ -13037,7 +13037,7 @@
 2+a| 
 都市計画区域。都市の実態や将来の計画を勘案して、一体の都市地域となるべき区域として指定された区域。（都市計画法第5条第1項）
 
-image::images/227.webp["",250,"",title=" 図　都市計画区域の例"]
+image::images/227.webp["",250,title=" 図　都市計画区域の例"]
 
 複数の市区町村にまたがる都市計画区域の場合は、市区町村の境界で区切る。
 
@@ -13177,7 +13177,7 @@
 2+a| 
 都市計画法第7条に基づき、無秩序な市街地の拡大による環境悪化の防止、計画的な公共施設整備などによる良好な市街地の形成などを行うため、都市計画区域について区分された、計画的な市街化を図るべき区域「市街化区域」と、市街化を抑制すべき「市街化調整区域」。（都市計画法第7条）
 
-image::images/228.webp["",250,"",title=" 図　区域区分（市街化調整地域）の例"]
+image::images/228.webp["",250,title=" 図　区域区分（市街化調整地域）の例"]
 
 複数の市区町村にまたがる市街化区域又は市街化調整区域の場合は、市区町村の境界で区切る。
 
@@ -13241,7 +13241,7 @@
 地域地区。都市計画法第8条に基づき、都市計画区域内の土地をその利用目的によって区分し、建築物などに対するルールを決め、土地の合理的な利用を図るために指定された区域。 +
 下位の地物型として定義されていない地域地区を記述したい場合にのみ、この地物型を使用し、属性「urf:function」でその内容を識別する。下位の地物型として定義されている場合は、必ず下位の地物型を使用すること。
 
-image::images/229.webp["",350,"",title=" 図　urf:DistrictsAndZones及び下位型の例"]
+image::images/229.webp["",350,title=" 図　urf:DistrictsAndZones及び下位型の例"]
 
 （3D地形の上でLOD1のbldg:Buildingと重畳表示している）
 
@@ -20209,11 +20209,11 @@
 |===
 h| 5+^h| LOD0
 h| 取得例
-^a| image::images/230.webp["",150,""]
-^a| image::images/231.webp["",120,""]
-^a| image::images/232.webp["",150,""]
-^a| image::images/233.webp["",120,""]
-^a| image::images/234.webp["",120,""]
+^a| image::images/230.webp["",150]
+^a| image::images/231.webp["",120]
+^a| image::images/232.webp["",150]
+^a| image::images/233.webp["",120]
+^a| image::images/234.webp["",120]
 
 h| 説明 | 道路橋は、地図情報レベル2500では、縁線を取得する。また、ひ開部を表示する。地図情報レベル500及び1000では、縁線のほか、高欄、橋脚及び親柱（橋の両端に高欄の続きとして設けられる高欄より大きな柱）の外周を取得する。 | 桟道橋は、橋桁が斜面に接していない側の縁線を取得し、橋脚の外周を取得する。 | 鉄道橋は、地図情報レベル2500では、縁線を取得する。地図情報レベル500及び1000では、橋の縁線と橋脚の縁線を取得する。 | 横断歩道橋、跨線橋及び公共用歩廊は、外周の正射影を取得する。 | 徒橋は、中心線を取得する。ひ開部を表示する。
 
@@ -20300,10 +20300,10 @@
 |===
 h| 4+^h| LOD1
 h| 取得例
-^a| image::images/235.webp["",190,""]
-^a| image::images/236.webp["",150,""]
-^a| image::images/237.webp["",150,""]
-^a| image::images/238.webp["",150,""]
+^a| image::images/235.webp["",190]
+^a| image::images/236.webp["",150]
+^a| image::images/237.webp["",150]
+^a| image::images/238.webp["",150]
 
 h| 説明
 a| 道路橋及び鉄道橋は、橋梁の縁線をつないだ外周に、地上から一律の高さを下向きに与えて立ち上げた立体とする。 +
@@ -20447,7 +20447,7 @@
 
 　
 
-image::images/239.webp["","","",title=" 図 4-5　橋梁の部材の名称"]
+image::images/239.webp[title=" 図 4-5　橋梁の部材の名称"]
 
 橋梁モデル（LOD2）の取得イメージを表 4-63に示す。
 
@@ -20456,8 +20456,8 @@
 |===
 h| 3+^h| LOD2.0
 h| 取得例
-a| image::images/240.webp["",250,""]
-2+a| image::images/241.webp["",350,""]
+a| image::images/240.webp["",250]
+2+a| image::images/241.webp["",350]
 
 h| 説明
 | 道路橋、桟道橋及び鉄道橋は、床版の外周を、高さをもった面として表現する。
@@ -20466,9 +20466,9 @@
 
 h| 3+^h| LOD2.1
 h| 取得例
-a| image::images/242.webp["",300,""]
-a| image::images/243.webp["",300,""]
-a| image::images/244.webp["",330,""]
+a| image::images/242.webp["",300]
+a| image::images/243.webp["",300]
+a| image::images/244.webp["",330]
 
 h| 説明
 a| 道路橋、桟道橋及び鉄道橋は、床版及び主桁によって、厚みと高さをもった立体として表現する。 +
@@ -20719,14 +20719,14 @@
 |===
 h| 2+^h| LOD3
 h| 取得例
-a| image::images/245.webp["",280,""]
-a| image::images/246.webp["",270,""]
+a| image::images/245.webp["",280]
+a| image::images/246.webp["",270]
 
 h| 説明 | 道路橋及び鉄道橋の場合は、床版及び主桁以外の構造上不可欠な部材をBridgeConstructionElementとして取得する。上図の例では橋脚が該当する。それ以外の橋梁の外観を構成する部材をBridgeInstallationとして取得する。上図の例では高欄が該当する。 | 跨線橋の場合は、道路橋及び鉄道橋と同様に、床版及び主桁以外の構造上不可欠な部材をBridgeConstructionElementとして取得する。上図の例では橋脚が該当する。それ以外の橋梁の外観を構成する部材をBridgeInstallationとして取得する。上図の例では高欄が該当する。
 h| 2+^h| LOD3
 h| 取得例
-a| image::images/247.webp["",260,""]
-a| image::images/248.webp["",370,""]
+a| image::images/247.webp["",260]
+a| image::images/248.webp["",370]
 
 h| 説明
 a| ケーブル橋の場合、パイロン、ケーブル及び吊材を構造上不可欠な部材（BuildingConstructionElement）として取得する。 +
@@ -20945,7 +20945,7 @@
 そこで、これらの部材クラスの集まりであるIfcBridgePart及びIfcElementAssemblyとCityGMLの地物型とを対応付けた。 +
 このとき、IfcBridgePart及びIfcElementAssemblyの属性PredefinedTypeによりCityGMLの地物型であるbrid:Bridge、brid:BridgeConstructionElement又はbrid:BridgeInstallationへの振り分けを行っている。
 
-image::images/249.webp["","","",title=" 図 4-6　IfcBridgeにおけるクラス間の階層構造（出典：IFC Bridge Fast Track Project Report WP2: Conceptual Model）"]
+image::images/249.webp[title=" 図 4-6　IfcBridgeにおけるクラス間の階層構造（出典：IFC Bridge Fast Track Project Report WP2: Conceptual Model）"]
 
 ===== 2)　橋梁モデル（LOD4）の定義
 
@@ -21201,11 +21201,11 @@
 
 ===== (1) Bridge（CityGML）
 
-image::images/250.svg["","",""]
+image::images/250.svg[]
 
 ===== (2)　Urban Object（i-UR）
 
-image::images/251.svg["","",""]
+image::images/251.svg[]
 
 [[toc4_11_03]]
 ==== 　橋梁モデルの応用スキーマ文書
@@ -21456,7 +21456,7 @@
 橋梁の構造上重要な部材。 +
 橋脚、橋台、トラス、アーチ、吊材、パイロン、ケーブルをさす。
 
-image::images/252.webp["",600,"",title=" 図　brid:BridgeConstructionElementの例"]
+image::images/252.webp["",600,title=" 図　brid:BridgeConstructionElementの例"]
 
 h| 上位の型 2+| brid:_CityObject
 h| ステレオタイプ 2+| << FeatureType >>
@@ -22483,11 +22483,11 @@
 |===
 h| 5+^h| LOD0
 h| 取得例
-a| image::images/253.webp["",200,""]
-a| image::images/254.webp["",200,""]
-a| image::images/255.webp["",200,""]
-a| image::images/256.webp["",200,""]
-a| image::images/257.webp["",200,""]
+a| image::images/253.webp["",200]
+a| image::images/254.webp["",200]
+a| image::images/255.webp["",200]
+a| image::images/256.webp["",200]
+a| image::images/257.webp["",200]
 
 h| 説明 | 中央位置の点と方向を取得する。 | 坑口部分の外周を線として取得する。 | 坑口部分の外周を面として取得する。 | | 
 
@@ -22552,8 +22552,8 @@
 |===
 h| 2+^h| LOD1
 h| 取得例
-a| image::images/258.webp["",300,""]
-a| image::images/259.webp["",300,""]
+a| image::images/258.webp["",300]
+a| image::images/259.webp["",300]
 
 h| 説明 | トンネルの場合は、トンネルの坑口を含めた外周に一律の高さを与えて立ち上げた立体として表現する。 一律の高さは、トンネルの最も低い高さから最も高い高さまでとする。 トンネル内部が傾斜している場合は、その標高差によりトンネルの形状が実際の形状と乖離する。 そのため、ユースケースの必要に応じて、トンネルをTunnelPartに区切り、区切った区間ごとに一律の高さを立ち上げることで、より実際に近い形状で表現できる。 | 地下横断歩道の場合は、地下横断歩道の外周に、路面の高さから一律の高さ（設計図や竣工図に示された構造物の深さ）を下向きに与えた立体として表現する。 地下横断歩道内部が傾斜している場合は、その標高差により地下横断歩道の形状が実際の形状と乖離する。 そのため、ユースケースの必要に応じて、地下横断歩道をTunnelPartに区切り、区切った区間ごとに一律の高さを立ち上げることで、より実際に近い形状で表現できる。 なお、地下横断歩道の出入口に、防風・雨・雪及び採光を目的として設けられた建屋は、都市設備（CityFurniture）として取得する。
 
@@ -22619,8 +22619,8 @@
 |===
 h| 2+^h| LOD2
 h| 取得例
-a| image::images/260.webp["",300,""]
-a| image::images/261.webp["",300,""]
+a| image::images/260.webp["",300]
+a| image::images/261.webp["",300]
 
 h| 説明 | トンネルの外形を立体として表現し、立体の各境界面を、屋根や外壁に区分する。トンネルの外形には坑口を含む。 | 地下横断歩道の外形を立体として取得し、立体の各境界面を、屋根や外壁に区分する。 地下横断歩道の出入口に設けられた建屋は、都市設備（CityFurniture）として取得する。
 
```
(diff is trimmed)

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
