### PR TITLE
coradoc/input/html: Add compatibility shim

### DIFF
--- a/lib/coradoc/reverse_adoc.rb
+++ b/lib/coradoc/reverse_adoc.rb
@@ -1,0 +1,18 @@
+warn <<~WARN
+  Deprecated: coradoc/reverse_adoc has been renamed to coradoc/input/html.
+  | Please update your references from:
+  |   require 'coradoc/reverse_adoc'
+  | To:
+  |   require 'coradoc/input/html'
+  |
+  | You are referencing an old require here:
+  |   #{caller.join("\n|   ")}
+  |
+  | Please also ensure that you replace all references to Coradoc::ReverseAdoc
+  | in your code with Coradoc::Input::HTML.
+WARN
+
+require 'coradoc'
+require 'coradoc/input/html'
+
+Coradoc::ReverseAdoc = Coradoc::Input::HTML


### PR DESCRIPTION
Ref: metanorma/iso-22726-1#1

This restores the issue with compatibility breakage. I wasn't aware the new API is in use already.

@opoudjis 

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
