### PR TITLE
chore: migrate from libreoffice-rake to generic-rake workflow

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/libreoffice-rake.yml@main
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: libreoffice
+      submodules: false
     secrets:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}


### PR DESCRIPTION
Migrate to the consolidated generic-rake.yml workflow with setup-tools: libreoffice. Part of metanorma/ci#259.