### PR TITLE
ISO-22726-1 compatibility fixes

### DIFF
--- a/lib/coradoc/element/attribute_list.rb
+++ b/lib/coradoc/element/attribute_list.rb
@@ -12,6 +12,16 @@ module Coradoc
         @rejected_named = []
       end
 
+      def inspect
+        "AttributeList: " +
+          [
+            @positional.map(&:inspect).join(", "),
+            @named.map { |k, v| "#{k}: #{v.inspect}" }.join(", "),
+            (@rejected_positional.empty? or "rejected: #{@rejected_positional.inspect}"),
+            (@rejected_positional.empty? or "rejected: #{@rejected_named.inspect}"),
+          ].reject { |i| i == true || i.empty? }.join(", ")
+      end
+
       def add_positional(*attr)
         @positional += attr
       end
@@ -65,7 +75,9 @@ module Coradoc
 
         adoc = +""
         if !@positional.empty?
-          adoc << @positional.map { |p| [nil, ""].include?(p) ? '""' : p }.join(",")
+          adoc << @positional.map do |p|
+            [nil, ""].include?(p) ? '""' : p
+          end.join(",")
         end
         adoc << "," if @positional.any? && @named.any?
         adoc << @named.map do |k, v|

--- a/lib/coradoc/element/base.rb
+++ b/lib/coradoc/element/base.rb
@@ -14,6 +14,8 @@ module Coradoc
           when Coradoc::Element::Section
             return content unless i.safe_to_collapse?
 
+            collected_content << i.anchor if i.anchor
+
             simplified = simplify_block_content(i.contents)
 
             if simplified && !simplified.empty?

--- a/lib/coradoc/element/section.rb
+++ b/lib/coradoc/element/section.rb
@@ -1,7 +1,7 @@
 module Coradoc
   module Element
     class Section < Base
-      attr_accessor :id, :title, :attrs, :contents, :sections
+      attr_accessor :id, :title, :attrs, :contents, :sections, :anchor
 
       declare_children :id, :title, :contents, :sections
 
@@ -49,7 +49,7 @@ module Coradoc
       # HTML element and if it happens inside some other block element, can be
       # safely collapsed.
       def safe_to_collapse?
-        @title.nil? && @id.nil? && @sections.empty?
+        @title.nil? && @sections.empty?
       end
 
       private

--- a/lib/coradoc/element/text_element.rb
+++ b/lib/coradoc/element/text_element.rb
@@ -15,6 +15,15 @@ module Coradoc
         end
       end
 
+      def inspect
+        str = "TextElement"
+        str += "(#{@id})" if @id
+        str += ": "
+        str += @content.inspect
+        str += " + #{@line_break.inspect}" unless line_break.empty?
+        str
+      end
+
       def to_adoc
         Coradoc::Generator.gen_adoc(@content) + @line_break
       end

--- a/lib/coradoc/input/html/converters/div.rb
+++ b/lib/coradoc/input/html/converters/div.rb
@@ -10,5 +10,6 @@ module Coradoc::Input::HTML
 
     register :div,     Div.new
     register :article, Div.new
+    register :center,  Div.new
   end
 end


### PR DESCRIPTION
This PR fixes #133 

In particular, it's concerned about extracting titles if they are nested in ordered lists.

Keep in mind, that this logic is done on coradoc tree, so it'll still be valid once we create a DOCX/ODT input.

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
