### PR TITLE
Coradoc::Input::HTML: Fix for when no cells are present in a row

### DIFF
--- a/lib/coradoc/input/html/converters/table.rb
+++ b/lib/coradoc/input/html/converters/table.rb
@@ -114,6 +114,12 @@ module Coradoc::Input::HTML
           columns = row.xpath("./td | ./th")
           column_id = 0
 
+          cell_references[i] ||= []
+          cell_matrix[i] ||= []
+
+          # Empty row support: pass row object via an instance variable
+          cell_references[i].instance_variable_set(:@row_obj, row)
+
           columns.each do |cell|
             colspan = cell["colspan"]&.to_i || 1
             rowspan = cell["rowspan"]&.to_i || 1
@@ -179,7 +185,7 @@ module Coradoc::Input::HTML
           min_rows.each do |row|
             break if row.length != cpr_min
 
-            row_obj = row.last.first.parent
+            row_obj = row.last&.first&.parent || row.instance_variable_get(:@row_obj)
             doc = row_obj.document
             added_node = Nokogiri::XML::Node.new("td", doc)
             added_node["x-added"] = "x-added"

--- a/spec/coradoc/input/html/assets/tables.html
+++ b/spec/coradoc/input/html/assets/tables.html
@@ -82,6 +82,13 @@
       </tr>
     </table>
 
+    <table>
+      <tr></tr>
+      <tr><td>This table has empty rows</td><td>x</td></tr>
+      <tr></tr>
+      <tr><td>This table has empty rows</td><td>x</td></tr>
+    </table>
+
     <table width="75%">
       <tr>
         <td>75% width table</td>

--- a/spec/coradoc/input/html/components/tables_spec.rb
+++ b/spec/coradoc/input/html/components/tables_spec.rb
@@ -35,6 +35,15 @@ describe Coradoc::Input::HTML do
     is_expected.to match /\n\[frame=topbot,rules=cols,cols=1\]\n\|===\n\| topbot\n/
   }
 
+  it { is_expected.to include <<~ADOC
+    | | 
+    
+    | This table has empty rows | x
+    | | 
+    | This table has empty rows | x
+    ADOC
+  }
+
   it {
     is_expected.to match /\na|\nHello\n\nThis cell has multiple paragraphs\n\n/
   }


### PR DESCRIPTION
The previous behavior was to fail whenever a table like the following was encountered:

```html
<table>
<tr>
  <td>x</td>
</tr>
<tr>
</tr>
</table>
```

Failing should never be an option. This commit fixes that.

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
