### PR TITLE
#27 Support for citations and xref anchors

### DIFF
--- a/lib/coradoc/element/inline/citation.rb
+++ b/lib/coradoc/element/inline/citation.rb
@@ -6,14 +6,15 @@ module Coradoc
 
         declare_children :cross_reference, :comment
 
-        def initialize(cross_reference, comment = nil)
-          @cross_reference = cross_reference
-          @comment = comment
+        def initialize(opts = {})
+          @cross_reference = opts.fetch(:cross_reference, nil)
+          @comment = opts.fetch(:comment, nil)
         end
 
         def to_adoc
           adoc = "[.source]\n"
-          adoc << @cross_reference.to_adoc
+          adoc << @cross_reference.to_adoc if @cross_reference
+          adoc << "\n" if @cross_reference && !@comment
           adoc << Coradoc::Generator.gen_adoc(@comment) if @comment
           adoc
         end

--- a/lib/coradoc/element/inline/cross_reference.rb
+++ b/lib/coradoc/element/inline/cross_reference.rb
@@ -2,21 +2,42 @@ module Coradoc
   module Element
     module Inline
       class CrossReference < Base
-        attr_accessor :href, :name
+        attr_accessor :href, :args
 
-        declare_children :href, :name
+        declare_children :href, :args
 
-        def initialize(href, name = nil)
+        def initialize(href, args = nil)
           @href = href
-          @name = name
+          @args = args
+          @args = nil if @args == ""
+          @args = [@args] unless @args.is_a?(Array) || @args == nil
         end
 
         def to_adoc
-          if @name.to_s.empty?
-            "<<#{@href}>>"
-          else
-            "<<#{@href},#{@name}>>"
+          if @args
+            args = @args.map{|a|
+              Coradoc::Generator.gen_adoc(a)}.join(',')
+            if args.empty?
+              return "<<#{@href}>>"
+            else
+              return "<<#{@href},#{args}>>"
+            end
           end
+          "<<#{@href}>>"
+        end
+      end
+
+      class CrossReferenceArg < Base
+        attr_accessor :key, :delimiter, :value
+
+        def initialize(key, delimiter, value)
+          @key = key
+          @delimiter = delimiter
+          @value = value
+        end
+
+        def to_adoc
+          [@key,@delimiter,@value].join
         end
       end
     end

--- a/lib/coradoc/parser/asciidoc/base.rb
+++ b/lib/coradoc/parser/asciidoc/base.rb
@@ -2,6 +2,7 @@ require_relative "admonition"
 require_relative "attribute_list"
 require_relative "bibliography"
 require_relative "block"
+require_relative "citation"
 require_relative "content"
 require_relative "document_attributes"
 require_relative "header"
@@ -20,6 +21,7 @@ module Coradoc
         include Coradoc::Parser::Asciidoc::AttributeList
         include Coradoc::Parser::Asciidoc::Bibliography
         include Coradoc::Parser::Asciidoc::Block
+        include Coradoc::Parser::Asciidoc::Citation
         include Coradoc::Parser::Asciidoc::Content
         include Coradoc::Parser::Asciidoc::DocumentAttributes
         include Coradoc::Parser::Asciidoc::Header

--- a/lib/coradoc/parser/asciidoc/citation.rb
+++ b/lib/coradoc/parser/asciidoc/citation.rb
@@ -1,0 +1,48 @@
+module Coradoc
+  module Parser
+    module Asciidoc
+      module Citation
+        def xref_anchor
+          match('[^,>]').repeat(1).as(:href_arg).repeat(1,1)
+        end
+
+        def xref_str
+          match('[^,>]').repeat(1).as(:text)
+        end
+
+        def xref_arg
+          (str('section') | str('paragraph') | str('clause') | str('annex') | str('table')).as(:key) >>
+          match('[ =]').as(:delimiter) >>
+          match('[^,>=]').repeat(1).as(:value)
+        end
+
+        def cross_reference
+          str('<<') >> xref_anchor >>
+          ( (str(',') >> xref_arg).repeat(1) |
+            (str(',') >> xref_str).repeat(1)
+            ).maybe >>
+            str('>>')
+        end
+
+        def citation_xref
+          cross_reference.as(:cross_reference) >> newline |
+          cross_reference.as(:cross_reference) >>
+            (text_line.repeat(1)
+            ).as(:comment).maybe
+        end
+
+        def citation_noxref
+          (text_line.repeat(1)
+          ).as(:comment)
+        end
+
+        def citation
+          match('^[\[]') >> str(".source]\n") >>
+          ( citation_xref |
+            citation_noxref
+          ).as(:citation)
+        end
+      end
+    end
+  end
+end

--- a/lib/coradoc/parser/asciidoc/content.rb
+++ b/lib/coradoc/parser/asciidoc/content.rb
@@ -26,10 +26,14 @@ module Coradoc
         end
 
         # Text
-        def text_line( n_line_breaks = 1)
-            (asciidoc_char_with_id.absent? | text_id) >> literal_space? >>
-            text.as(:text) >>
-            line_ending.repeat(n_line_breaks).as(:line_break)
+        def text_line(many_breaks = false)
+            tl = (asciidoc_char_with_id.absent? | text_id) >> literal_space? >>
+            text.as(:text)
+            if many_breaks
+              tl >> line_ending.repeat(1).as(:line_break)
+            else
+              tl >> line_ending.as(:line_break)
+            end
         end
 
         def asciidoc_char

