### PR TITLE
reverse_adoc: Correct syntax for levels >= 6

### DIFF
--- a/lib/coradoc/element/title.rb
+++ b/lib/coradoc/element/title.rb
@@ -22,16 +22,28 @@ module Coradoc
       def to_adoc
         anchor = @anchor.nil? ? "" : "#{@anchor.to_adoc}\n"
         content = Coradoc::Generator.gen_adoc(@content)
-        level_str = "=" * (@level_int + 1)
-        style_str = "[#{@style}]\n" if style
         ["\n", anchor, style_str, level_str, " ", content, "\n"].join("")
+      end
+
+      def level_str
+        if @level_int <= 4
+          "=" * (@level_int + 1)
+        else
+          "====="
+        end
+      end
+
+      def style_str
+        style = [@style]
+        style << "level=#{@level_int}" if @level_int > 4
+        style = style.compact.join(",")
+
+        "[#{style}]\n" unless style.empty?
       end
 
       alias :text :content
 
       private
-
-      attr_reader :level_str
 
       def level_from_string
         case @level_int

--- a/lib/coradoc/element/title.rb
+++ b/lib/coradoc/element/title.rb
@@ -22,20 +22,23 @@ module Coradoc
       def to_adoc
         anchor = @anchor.nil? ? "" : "#{@anchor.to_adoc}\n"
         content = Coradoc::Generator.gen_adoc(@content)
-        ["\n", anchor, style_str, level_str, " ", content, "\n"].join("")
+        <<~HERE
+
+        #{anchor}#{style_str}#{level_str} #{content}
+        HERE
       end
 
       def level_str
-        if @level_int <= 4
+        if @level_int <= 5
           "=" * (@level_int + 1)
         else
-          "====="
+          "======"
         end
       end
 
       def style_str
         style = [@style]
-        style << "level=#{@level_int}" if @level_int > 4
+        style << "level=#{@level_int}" if @level_int > 5
         style = style.compact.join(",")
 
         "[#{style}]\n" unless style.empty?
@@ -50,6 +53,7 @@ module Coradoc
         when 2 then :heading_two
         when 3 then :heading_three
         when 4 then :heading_four
+        when 5 then :heading_five
         else :unknown
         end
       end

--- a/lib/coradoc/reverse_adoc/plugins/plateau.rb
+++ b/lib/coradoc/reverse_adoc/plugins/plateau.rb
@@ -56,6 +56,7 @@ module Coradoc::ReverseAdoc
 
         # Add hooks for H1, H2, H3, H4
         html_tree_add_hook_post_by_css("h1, h2, h3", &method(:handle_headers))
+        html_tree_add_hook_post_by_css("h4", &method(:handle_headers_h4))
 
         # Table cells aligned to center
         html_tree_change_properties_by_css(".tableTopCenter", align: "center")
@@ -130,6 +131,21 @@ module Coradoc::ReverseAdoc
         coradoc.content.first.content.sub!(/\A[\d\s.]+/, "")
 
         coradoc
+      end
+
+      def handle_headers_h4(node, coradoc, state)
+        case coradoc.content.first.content
+        when /\A\(\d+\)(.*)/
+          coradoc.level_int = 4
+          coradoc.content.first.content = $1.strip
+          coradoc
+        when /\A\d+\)(.*)/
+          coradoc.level_int = 5
+          coradoc.content.first.content = $1.strip
+          coradoc
+        else
+          ["// FIXME\n", coradoc]
+        end
       end
 
       def postprocess_asciidoc_string

--- a/spec/reverse_adoc/components/basic_spec.rb
+++ b/spec/reverse_adoc/components/basic_spec.rb
@@ -11,8 +11,8 @@ describe Coradoc::ReverseAdoc do
   it { is_expected.to match /\n=== h2\n/ }
   it { is_expected.to match /\n==== h3\n/ }
   it { is_expected.to match /\n===== h4\n/ }
-  it { is_expected.to include "\n[level=5]\n===== h5\n" }
-  it { is_expected.to include "\n[level=6]\n===== h6\n" }
+  it { is_expected.to match /\n====== h5\n/ }
+  it { is_expected.to include "\n[level=6]\n====== h6\n" }
 
   it { is_expected.to match /_em tag content_/ }
   it { is_expected.to match /before and after empty em tags/ }

--- a/spec/reverse_adoc/components/basic_spec.rb
+++ b/spec/reverse_adoc/components/basic_spec.rb
@@ -11,8 +11,8 @@ describe Coradoc::ReverseAdoc do
   it { is_expected.to match /\n=== h2\n/ }
   it { is_expected.to match /\n==== h3\n/ }
   it { is_expected.to match /\n===== h4\n/ }
-  it { is_expected.to match /\n====== h5\n/ }
-  it { is_expected.to match /\n======= h6\n/ }
+  it { is_expected.to include "\n[level=5]\n===== h5\n" }
+  it { is_expected.to include "\n[level=6]\n===== h6\n" }
 
   it { is_expected.to match /_em tag content_/ }
   it { is_expected.to match /before and after empty em tags/ }


