### PR TITLE
`coradoc` CLI utility implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,16 @@ make test
 ```
 
 
-## Usages
+## Usage from command line
+
+### Converting a document
+
+```bash
+$ coradoc help convert
+$ coradoc convert file.html -o file.adoc
+```
+
+## Usage from Ruby
 
 ### Parsing a document
 

--- a/coradoc.gemspec
+++ b/coradoc.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "premailer", "~> 1.11.0"
   spec.add_dependency "word-to-markdown"
   spec.add_dependency "base64"
+  spec.add_dependency "thor"
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"

--- a/exe/coradoc
+++ b/exe/coradoc
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require "coradoc/cli"
+
+Coradoc::CLI.start

--- a/lib/coradoc/cli.rb
+++ b/lib/coradoc/cli.rb
@@ -50,8 +50,9 @@ module Coradoc
            type: :numeric,
            default: 0, banner: "LEVEL",
            desc: "Split sections into separate files up to a provided level"
+
     def convert(input = nil)
-      options[:require]&.each { |r| require r }
+      options[:require]&.each { |r| Kernel.require r }
 
       config = {
         input_options: input_options = {},

--- a/lib/coradoc/cli.rb
+++ b/lib/coradoc/cli.rb
@@ -1,0 +1,104 @@
+require "coradoc"
+require "thor"
+
+module Coradoc
+  class CLI < Thor
+    package_name "coradoc"
+
+    desc "convert [FILE]", "Convert document to another format"
+
+    option :output,
+           type: :string, aliases: "-o",
+           desc: "Output file to write"
+
+    option :input_format,
+           type: :string, aliases: "-I",
+           enum: Input.keys.map(&:to_s), default: nil,
+           desc: "Define input format (defaults to input file extension)"
+
+    option :output_format,
+           type: :string, aliases: "-O",
+           enum: Output.keys.map(&:to_s), default: nil,
+           desc: "Define output format (defaults to output file extension)"
+
+    at_least_one :output, :output_format
+
+    option :require,
+           type: :string, aliases: "-r",
+           repeatable: true,
+           desc: "Require additional Ruby file (eg. to load a plugin)"
+
+    option :external_images,
+           type: :boolean, aliases: "-e",
+           desc: "Extract images from input document"
+
+    option :unknown_tags,
+           type: :string, aliases: "-u",
+           enum: %w[pass_through drop bypass raise],
+           default: "pass_through",
+           desc: "Unknown tag handling"
+
+    option :mathml2asciimath,
+           type: :boolean, aliases: "-m",
+           desc: "Convert MathML to AsciiMath"
+
+    option :track_time,
+           type: :boolean,
+           desc: "Track time spent on each step"
+
+    option :split_sections,
+           type: :numeric,
+           default: 0, banner: "LEVEL",
+           desc: "Split sections into separate files up to a provided level"
+    def convert(input = nil)
+      options[:require]&.each { |r| require r }
+
+      config = {
+        input_options: input_options = {},
+        input_processor: nil,
+        output_options: output_options = {},
+        output_processor: nil,
+      }
+
+      config[:input_processor] = options[:input_format]&.to_sym
+      config[:output_processor] = options[:output_format]&.to_sym
+
+      %i[
+        external_images
+        unknown_tags
+        mathml2asciimath
+        track_time
+        split_sections
+      ].each do |i|
+        input_options[i] = options[i]
+      end
+
+      output = options[:output]
+
+      begin
+        Coradoc::Converter.(input, output, **config)
+      rescue Converter::NoInputPathError => e
+        warn "You must provide INPUT file as a file for this optionset."
+        warn "Detail: #{e.message}"
+      rescue Converter::NoOutputPathError => e
+        warn "You must provide OUTPUT file as a file for this optionset."
+        warn "Detail: #{e.message}"
+      rescue Converter::NoProcessorError => e
+        warn "No processor found for given input/output."
+        warn "Hint: set -I/--input-format or -O/--output-format option."
+        warn "Detail: #{e.message}"
+      end
+    end
+
+    desc "version", "display version information"
+    def version
+      puts "Coradoc: v#{Coradoc::VERSION}"
+      puts "[dependency] WordToMarkdown: v#{WordToMarkdown::VERSION}"
+      if Gem.win_platform?
+        puts "[dependency] LibreOffice: version not available on Windows"
+      else
+        puts "[dependency] LibreOffice: v#{WordToMarkdown.soffice.version}"
+      end
+    end
+  end
+end

--- a/lib/coradoc/converter.rb
+++ b/lib/coradoc/converter.rb
@@ -109,9 +109,11 @@ module Coradoc
       end
     end
 
-    class NoInputPathError < StandardError; end
-    class NoOutputPathError < StandardError; end
-    class NoProcessorError < StandardError; end
+    class ConverterArgumentError < ArgumentError; end
+
+    class NoInputPathError < ConverterArgumentError; end
+    class NoOutputPathError < ConverterArgumentError; end
+    class NoProcessorError < ConverterArgumentError; end
 
     module CommonInputOutputMethods
       def define(const)
@@ -122,17 +124,21 @@ module Coradoc
         @processors[id.to_sym]
       end
 
+      def keys
+        @processors.keys
+      end
+
       def select_processor(filename)
         filename = filename.path if filename.respond_to? :path
         unless filename.is_a? String
           raise Converter::NoProcessorError,
-                "can't find a path for #{filename}. You must manually select the processor."
+                "Can't find a path for #{filename}. You must manually select the processor."
         end
 
         @processors.values.find do |i|
           i.processor_match?(filename)
         end or raise Converter::NoProcessorError,
-                     "you must manually select the processor for #{filename}"
+                     "You must manually select the processor for #{filename}"
       end
     end
   end

--- a/lib/coradoc/parser/base.rb
+++ b/lib/coradoc/parser/base.rb
@@ -1,7 +1,6 @@
 require "parslet"
 require "parslet/convenience"
 
-
 require_relative "asciidoc/attribute_list"
 require_relative "asciidoc/base"
 require_relative "asciidoc/block"
@@ -35,7 +34,7 @@ module Coradoc
       rule(:document) do
         (
           admonition_line |
-          bib_entry | 
+          bib_entry |
           block_image |
           term | term2 |
           citation |
@@ -57,8 +56,8 @@ module Coradoc
       def self.parse(filename)
         content = File.read(filename)
         new.parse(content)
-      rescue Parslet::ParseFailed => failure
-        puts failure.parse_failure_cause.ascii_tree
+      rescue Parslet::ParseFailed => e
+        puts e.parse_failure_cause.ascii_tree
       end
     end
   end

--- a/spec/coradoc/cli_spec.rb
+++ b/spec/coradoc/cli_spec.rb
@@ -1,0 +1,112 @@
+require "spec_helper"
+require "coradoc/cli"
+
+RSpec.describe Coradoc::CLI do
+  let(:cli) { described_class.new }
+  let(:input_file) { "input.html" }
+  let(:output_file) { "output.adoc" }
+  let(:input_format) { :html }
+  let(:output_format) { :adoc }
+
+  describe "#convert" do
+    let(:mock_converter) { double("Coradoc::Converter") }
+
+    before do
+      allow(Coradoc::Converter).to receive(:call).and_return(mock_converter)
+    end
+
+    context "when called with valid input and output" do
+      it "calls the Converter with the correct arguments" do
+        expect(Coradoc::Converter).to receive(:call).with(
+          input_file,
+          output_file,
+          input_options: {
+            external_images: nil,
+            unknown_tags: "pass_through",
+            mathml2asciimath: nil,
+            track_time: nil,
+            split_sections: 0,
+          },
+          input_processor: nil,
+          output_options: {},
+          output_processor: nil,
+        )
+
+        cli.invoke(:convert, [input_file], output: output_file)
+      end
+    end
+
+    context "when input file is not provided" do
+      it "warns the user about the missing input file" do
+        allow(Coradoc::Converter).to receive(:call).and_raise(Coradoc::Converter::NoInputPathError.new("Input file missing"))
+
+        expect do
+          cli.invoke(:convert, [], output_format: output_format)
+        end.to output(/You must provide INPUT file as a file for this optionset./).to_stderr
+      end
+    end
+
+    context "when output file is not provided" do
+      it "warns the user about the missing output file" do
+        allow(Coradoc::Converter).to receive(:call).and_raise(Coradoc::Converter::NoOutputPathError.new("Output file missing"))
+
+        expect do
+          cli.invoke(:convert,
+                     [input_file], output_format: output_format)
+        end.to output(/You must provide OUTPUT file as a file for this optionset./).to_stderr
+      end
+    end
+
+    context "when no processor is found" do
+      it "warns the user about the missing processor" do
+        allow(Coradoc::Converter).to receive(:call).and_raise(Coradoc::Converter::NoProcessorError.new("No processor found"))
+
+        expect do
+          cli.invoke(:convert, [input_file],
+                     output: output_file, output_format: :asdf)
+        end.to output(/No processor found for given input\/output./).to_stderr
+      end
+    end
+
+    context "when additional Ruby files are required" do
+      it "requires the specified files" do
+        expect(Kernel).to receive(:require).with("some_file")
+        expect(Kernel).to receive(:require).with("another_file")
+
+        cli.invoke(:convert, [input_file],
+                   require: ["some_file", "another_file"],
+                   output_format: output_format)
+      end
+    end
+
+    context "when options are provided" do
+      it "passes the options to the converter" do
+        expect(Coradoc::Converter).to receive(:call).with(
+          input_file,
+          output_file,
+          input_options: {
+            external_images: true,
+            unknown_tags: "drop",
+            mathml2asciimath: true,
+            track_time: true,
+            split_sections: 2,
+          },
+          input_processor: input_format,
+          output_options: {},
+          output_processor: output_format,
+        )
+
+        cli.invoke(:convert, [input_file], {
+                     output: output_file,
+                     input_format: input_format,
+                     output_format: output_format,
+                     external_images: true,
+                     unknown_tags: "drop",
+                     mathml2asciimath: true,
+                     track_time: true,
+                     split_sections: 2,
+                   })
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR provides a simple `coradoc` CLI utility, which fixes #64 . This CLI tool, or more precisely, its `convert` command, has the same functionality as both `exe/reverse_adoc` and `exe/w2a` combined and will support additional formats as they are implemented (see https://github.com/metanorma/coradoc/issues/72).

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
