### PR TITLE
reverse_adoc: Fix regression: empty list items generated in nested lists

### DIFF
--- a/lib/coradoc/element/list/core.rb
+++ b/lib/coradoc/element/list/core.rb
@@ -25,8 +25,13 @@ module Coradoc
           @items.each do |item|
             c = Coradoc::Generator.gen_adoc(item)
             if !c.empty?
-              content << prefix.to_s
-              content << " " if c[0]!=" "
+              # If there's a list inside a list directly, we want to
+              # skip adding an empty list item.
+              # See: https://github.com/metanorma/coradoc/issues/96
+              unless item.is_a? List::Core
+                content << prefix.to_s
+                content << " " if c[0]!=" "
+              end
               content << c
             end
           end

--- a/lib/coradoc/element/list/definition.rb
+++ b/lib/coradoc/element/list/definition.rb
@@ -1,8 +1,10 @@
 module Coradoc
   module Element
     module List
-      class Definition < Core
+      class Definition < Base
         attr_accessor :items, :delimiter
+
+        declare_children :items
 
         def initialize(items, options = {})
           @items = items

--- a/spec/reverse_adoc/components/regressions_spec.rb
+++ b/spec/reverse_adoc/components/regressions_spec.rb
@@ -45,4 +45,9 @@ describe Coradoc::ReverseAdoc do
   t "attached<i>italics</i>here", "attached__italics__here"
   t "<mark>highlight</mark> itself", "#highlight# itself"
   t "attached<mark>highlight</mark>here", "attached##highlight##here"
+
+  # https://github.com/metanorma/coradoc/issues/96
+  t "<ul><li>test</li><ul><li>test</li></ul></ul>", "* test\n\n** test"
+  t "<ol><li>test</li><ol><li>test</li></ol></ol>", ". test\n\n.. test"
+  t "<ul><li>test</li><ol><li>test</li></ol></ul>", "* test\n\n.. test"
 end


### PR DESCRIPTION
This fixes #96

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
