### PR TITLE
reverse_adoc: Interim fix: Ensure header doesn't span multiple rows

### DIFF
--- a/lib/coradoc/reverse_adoc/converters/table.rb
+++ b/lib/coradoc/reverse_adoc/converters/table.rb
@@ -56,6 +56,12 @@ module Coradoc::ReverseAdoc
         cols = ensure_row_column_integrity_and_get_column_sizes(node)
         attrs.add_named("cols", cols)
 
+        # Header first rows can't span multiple riws - drop header if they do.
+        header = node.at_xpath(".//tr")
+        unless header.xpath("./td | ./th").all? { |i| [nil, "1", ""].include? i["rowspan"] }
+          attrs.add_named("options", ["noheader"])
+        end
+
         # This line should be removed.
         return "" if attrs.empty?
 


### PR DESCRIPTION
This is an interim fix for #77. After this patch, metanorma doesn't drop an error. Diff for the incoming document:

```diff
diff -Naur _prev/sections/section-04.adoc _curr/sections/section-04.adoc
--- _prev/sections/section-04.adoc      2024-05-31 11:47:23.456094406 +0200
+++ _curr/sections/section-04.adoc      2024-05-31 11:47:00.377082538 +0200
@@ -57,7 +57,7 @@
 
 各パッケージは、CityGML及びi-URに定義されたパッケージを引用する（表 4-2）。
 
-[cols="15,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4"]
+[cols="15,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4",options="noheader"]
 .表 4-2　3D都市モデルが引用するCityGML及びi-URのパッケージ
 |===
 .2+a| 
@@ -2429,7 +2429,7 @@
 
 ===== 9)　bldg:ClosureSurface
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .3+| 型の定義
 2+a| 
@@ -6929,7 +6929,7 @@
 
 ===== 1)　tran:Road
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .3+| 型の定義
 2+a| 
@@ -7004,7 +7004,7 @@
 
 ===== 2)　tran:TrafficArea
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .4+| 型の定義
 2+a| 
@@ -7090,7 +7090,7 @@
 
 ===== 3)　tran:AuxiliaryTrafficArea
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .3+| 型の定義
 2+a| 
@@ -8308,7 +8308,7 @@
 
 ===== 1)　tran:Railway
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .4+| 型の定義
 2+a| 
@@ -8388,7 +8388,7 @@
 
 ===== 2)　tran:TrafficArea
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .4+| 型の定義
 2+a| 
@@ -8452,7 +8452,7 @@
 
 ===== 3)　tran:AuxiliaryTrafficArea
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .2+| 型の定義
 2+a| 
@@ -9779,7 +9779,7 @@
 
 ===== 1)　tran:Track
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .6+| 型の定義 2+| 徒歩道。徒歩道とは、人や車両等の通行の用に供される道路のうち、道路法第3条に示された道路の種類及び建築基準法第42条による「道路」を除く道路を指す。徒歩道には、作業規程の準則　付録７公共測量標準図式における徒歩道及び庭園路（ただし、庭園路のうち、自動車ターミナル内の道路は、広場として取得するため、徒歩道には含まない）を含む。 ここで、作業規程の準則付録７公共測量標準図式における徒歩道とは、「道路縁及び軽車道に接続するもの、登山、観光等に利用されるもの、神社等主要な地点へ到達するもの、耕地の区画等の景観を表現するために必要なもの」であり、庭園路とは、「公園、住宅地等で自動車の通行を規制している道路及び工場等特定の敷地内の道路」である。 徒歩道の延長方向は、以下の場所で区切る。 • 交差部（十字路、丁字路、その他二つ以上の徒歩道が交わる部分、tran:Roadと交わる部分） • 道路構造の変化点（トンネル、橋梁） • 位置正確度（地図情報レベル）や取得方法 同一のLODにおいて、連続する徒歩道の境界は一致しなければならない。 tran:Trackは、LOD0ではネットワーク（中心線）又は徒歩道縁により取得する。 LOD1以上では、面として取得する。 LOD2以上では、tran:Trackの面を、tran:TrafficAreaとtran:AuxiliaryTrafficAreaに細分する。 さらに、LOD3では、各地物の面に高さを付与する。 以下に、取得例を示す。
 
@@ -10908,7 +10908,7 @@
 
 ===== 1)　tran:Square
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .5+| 型の定義
 2+a| 広場。広場は、都市計画法第11条第1項に示される交通施設のうち、「駅前広場」、「自動車ターミナル」及び「交通広場」について、都市計画で定められた施設（都市計画施設）を指す。 +
@@ -29643,7 +29643,7 @@
 
 ===== 1)　uro:UndergroundBuilding
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .2+| 型の定義
 2+a| 
@@ -30635,7 +30635,7 @@
 
 　
 
-[cols=3]
+[cols=3,options="noheader"]
 |===
 .2+| LOD 2+^| 原典資料
 
@@ -31281,7 +31281,7 @@
 
 ===== 1)　wtr:WaterBody
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .4+| 型の定義
 2+a| 
@@ -32222,7 +32222,7 @@
 
 ===== 1)　grp:CityObjectGroup
 
-[cols="1,1,2"]
+[cols="1,1,2",options="noheader"]
 |===
 .2+| 型の定義
 2+a| 
````

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