### PR DESCRIPTION
This fixes #69 and fixes #66. This does fix NOT #65.

Excerpts from a diff of our incoming document **(please don't miss my comment for the second excerpt)**:

```diff
diff -Naur _prev/sections/section-09.adoc _curr/sections/section-09.adoc
--- _prev/sections/section-09.adoc      2024-05-30 23:39:22.776664086 +0200
+++ _curr/sections/section-09.adoc      2024-05-30 23:38:59.504662193 +0200
@@ -154,7 +154,7 @@
 [[toc9_06_02]]
 ==== 　ファイル単位
 
-===== (1)　ファイル単位
+===== 　ファイル単位
 
 ファイル単位は、「作業規程の準則　付録７　公共測量標準図式　第84条」において定められた国土基本図の図郭とする。 +
 また、一つのファイルには、同一の空間参照系のオブジェクトのみを含む。 +
@@ -162,7 +162,7 @@
 
 　
 
-===== (2)　ファイルサイズとファイル分割
+===== 　ファイルサイズとファイル分割
 
 1ファイルのデータ量の上限は最大1GBとする。 +
 1ファイルのデータ量が1GBを超える場合は、ファイルを分割する。分割したファイルは、同じ図郭を重複して含んではならない。
@@ -180,7 +180,7 @@
 [[toc9_06_03]]
 ==== 　境界線上の地物の取り扱い
 
-===== (1)　ファイルの境界線上に存在する地物
+===== 　ファイルの境界線上に存在する地物
 
 ファイル単位となる国土基本図の図郭の境界線上に存在する地物は分割しない。 +
 複数の図郭に跨って存在する地物は、それぞれの図郭に平面投影した形状が含まれる面積又は延長の割合を算出し、この割合が最も大きい図郭に対応するファイルに含む。 +
@@ -189,7 +189,7 @@
 
 　
 
-===== (2)　行政区域の境界線上に存在する地物
+===== 　行政区域の境界線上に存在する地物
 
 　データセットの単位となる行政区域の境界線に跨って存在する地物は、分割しない。
 
@@ -282,7 +282,8 @@
 
 image::images/461.webp["","",""]
 
-===== 1)　core:ImplicitGeometry
+[level=5]
+===== 　core:ImplicitGeometry
 
 [cols="1,1,2"]
 |===
@@ -302,7 +303,8 @@
 
 |===
 
-===== 2)　core:TransformationMatrix4x4
+[level=5]
+===== 　core:TransformationMatrix4x4
 
 [cols="1,1,2"]
 |===
@@ -316,7 +318,8 @@
 
 |===
 
-===== 3)　ImplicitGeometry_mimeType.xml
+[level=5]
+===== 　ImplicitGeometry_mimeType.xml
 
 [cols=2]
 |===
@@ -331,7 +334,8 @@
 
 |===
 
-===== 4)　ImplicitGeometryにより地下埋設物の形状を表現する場合の関連役割
+[level=5]
+===== 　ImplicitGeometryにより地下埋設物の形状を表現する場合の関連役割
 
 地下埋設物の形状を、ImplicitGeometryにより表現する場合、frn:CityFurnitureから継承する関連役割を使用する。
```

Here, we have some issue. Some level 4 paragraph has no number. I'm adding a comment FIXME for editor to correct.

```diff
diff -Naur _prev/sections/section-07.adoc _curr/sections/section-07.adoc
--- _prev/sections/section-07.adoc      2024-05-30 23:39:22.776664086 +0200
+++ _curr/sections/section-07.adoc      2024-05-30 23:38:59.504662193 +0200
@@ -22,7 +22,9 @@
 
 　
 
-===== (1)　符号化要件
+===== 　符号化要件
+
+// FIXME
 
 ===== 【符号化の対象とする応用スキーマとスキーマ言語】
 
@@ -31,6 +33,8 @@
 
 　
 
+// FIXME
+
 ===== 【使用する文字レパートリ】
 
 [none]
@@ -40,6 +44,8 @@
 
 　
 
+// FIXME
+
 ===== 【データ集合とオブジェクトの識別】
 
 [none]
@@ -51,21 +57,21 @@
 
 　
 
-===== (2)　入力データ構造
+===== 　入力データ構造
 
 [none]
 ** 　入力データ構造は、応用スキーマクラス図と実装される個々のインスタンスとの関係を示すものである。入力データ構造は、CityGMLが参照するGML[3]において定義される Annex F GML-to-UML Application Schema Encoding Rulesに従う。&nbsp;
 
 　
 
-===== (3)　出力データ構造
+===== 　出力データ構造
 
 [none]
 ** 　出力データ構造には、i-UR 3.0及びCityGML 2.0を使用する。拡張子は、「.gml」とする。
 
 　
 
-===== (4)　変換規則
+===== 　変換規則
 
 [none]
 ** 1)&nbsp;スキーマ変換規則
```

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