--- a/lib/coradoc/parser/asciidoc/inline.rb
+++ b/lib/coradoc/parser/asciidoc/inline.rb
@@ -3,19 +3,6 @@ module Coradoc
     module Asciidoc
       module Inline
 
-        def cross_reference
-          str('<<') >> match("[^,>]").repeat(1).as(:href) >>
-          (str(',') >> match("[^>]").repeat(1).as(:name)).maybe >>
-          str('>>')
-        end
-
-        def citation
-          (str("[.source]\n") >>
-            cross_reference.as(:cross_reference) >>
-            (match['[^\n]'].repeat(1)).as(:comment).maybe >>
-            newline).as(:citation)
-        end
-
         def bold_constrained
           (str('*') >>
             match("[^*]").repeat(1).as(:text).repeat(1,1) >>

--- a/lib/coradoc/parser/asciidoc/list.rb
+++ b/lib/coradoc/parser/asciidoc/list.rb
@@ -40,7 +40,7 @@ module Coradoc
           marker = marker >>  str(".").repeat(nl2, nl2) if nl2 > 0
           str("").as(:list_item) >> 
           marker.as(:marker) >> str(".").absent? >>
-          match("\n").absent? >> space >> text_line
+          match("\n").absent? >> space >> text_line(true)
         end
 
         def ulist_item(nesting_level = 1)
@@ -50,7 +50,7 @@ module Coradoc
           str("").as(:list_item) >>
           marker.as(:marker) >> str("*").absent? >>
           str(' [[[').absent? >>
-          match("\n").absent? >> space >> text_line
+          match("\n").absent? >> space >> text_line(true)
         end
 
         def dlist_delimiter

--- a/lib/coradoc/parser/base.rb
+++ b/lib/coradoc/parser/base.rb
@@ -4,6 +4,7 @@ require "parslet/convenience"
 require_relative "asciidoc/attribute_list"
 require_relative "asciidoc/base"
 require_relative "asciidoc/block"
+require_relative "asciidoc/citation"
 require_relative "asciidoc/content"
 require_relative "asciidoc/document_attributes"
 require_relative "asciidoc/header"
@@ -20,6 +21,7 @@ module Coradoc
       include Coradoc::Parser::Asciidoc::AttributeList
       include Coradoc::Parser::Asciidoc::Base
       include Coradoc::Parser::Asciidoc::Block
+      include Coradoc::Parser::Asciidoc::Citation
       include Coradoc::Parser::Asciidoc::Content
       include Coradoc::Parser::Asciidoc::DocumentAttributes
       include Coradoc::Parser::Asciidoc::Header

--- a/spec/coradoc/parser/asciidoc/citation_spec.rb
+++ b/spec/coradoc/parser/asciidoc/citation_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe "Coradoc::Parser::Asciidoc::Citatione" do
+  describe ".parse" do
+    it "parses various inline text formattings" do
+      parser = Asciidoc::CitationTester
+
+
+      ast = parser.parse("[.source]\nsome reference\n")
+      expect(ast).to eq([{:citation=>{:comment=>[{:text=>"some reference", :line_break=>"\n"}]}}])
+
+      ast = parser.parse("[.source]\n<<xref_anchor>>\n")
+      expect(ast).to eq([{:citation=>{:cross_reference=>[{:href_arg=>"xref_anchor"}]}}])
+
+
+      ast = parser.parse("[.source]\n<<xref_anchor,display text>>\n")
+      expect(ast).to eq([{:citation=>{:cross_reference=>[{:href_arg=>"xref_anchor"}, {:text=>"display text"}]}}])
+
+
+      ast = parser.parse("[.source]\n<<xref_anchor,section=1>>\n")
+      expect(ast).to eq([{:citation=>{:cross_reference=>[{:href_arg=>"xref_anchor"}, {:key=>"section", :delimiter=>"=", :value=>"1"}]}}])
+
+      ast = parser.parse("[.source]\n<<xref_anchor>>some reference\n")
+      expect(ast).to eq([{:citation=>{:cross_reference=>[{:href_arg=>"xref_anchor"}], :comment=>[{:text=>"some reference", :line_break=>"\n"}]}}])
+
+      ast = parser.parse("[.source]\n<<xref_anchor>>some reference\nsecond line\n")
+      expect(ast).to eq([{:citation=>{:cross_reference=>[{:href_arg=>"xref_anchor"}], :comment=>[{:text=>"some reference", :line_break=>"\n"}, {:text=>"second line", :line_break=>"\n"}]}}])
+
+    end
+  end
+end
+
+
+module Asciidoc
+  class CitationTester < Parslet::Parser
+    include Coradoc::Parser::Asciidoc::Base
+
+    rule(:document) { (citation | any.as(:unparsed)).repeat(1) }
+    root :document
+
+    def self.parse(text)
+      new.parse_with_debug(text)
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces support for citations and xref anchors. I have checked that it also works in reverse (it generates correct AsciiDoc from Coradoc tree). This fixes #27

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
