### PR TITLE
refactor: model-driven architecture phase 4

### DIFF
--- a/BUGREPORT.model-driven/12-html-raw-string-converters.md
+++ b/BUGREPORT.model-driven/12-html-raw-string-converters.md
@@ -1,6 +1,6 @@
 # 12: 23 HTML converter files use raw string concatenation instead of NodeBuilder
 
-## Status: NOT FIXED
+## Status: FIXED
 
 - 23 converter files in `coradoc-html/lib/coradoc/html/converters/` construct HTML via string interpolation
 - 26 files already use NodeBuilder correctly (bold, paragraph, section, table, etc.)

--- a/BUGREPORT.model-driven/12-html-raw-string-converters.md
+++ b/BUGREPORT.model-driven/12-html-raw-string-converters.md
@@ -1,0 +1,68 @@
+# 12: 23 HTML converter files use raw string concatenation instead of NodeBuilder
+
+## Status: NOT FIXED
+
+- 23 converter files in `coradoc-html/lib/coradoc/html/converters/` construct HTML via string interpolation
+- 26 files already use NodeBuilder correctly (bold, paragraph, section, table, etc.)
+- The clean pattern exists and is well-established — conversion is mechanical
+
+
+**Severity:** HIGH
+**Location:** `coradoc-html/lib/coradoc/html/converters/` (23 files)
+
+## Problem
+
+The `NO RAW HTML STRINGS` convention in CLAUDE.md mandates that all HTML construction must use NodeBuilder or Nokogiri. However, 23 converter files still construct HTML via string interpolation (`%()`, `"#{}"`, heredocs).
+
+26 converters already follow the pattern correctly. The clean pattern is well-established — conversion is mechanical.
+
+## Affected Files (RAW)
+
+| File | Key Raw Patterns |
+|------|-----------------|
+| `admonition.rb` | `%(<div#{attrs}>\n...#{content}...</div>)`, `"<p>#{...}</p>"` |
+| `attribute.rb` | `"<!-- :#{key}: -->"` |
+| `audio.rb` | heredocs for `<figure>/<audio>`, `%(<source src=...>)` |
+| `bibliography.rb` | `%(<section#{attrs}>...#{content}...</section>)` |
+| `bibliography_entry.rb` | `%(<a id=...>)`, `%(<div#{attrs}>...</div>)` |
+| `comment_block.rb` | `"<!--\n#{content}\n-->"` |
+| `comment_line.rb` | `"<!-- #{content} -->"` |
+| `cross_reference.rb` | `%(<a href=...>#{text}</a>)` |
+| `example.rb` | `%(<div#{attrs}>...#{content}...</div>)`, `"<p>#{...}</p>"` |
+| `include.rb` | `"<!-- #{content} -->"` |
+| `listing.rb` | `%(<pre#{attrs}>#{content}</pre>)` |
+| `literal.rb` | `%(<pre#{attrs}>#{content}</pre>)` |
+| `open.rb` | `"<div#{attrs}>...#{content}...</div>"` |
+| `quote.rb` | `"<blockquote#{attrs}>...#{content}...</blockquote>"` |
+| `reviewer_comment.rb` | multiline `%(<div#{attrs}>...)` |
+| `reviewer_note.rb` | multiline `%(<aside#{attrs}>...)` |
+| `sidebar.rb` | `%(<aside#{attrs}>...#{content}...</aside>)` |
+| `source.rb` | `%(<pre...><code...>#{content}</code></pre>)` |
+| `table_cell.rb` | `"<#{tag}#{attrs}>#{content}</#{tag}>"` |
+| `table_row.rb` | `"<tr#{attrs}>...#{content}...</tr>"` |
+| `term.rb` | `%(<span class=...>#{text}</span>)` |
+| `verse.rb` | `%(<pre class="verse">#{content}</pre>)` |
+| `video.rb` | heredocs for `<figure>/<video>`, `%(<source src=...>)` |
+
+Also in theme layer:
+- `classic_renderer.rb` (build_html5_document — array join of raw HTML strings)
+- `config.rb` (css_tags, js_tags — raw `<link>`, `<script>` strings)
+- `theme/base.rb` (build_meta_tags — raw `<meta>` strings)
+- `modern_renderer.rb` (build_meta_tags — raw `<meta>` strings)
+
+## Clean Pattern (from bold.rb, paragraph.rb, etc.)
+
+```ruby
+def self.to_html(model, options = {})
+  content = escape_html(model.content)
+  attrs = {}
+  attrs[:id] = model.id if model.id
+  build_element('strong', content, **attrs)
+end
+```
+
+Where `build_element` delegates to `NodeBuilder.build(tag, content, **attrs)`.
+
+## Fix
+
+Convert each RAW file to use `NodeBuilder.build(tag, content, **attrs)` following the established pattern. The `build_element` helper in `base.rb` already provides the correct interface.

--- a/BUGREPORT.model-driven/13-adoc-parser-send-bypass.md
+++ b/BUGREPORT.model-driven/13-adoc-parser-send-bypass.md
@@ -1,6 +1,6 @@
 # 13: AsciiDoc parser uses `send` instead of `public_send`
 
-## Status: NOT FIXED
+## Status: FIXED
 
 - 3 `send` calls in `parser/base.rb` bypass access control
 - All target methods are public, so `public_send` is safe

--- a/BUGREPORT.model-driven/13-adoc-parser-send-bypass.md
+++ b/BUGREPORT.model-driven/13-adoc-parser-send-bypass.md
@@ -1,0 +1,22 @@
+# 13: AsciiDoc parser uses `send` instead of `public_send`
+
+## Status: NOT FIXED
+
+- 3 `send` calls in `parser/base.rb` bypass access control
+- All target methods are public, so `public_send` is safe
+
+
+**Severity:** MEDIUM
+**Location:** `coradoc-adoc/lib/coradoc/asciidoc/parser/base.rb`
+
+## Evidence
+
+Line 93: `send(rule_name, *args, **kwargs)`
+Line 99: `send(dispatch_method)`
+Line 143: `send(alias_name)`
+
+All three call dynamically computed method names for Parslet rule dispatch.
+
+## Fix
+
+Replace all 3 `send` calls with `public_send`.

--- a/BUGREPORT.model-driven/14-docx-element-type-string-dispatch.md
+++ b/BUGREPORT.model-driven/14-docx-element-type-string-dispatch.md
@@ -1,0 +1,22 @@
+# 14: DOCX from_core_model still uses element_type string dispatch
+
+## Status: NOT FIXED
+
+- `from_core_model.rb` uses `case element.element_type` with string matching
+- Should use class-based `case element; when DocumentElement` pattern
+
+
+**Severity:** MEDIUM
+**Location:** `coradoc-docx/lib/coradoc/docx/transform/from_core_model.rb`
+
+## Evidence
+
+Line 85-92: `case element.element_type` matching `'document'`, `'section'`
+Line 130-139: `case block.element_type` matching `'page_break'`, `'paragraph'`, `'comment'`
+Line 209-214: `case block.element_type` matching `'page_break'`
+
+The ADOC and Markdown gems already use class-based dispatch. DOCX should follow the same pattern.
+
+## Fix
+
+Replace `case element.element_type` with `case element; when CoreModel::DocumentElement` etc. Replace `case block.element_type` with `case block; when CoreModel::ParagraphBlock` etc.

--- a/BUGREPORT.model-driven/14-docx-element-type-string-dispatch.md
+++ b/BUGREPORT.model-driven/14-docx-element-type-string-dispatch.md
@@ -1,6 +1,6 @@
 # 14: DOCX from_core_model still uses element_type string dispatch
 
-## Status: NOT FIXED
+## Status: FIXED
 
 - `from_core_model.rb` uses `case element.element_type` with string matching
 - Should use class-based `case element; when DocumentElement` pattern

--- a/BUGREPORT.model-driven/15-missing-coremodel-specs.md
+++ b/BUGREPORT.model-driven/15-missing-coremodel-specs.md
@@ -1,0 +1,38 @@
+# 15: 14 CoreModel typed Block subclasses have no specs
+
+## Status: NOT FIXED
+
+- 14 of 34 CoreModel classes lack dedicated spec files
+- Typed block subclasses define `semantic_type` but have no test coverage
+
+
+**Severity:** MEDIUM
+**Location:** `spec/core_model/`
+
+## Missing Specs
+
+| Class | File |
+|-------|------|
+| `CommentBlock` | `lib/coradoc/core_model/comment_block.rb` |
+| `ExampleBlock` | `lib/coradoc/core_model/example_block.rb` |
+| `HorizontalRuleBlock` | `lib/coradoc/core_model/horizontal_rule_block.rb` |
+| `ListingBlock` | `lib/coradoc/core_model/listing_block.rb` |
+| `LiteralBlock` | `lib/coradoc/core_model/literal_block.rb` |
+| `OpenBlock` | `lib/coradoc/core_model/open_block.rb` |
+| `ParagraphBlock` | `lib/coradoc/core_model/paragraph_block.rb` |
+| `PassBlock` | `lib/coradoc/core_model/pass_block.rb` |
+| `QuoteBlock` | `lib/coradoc/core_model/quote_block.rb` |
+| `ReviewerBlock` | `lib/coradoc/core_model/reviewer_block.rb` |
+| `SidebarBlock` | `lib/coradoc/core_model/sidebar_block.rb` |
+| `SourceBlock` | `lib/coradoc/core_model/source_block.rb` |
+| `VerseBlock` | `lib/coradoc/core_model/verse_block.rb` |
+| `DefinitionItem` | `lib/coradoc/core_model/definition_item.rb` |
+
+## Fix
+
+Create a single spec file `spec/core_model/typed_blocks_spec.rb` covering all typed block subclasses. Each should test:
+- Inherits from `Block`
+- `semantic_type` returns the correct symbol
+- `element_type` returns the correct string
+- Can be instantiated with content/attributes
+- `comparable_attributes` works correctly

--- a/BUGREPORT.model-driven/15-missing-coremodel-specs.md
+++ b/BUGREPORT.model-driven/15-missing-coremodel-specs.md
@@ -1,6 +1,6 @@
 # 15: 14 CoreModel typed Block subclasses have no specs
 
-## Status: NOT FIXED
+## Status: FIXED
 
 - 14 of 34 CoreModel classes lack dedicated spec files
 - Typed block subclasses define `semantic_type` but have no test coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ Format gems register via `Coradoc.register_format(:name, Module)` and must imple
 
 ## Conventions
 
+- **NO VERSION RELEASES**: Do not trigger gem releases or version bumps via GHA or any other mechanism. This restriction applies until the user explicitly says otherwise.
 - **NO HASHES IN MODELS**: CoreModel classes must NEVER use `:hash` as an attribute type. Every attribute must be a typed model, string, integer, or array of typed models. No hash bags, no generic key-value stores. This enforces the model-driven architecture.
 - **NO SERIALIZATION IN MODELS**: CoreModel classes must NEVER contain `to_hash`, `to_json`, `serialize`, or any custom serialization methods. Models are pure data structures. Serialization is handled by dedicated serializer classes (lutaml-model handles this automatically).
 - **NO RAW HTML STRINGS**: The HTML gem must use Nokogiri as both the model layer AND the HTML builder. Never concatenate raw HTML strings. Never manually construct HTML in text. Use `Nokogiri::HTML::Builder` or `Nokogiri::XML::Node` methods to construct HTML output. ALL non-model-driven HTML construction code must be converted to Nokogiri builder.

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/base.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/base.rb
@@ -90,13 +90,13 @@ module Coradoc
             alias_name = :"#{rule_name}_#{dispatch_hash}"
             Coradoc::AsciiDoc::Parser::Base.class_exec do
               rule(alias_name) do
-                send(rule_name, *args, **kwargs)
+                public_send(rule_name, *args, **kwargs)
               end
             end
             @dispatch_data[dispatch_hash] = alias_name
           end
           dispatch_method = @dispatch_data[dispatch_hash]
-          send(dispatch_method)
+          public_send(dispatch_method)
         end
 
         def self.config(key)
@@ -140,7 +140,7 @@ module Coradoc
             Coradoc::AsciiDoc::Parser::Base.class_exec do
               alias_method alias_name, rule_name
               rule(rule_name) do
-                send(alias_name)
+                public_send(alias_name)
               end
             end
           elsif config(:add_dispatch) && config(:with_params)

--- a/coradoc-docx/lib/coradoc/docx/transform/from_core_model.rb
+++ b/coradoc-docx/lib/coradoc/docx/transform/from_core_model.rb
@@ -82,10 +82,10 @@ module Coradoc
         private
 
         def transform_structural_element(element)
-          case element.element_type
-          when 'document'
+          case element
+          when CoreModel::DocumentElement
             transform_document(element)
-          when 'section'
+          when CoreModel::SectionElement
             transform_section(element)
           else
             transform_section(element)
@@ -127,12 +127,11 @@ module Coradoc
         end
 
         def transform_block(block)
-          case block.element_type
-          when 'page_break'
+          semantic = block.resolve_semantic_type
+          case semantic
+          when :page_break
             build_page_break
-          when 'paragraph', nil
-            build_ooxml_paragraph(block)
-          when 'comment'
+          when :comment
             nil
           else
             build_ooxml_paragraph(block)
@@ -206,8 +205,8 @@ module Coradoc
         end
 
         def add_block_to_builder(block, builder)
-          case block.element_type
-          when 'page_break'
+          case block.resolve_semantic_type
+          when :page_break
             builder.page_break
           else
             add_paragraph_to_builder(block, builder)

--- a/coradoc-docx/spec/coradoc/docx/transform/from_core_model_spec.rb
+++ b/coradoc-docx/spec/coradoc/docx/transform/from_core_model_spec.rb
@@ -100,11 +100,10 @@ RSpec.describe Coradoc::Docx::Transform::FromCoreModel do
 
     context 'with document containing mixed types' do
       let(:core_model) do
-        Coradoc::CoreModel::StructuralElement.new(
-          element_type: 'document',
+        Coradoc::CoreModel::DocumentElement.new(
           title: 'Test Doc',
           children: [
-            Coradoc::CoreModel::Block.new(element_type: 'paragraph', content: 'First para'),
+            Coradoc::CoreModel::Block.new(block_semantic_type: 'paragraph', content: 'First para'),
             Coradoc::CoreModel::DefinitionList.new(
               items: [
                 Coradoc::CoreModel::DefinitionItem.new(term: 'Foo', definitions: ['Bar'])
@@ -175,7 +174,7 @@ RSpec.describe Coradoc::Docx::Transform::FromCoreModel do
     end
 
     context 'with Block (paragraph)' do
-      let(:core_model) { Coradoc::CoreModel::Block.new(element_type: 'paragraph', content: 'Hello world') }
+      let(:core_model) { Coradoc::CoreModel::Block.new(block_semantic_type: 'paragraph', content: 'Hello world') }
 
       it 'produces a Paragraph with text content' do
         expect(result).to be_a(Uniword::Wordprocessingml::Paragraph)
@@ -184,7 +183,7 @@ RSpec.describe Coradoc::Docx::Transform::FromCoreModel do
     end
 
     context 'with Block (page_break)' do
-      let(:core_model) { Coradoc::CoreModel::Block.new(element_type: 'page_break') }
+      let(:core_model) { Coradoc::CoreModel::Block.new(block_semantic_type: 'page_break') }
 
       it 'produces a Paragraph with page break' do
         expect(result).to be_a(Uniword::Wordprocessingml::Paragraph)

--- a/coradoc-html/lib/coradoc/html/converters/admonition.rb
+++ b/coradoc-html/lib/coradoc/html/converters/admonition.rb
@@ -3,50 +3,37 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::AnnotationBlock to HTML admonition block
       class Admonition < Base
-        # Convert CoreModel::AnnotationBlock to HTML admonition block
         def self.to_html(admonition, _options = {})
           return '' unless admonition
 
-          # Get admonition type (NOTE, TIP, IMPORTANT, WARNING, CAUTION)
           type = admonition.annotation_type ? admonition.annotation_type.to_s.upcase : 'NOTE'
 
-          # Build div attributes
-          attrs = build_attributes(admonition, type)
+          attrs = { class: "admonition admonition-#{type.downcase}" }
+          attrs[:id] = admonition.id if admonition.id
 
-          # Build title if present
-          title_html = build_title(admonition)
+          children = []
 
-          # Build admonition label
-          label = build_label(type)
+          children << NodeBuilder.build(:div, escape_html(type), class: 'admonition-label')
 
-          # Process admonition content
+          children << NodeBuilder.build(:div, escape_html(admonition.title.to_s), class: 'admonition-title') if admonition.title && !admonition.title.to_s.empty?
+
           content = process_content(admonition.content)
+          children << content unless content.empty?
 
-          # Combine label, title, and content
-          admonition_html = ''
-          admonition_html += "#{label}\n"
-          admonition_html += "#{title_html}\n" if title_html
-          admonition_html += content
-
-          %(<div#{attrs}>\n#{admonition_html}\n</div>)
+          NodeBuilder.build(:div, children, **attrs).to_html
         end
 
-        # Convert HTML admonition div to CoreModel::AnnotationBlock
         def self.to_coradoc(element, _options = {})
           return nil unless element.name == 'div'
           return nil unless element['class']&.include?('admonition')
 
-          # Extract admonition type from class
           type = extract_type(element)
           return nil unless type
 
-          # Extract title if present
           title_elem = element.at_css('.admonition-title')
           title = title_elem&.text&.strip
 
-          # Extract content - all children except label and title
           content_nodes = element.children.reject do |node|
             node == element.at_css('.admonition-label') ||
               node == title_elem ||
@@ -55,44 +42,18 @@ module Coradoc
 
           content = extract_content(content_nodes)
 
-          # Extract ID if present
-          id = element['id']
-
           Coradoc::CoreModel::AnnotationBlock.new(
             annotation_type: type.downcase,
             content: content,
             title: title,
-            id: id
+            id: element['id']
           )
-        end
-
-        def self.build_attributes(admonition, type)
-          attrs = [%( class="admonition admonition-#{type.downcase}")]
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(admonition.id)}") if admonition.id
-
-          attrs.join
-        end
-
-        def self.build_label(type)
-          %(<div class="admonition-label">#{escape_html(type)}</div>)
-        end
-
-        def self.build_title(admonition)
-          return nil unless admonition.title
-
-          title_text = admonition.title.to_s
-          return nil if title_text.empty?
-
-          %(<div class="admonition-title">#{escape_html(title_text)}</div>)
         end
 
         def self.process_content(content)
           return '' if content.nil?
 
           if content.is_a?(Array)
-            # Group consecutive lines into paragraphs, handling inline elements
             result = []
             current_para = []
 
@@ -101,7 +62,6 @@ module Coradoc
               when String
                 current_para << item
               else
-                # End current paragraph and start a new one
                 if current_para.any?
                   result << build_paragraph(current_para)
                   current_para = []
@@ -110,12 +70,11 @@ module Coradoc
               end
             end
 
-            # Don't forget the last paragraph
             result << build_paragraph(current_para) if current_para.any?
 
             result.compact.join("\n")
           elsif content.is_a?(String)
-            "<p>#{escape_html(content)}</p>"
+            NodeBuilder.build(:p, escape_html(content)).to_html
           else
             convert_item(content)
           end
@@ -124,7 +83,6 @@ module Coradoc
         def self.build_paragraph(items)
           return nil if items.nil? || items.empty?
 
-          # Convert all items to HTML and join them
           content_html = items.map do |item|
             case item
             when String
@@ -136,13 +94,13 @@ module Coradoc
 
           return nil if content_html.empty?
 
-          "<p>#{content_html}</p>"
+          NodeBuilder.build(:p, content_html).to_html
         end
 
         def self.convert_item(item)
           case item
           when String
-            "<p>#{escape_html(item)}</p>"
+            NodeBuilder.build(:p, escape_html(item)).to_html
           else
             convert_content_to_html(item)
           end
@@ -151,7 +109,6 @@ module Coradoc
         def self.extract_type(element)
           return nil unless element['class']
 
-          # Extract type from class like "admonition-note", "admonition-warning", etc.
           classes = element['class'].split
           type_class = classes.find { |c| c.start_with?('admonition-') && c != 'admonition' }
           return nil unless type_class
@@ -160,7 +117,6 @@ module Coradoc
         end
 
         def self.extract_content(nodes)
-          # Extract and convert content nodes
           nodes.map do |node|
             if node.text? && !node.text.strip.empty?
               node.text.strip

--- a/coradoc-html/lib/coradoc/html/converters/attribute.rb
+++ b/coradoc-html/lib/coradoc/html/converters/attribute.rb
@@ -5,53 +5,37 @@ require 'nokogiri'
 module Coradoc
   module Html
     module Converters
-      # Converts document attributes to/from HTML
-      #
-      # Attributes are document-level directives (e.g., :author:, :toc:).
-      # In HTML, we represent them as HTML comments to preserve the attribute
-      # information without affecting the rendered output.
-      #
-      # Examples:
-      #   :author: John Doe  => <!-- :author: John Doe -->
-      #   :toc:              => <!-- :toc: -->
       class Attribute
-        # Convert CoreModel::Block (attribute) to HTML comment
         def self.to_html(model, _options = {})
-          key = model.metadata&.dig(:key).to_s
-          key = escape_html(key)
+          key = escape_html(model.metadata&.dig(:key).to_s)
 
-          # Handle single value or array of values
           values = Array(model.metadata&.dig(:value)).compact
 
-          if values.empty?
-            # Attribute with no value (e.g., :toc:)
-            "<!-- :#{key}: -->"
-          else
-            # Attribute with value(s)
-            value_str = values.map { |v| escape_html(v.to_s) }.join(', ')
-            "<!-- :#{key}: #{value_str} -->"
-          end
+          comment_text = if values.empty?
+                           ":#{key}:"
+                         else
+                           value_str = values.map { |v| escape_html(v.to_s) }.join(', ')
+                           ":#{key}: #{value_str}"
+                         end
+
+          doc = Nokogiri::HTML::DocumentFragment.parse('')
+          comment = Nokogiri::XML::Comment.new(doc, " #{comment_text} ")
+          doc.add_child(comment)
+          doc.to_html
         end
 
-        # Convert HTML comment to CoreModel::Block (attribute)
         def self.to_coradoc(element, _options = {})
           return nil unless element.is_a?(Nokogiri::XML::Comment)
 
           content = element.content.strip
 
-          # Match attribute pattern: :key: or :key: value
           return nil unless content.match?(/^:([^:]+):(.*)$/)
 
           match = content.match(/^:([^:]+):(.*)$/)
           key = match[1].strip
           value_part = match[2].strip
 
-          # Parse value(s) - could be comma-separated
-          values = if value_part.empty?
-                     []
-                   else
-                     value_part.split(',').map(&:strip)
-                   end
+          values = value_part.empty? ? [] : value_part.split(',').map(&:strip)
 
           Coradoc::CoreModel::Block.new(
             block_semantic_type: 'attribute',

--- a/coradoc-html/lib/coradoc/html/converters/audio.rb
+++ b/coradoc-html/lib/coradoc/html/converters/audio.rb
@@ -3,48 +3,33 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for audio elements
       class Audio < Base
-        # Convert CoreModel::Block (audio) to HTML <audio>
         def self.to_html(audio, _options = {})
           return '' unless audio
 
-          # Build audio attributes
-          attrs = build_attributes(audio)
-
-          # Get audio source from metadata or content
           src = audio.metadata&.dig(:src) || audio.content
+          attrs = build_audio_attrs(audio)
 
-          # Build source element
-          source_tag = %(<source src="#{escape_attribute(src)}"#{build_type_attr(src)}>)
+          source_attrs = { src: src }
+          type = build_type_attr(src)
+          source_attrs[:type] = type if type
 
-          # Build optional caption/title
-          caption = audio.title
+          source_node = NodeBuilder.build(:source, nil, **source_attrs)
+          fallback = NodeBuilder.text('Your browser does not support the audio tag.')
 
-          # Determine if we need a wrapper (for block audio with caption)
-          if caption
-            <<~HTML.strip
-              <figure#{build_figure_attrs(audio)}>
-                <audio#{attrs}>
-                  #{source_tag}
-                  Your browser does not support the audio tag.
-                </audio>
-                <figcaption>#{escape_html(caption)}</figcaption>
-              </figure>
-            HTML
+          audio_node = NodeBuilder.build(:audio, [source_node, fallback], **attrs)
+
+          if audio.title
+            fig_attrs = {}
+            fig_attrs[:id] = "#{audio.id}-figure" if audio.id
+            caption = NodeBuilder.build(:figcaption, escape_html(audio.title))
+            NodeBuilder.build(:figure, [audio_node, caption], **fig_attrs).to_html
           else
-            <<~HTML.strip
-              <audio#{attrs}>
-                #{source_tag}
-                Your browser does not support the audio tag.
-              </audio>
-            HTML
+            audio_node.to_html
           end
         end
 
-        # Convert HTML <audio> to CoreModel::Block (audio)
         def self.to_coradoc(element, _options = {})
-          # Handle both <audio> and <figure><audio> structures
           audio_elem = if element.name == 'figure'
                          element.at_css('audio')
                        elsif element.name == 'audio'
@@ -55,20 +40,14 @@ module Coradoc
 
           return nil unless audio_elem
 
-          # Extract source from <source> tag or src attribute
           src = extract_audio_src(audio_elem)
           return nil unless src
 
-          # Extract caption if in figure
           caption = if element.name == 'figure'
                       figcaption = element.at_css('figcaption')
                       figcaption&.text&.strip
                     end
 
-          # Extract ID if present
-          id = audio_elem['id'] || element['id']
-
-          # Extract audio attributes
           metadata = extract_audio_metadata(audio_elem)
           metadata[:src] = src
 
@@ -76,72 +55,40 @@ module Coradoc
             block_semantic_type: 'audio',
             content: src,
             title: caption,
-            id: id,
+            id: audio_elem['id'] || element['id'],
             metadata: metadata
           )
         end
 
-        def self.build_attributes(audio)
-          attrs = []
-
-          # Extract options from metadata
+        def self.build_audio_attrs(audio)
+          attrs = {}
           options = audio.metadata&.dig(:options) || []
 
-          # Add controls by default (unless nocontrols option is set)
-          has_controls = !options.include?('nocontrols')
-          attrs << ' controls' if has_controls
+          attrs[:controls] = '' unless options.include?('nocontrols')
+          attrs[:autoplay] = '' if options.include?('autoplay')
+          attrs[:loop] = '' if options.include?('loop')
+          attrs[:muted] = '' if options.include?('muted')
+          attrs[:id] = audio.id if audio.id
 
-          # Add autoplay if specified in options
-          attrs << ' autoplay' if options.include?('autoplay')
-
-          # Add loop if specified in options
-          attrs << ' loop' if options.include?('loop')
-
-          # Add muted if specified in options
-          attrs << ' muted' if options.include?('muted')
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(audio.id)}") if audio.id
-
-          attrs.join
+          attrs
         end
 
         def self.build_type_attr(src)
-          # Determine audio MIME type from extension
-          ext = File.extname(src).downcase
-          type = case ext
-                 when '.mp3'
-                   'audio/mpeg'
-                 when '.ogg', '.oga'
-                   'audio/ogg'
-                 when '.wav'
-                   'audio/wav'
-                 when '.m4a'
-                   'audio/mp4'
-                 when '.aac'
-                   'audio/aac'
-                 when '.flac'
-                   'audio/flac'
-                 end
-
-          type ? %( type="#{type}") : ''
-        end
-
-        def self.build_figure_attrs(audio)
-          attrs = []
-
-          # Add ID to figure if present
-          attrs << %( id="#{escape_attribute(audio.id)}-figure") if audio.id
-
-          attrs.join
+          ext = File.extname(src.to_s).downcase
+          case ext
+          when '.mp3' then 'audio/mpeg'
+          when '.ogg', '.oga' then 'audio/ogg'
+          when '.wav' then 'audio/wav'
+          when '.m4a' then 'audio/mp4'
+          when '.aac' then 'audio/aac'
+          when '.flac' then 'audio/flac'
+          end
         end
 
         def self.extract_audio_src(element)
-          # Try to get src from <source> tag first
           source = element.at_css('source')
           return source['src'] if source && source['src']
 
-          # Fall back to src attribute on <audio>
           element['src']
         end
 
@@ -149,7 +96,6 @@ module Coradoc
           metadata = {}
           options = []
 
-          # Extract boolean attributes
           options << 'controls' if element.has_attribute?('controls')
           options << 'autoplay' if element.has_attribute?('autoplay')
           options << 'loop' if element.has_attribute?('loop')

--- a/coradoc-html/lib/coradoc/html/converters/bibliography.rb
+++ b/coradoc-html/lib/coradoc/html/converters/bibliography.rb
@@ -3,42 +3,34 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block (bibliography) to HTML bibliography section
       class Bibliography < Base
-        # Convert CoreModel::Block (bibliography) to HTML bibliography section
         def self.to_html(bibliography, _options = {})
           return '' unless bibliography
 
-          # Build section attributes
-          attrs = build_attributes(bibliography)
+          attrs = { class: 'bibliography' }
+          attrs[:id] = bibliography.id if bibliography.id
 
-          # Build title
-          title_html = build_title(bibliography)
+          children = []
 
-          # Process bibliography entries (children)
+          children << NodeBuilder.build(:h2, escape_html(bibliography.title.to_s), class: 'bibliography-title') if bibliography.title && !bibliography.title.to_s.empty?
+
           entries = bibliography.children || []
           entries_html = entries.map do |entry|
             BibliographyEntry.to_html(entry)
           end.join("\n")
 
-          # Combine into bibliography section
-          bib_html = ''
-          bib_html += "#{title_html}\n" if title_html
-          bib_html += %(<div class="bibliography-entries">\n#{entries_html}\n</div>) unless entries_html.empty?
+          children << NodeBuilder.build(:div, entries_html, class: 'bibliography-entries') unless entries_html.empty?
 
-          %(<section#{attrs}>\n#{bib_html}\n</section>)
+          NodeBuilder.build(:section, children, **attrs).to_html
         end
 
-        # Convert HTML bibliography section to CoreModel::Block (bibliography)
         def self.to_coradoc(element, _options = {})
           return nil unless element.name == 'section'
           return nil unless element['class']&.include?('bibliography')
 
-          # Extract title
           title_elem = element.at_css('h1, h2, h3, h4, h5, h6, .bibliography-title')
           title = title_elem&.text&.strip
 
-          # Extract entries
           entries_container = element.at_css('.bibliography-entries')
           entries = if entries_container
                       entries_container.css('.bibliography-entry').map do |entry_elem|
@@ -48,33 +40,12 @@ module Coradoc
                       []
                     end
 
-          # Extract ID if present
-          id = element['id']
-
           Coradoc::CoreModel::Block.new(
             block_semantic_type: 'bibliography',
             title: title,
-            id: id,
+            id: element['id'],
             children: entries
           )
-        end
-
-        def self.build_attributes(bibliography)
-          attrs = [%( class="bibliography")]
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(bibliography.id)}") if bibliography.id
-
-          attrs.join
-        end
-
-        def self.build_title(bibliography)
-          return nil unless bibliography.title
-
-          title_text = bibliography.title.to_s
-          return nil if title_text.empty?
-
-          %(<h2 class="bibliography-title">#{escape_html(title_text)}</h2>)
         end
       end
     end

--- a/coradoc-html/lib/coradoc/html/converters/bibliography_entry.rb
+++ b/coradoc-html/lib/coradoc/html/converters/bibliography_entry.rb
@@ -3,56 +3,42 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block (bibliography entry) to HTML bibliography entry
       class BibliographyEntry < Base
-        # Convert CoreModel::Block (bibliography entry) to HTML bibliography entry
         def self.to_html(entry, _options = {})
           return '' unless entry
 
-          # Build entry attributes
-          attrs = build_attributes(entry)
+          children = []
 
-          # Get entry ID from metadata
           entry_id = entry.metadata&.dig(:anchor_name) || entry.metadata&.dig(:document_id) || entry.id
+          if entry_id
+            anchor = NodeBuilder.build(:a, nil, id: entry_id, class: 'bibliography-anchor')
+            children << anchor
+          end
 
-          # Build anchor if ID present
-          anchor_html = if entry_id
-                          %(<a id="#{escape_attribute(entry_id)}" class="bibliography-anchor"></a>)
-                        else
-                          ''
-                        end
-
-          # Get citation label
           label = entry.metadata&.dig(:label) || entry_id || ''
+          unless label.empty?
+            label_span = NodeBuilder.build(:span, escape_html(label), class: 'bibliography-label')
+            children << label_span
+            children << NodeBuilder.text(' ')
+          end
 
-          # Get entry reference text
           content = entry.content || ''
-
-          # Process content
           content_html = process_content(content)
+          children << NodeBuilder.build(:fragment, content_html) unless content_html.empty?
 
-          # Combine into entry
-          entry_html = anchor_html
-          entry_html += %(<span class="bibliography-label">#{escape_html(label)}</span> ) unless label.empty?
-          entry_html += content_html
-
-          %(<div#{attrs}>#{entry_html}</div>)
+          NodeBuilder.build(:div, children, class: 'bibliography-entry').to_html
         end
 
-        # Convert HTML bibliography entry to CoreModel::Block (bibliography entry)
         def self.to_coradoc(element, _options = {})
           return nil unless element.name == 'div'
           return nil unless element['class']&.include?('bibliography-entry')
 
-          # Extract anchor/ID
           anchor = element.at_css('.bibliography-anchor, a[id]')
           entry_id = anchor&.[]('id')
 
-          # Extract label
           label_elem = element.at_css('.bibliography-label')
           label = label_elem&.text&.strip
 
-          # Extract content (everything except anchor and label)
           content_nodes = element.children.reject do |node|
             node == anchor || node == label_elem || (node.text? && node.text.strip.empty?)
           end
@@ -67,10 +53,6 @@ module Coradoc
               label: label
             }
           )
-        end
-
-        def self.build_attributes(_entry)
-          %( class="bibliography-entry")
         end
 
         def self.process_content(content)
@@ -95,12 +77,7 @@ module Coradoc
         end
 
         def self.extract_content(nodes)
-          # Extract and convert content nodes
-          nodes.map do |node|
-            if node.text?
-            end
-            node.text
-          end.compact.join
+          nodes.map(&:text).compact.join
         end
       end
     end

--- a/coradoc-html/lib/coradoc/html/converters/comment_block.rb
+++ b/coradoc-html/lib/coradoc/html/converters/comment_block.rb
@@ -3,36 +3,25 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block with element_type "comment"
       class CommentBlock < Base
-        # Convert CoreModel::Block (comment) to HTML comment
         def self.to_html(comment_block, options = {})
           return '' unless comment_block
-
-          # Check if comments should be preserved
           return '' unless options[:preserve_comments]
 
-          # Get comment text (CoreModel::Block has content attribute)
           text = comment_block.content.to_s
-
-          # HTML comments cannot contain --
-          # Replace -- with - - to avoid breaking the comment
           safe_text = text.gsub('--', '- -')
 
-          # Preserve newlines in comment block
-          # Multi-line comment blocks should preserve their internal newlines
-          "<!--\n#{escape_html(safe_text)}\n-->"
+          doc = Nokogiri::HTML::DocumentFragment.parse('')
+          comment = Nokogiri::XML::Comment.new(doc, "\n#{escape_html(safe_text)}\n")
+          doc.add_child(comment)
+          doc.to_html
         end
 
-        # Convert HTML comment to CoreModel::Block (comment)
         def self.to_coradoc(element, _options = {})
           return nil unless element.comment?
 
-          # Extract comment text
-          text = element.text.to_s
-
           Coradoc::CoreModel::CommentBlock.new(
-            content: text
+            content: element.text.to_s
           )
         end
       end

--- a/coradoc-html/lib/coradoc/html/converters/comment_line.rb
+++ b/coradoc-html/lib/coradoc/html/converters/comment_line.rb
@@ -4,14 +4,10 @@ module Coradoc
   module Html
     module Converters
       class CommentLine < Base
-        # Convert CoreModel to HTML comment
         def self.to_html(comment, options = {})
           return '' unless comment
-
-          # Check if comments should be preserved
           return '' unless options[:preserve_comments]
 
-          # Get comment text - check for content or text attribute
           text = if comment.content
                    comment.content
                  elsif comment.text
@@ -21,31 +17,21 @@ module Coradoc
                  end
 
           text = text.to_s
-
-          # HTML comments cannot contain --
-          # Replace -- with - - to avoid breaking the comment
           safe_text = text.gsub('--', '- -')
 
-          # Preserve newlines in comment text
-          # Empty comments (just "//") should become newlines in HTML comments
-          if safe_text.strip.empty?
-            "<!--\n-->"
-          else
-            "<!-- #{escape_html(safe_text)} -->"
-          end
+          doc = Nokogiri::HTML::DocumentFragment.parse('')
+          comment_text = safe_text.strip.empty? ? '' : " #{escape_html(safe_text)} "
+          comment_node = Nokogiri::XML::Comment.new(doc, comment_text)
+          doc.add_child(comment_node)
+          doc.to_html
         end
 
-        # Convert HTML comment to CoreModel
         def self.to_coradoc(element, _options = {})
           return nil unless element.comment?
 
-          # Extract comment text
-          text = element.text.to_s.strip
-
-          # For now, return an InlineElement with special format_type for comment
           Coradoc::CoreModel::InlineElement.new(
             format_type: 'comment',
-            content: text
+            content: element.text.to_s.strip
           )
         end
       end

--- a/coradoc-html/lib/coradoc/html/converters/cross_reference.rb
+++ b/coradoc-html/lib/coradoc/html/converters/cross_reference.rb
@@ -3,47 +3,32 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::InlineElement with format_type "xref"
       class CrossReference < Base
         class << self
-          # Convert CoreModel::InlineElement (xref) to HTML
-          # @param model [Coradoc::CoreModel::InlineElement] CrossReference model
-          # @param state [Hash] Conversion state
-          # @return [String] HTML anchor tag
           def to_html(model, _state = {})
             href = model.target.to_s
-            # Create anchor link to internal reference
-            # Format: <a href="#section-id">section-id</a> or with text from content
             text = if model.content&.to_s&.strip != ''
                      model.content.to_s
                    else
                      href
                    end
 
-            # Ensure href starts with # for internal links
             link_href = href.start_with?('#') ? href : "##{href}"
-
-            %(<a href="#{escape_attribute(link_href)}">#{escape_html(text)}</a>)
+            NodeBuilder.build(:a, escape_html(text), href: link_href).to_html
           end
 
-          # Convert HTML anchor to CoreModel::InlineElement (xref)
-          # @param node [Nokogiri::XML::Node] HTML anchor node
-          # @param state [Hash] Conversion state
-          # @return [Coradoc::CoreModel::InlineElement] CrossReference model
           def to_coradoc(node, _state = {})
             href = node['href'].to_s
             text = node.text.strip
 
-            # Only treat internal links as cross-references
             if href.start_with?('#')
-              ref_id = href[1..] # Remove leading #
+              ref_id = href[1..]
               content = text.empty? || text == ref_id ? nil : text
               Coradoc::CoreModel::CrossReferenceElement.new(
                 target: ref_id,
                 content: content
               )
             else
-              # External links become regular links
               Coradoc::CoreModel::LinkElement.new(
                 target: href,
                 content: text

--- a/coradoc-html/lib/coradoc/html/converters/example.rb
+++ b/coradoc-html/lib/coradoc/html/converters/example.rb
@@ -3,39 +3,30 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block (example) to HTML <div class="example">
       class Example < Base
-        # Convert CoreModel::Block (example) to HTML <div class="example">
         def self.to_html(example, _options = {})
           return '' unless example
 
-          # Build div attributes
-          attrs = build_attributes(example)
+          attrs = { class: 'example' }
+          attrs[:id] = example.id if example.id
 
-          # Build title if present
-          title_html = build_title(example)
+          children = []
 
-          # Process example content
+          children << NodeBuilder.build(:div, escape_html(example.title.to_s), class: 'example-title') if example.title && !example.title.to_s.empty?
+
           content = process_content(example.content)
+          children << content unless content.empty?
 
-          # Combine title and content
-          example_html = ''
-          example_html += "#{title_html}\n" if title_html
-          example_html += content
-
-          %(<div#{attrs}>\n#{example_html}\n</div>)
+          NodeBuilder.build(:div, children, **attrs).to_html
         end
 
-        # Convert HTML <div class="example"> to CoreModel::Block (example)
         def self.to_coradoc(element, _options = {})
           return nil unless element.name == 'div'
           return nil unless element['class']&.include?('example')
 
-          # Extract title if present
           title_elem = element.at_css('.example-title')
           title = title_elem&.text&.strip
 
-          # Extract content - all children except title
           content_nodes = if title_elem
                             element.children.reject { |node| node == title_elem }
                           else
@@ -44,32 +35,11 @@ module Coradoc
 
           content = extract_content(content_nodes)
 
-          # Extract ID if present
-          id = element['id']
-
           Coradoc::CoreModel::ExampleBlock.new(
             content: content,
             title: title,
-            id: id
+            id: element['id']
           )
-        end
-
-        def self.build_attributes(example)
-          attrs = [%( class="example")]
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(example.id)}") if example.id
-
-          attrs.join
-        end
-
-        def self.build_title(example)
-          return nil unless example.title
-
-          title_text = example.title.to_s
-          return nil if title_text.empty?
-
-          %(<div class="example-title">#{escape_html(title_text)}</div>)
         end
 
         def self.process_content(content)
@@ -78,7 +48,7 @@ module Coradoc
           if content.is_a?(Array)
             content.map { |item| convert_item(item) }.join("\n")
           elsif content.is_a?(String)
-            "<p>#{escape_html(content)}</p>"
+            NodeBuilder.build(:p, escape_html(content)).to_html
           else
             convert_item(content)
           end
@@ -87,14 +57,13 @@ module Coradoc
         def self.convert_item(item)
           case item
           when String
-            "<p>#{escape_html(item)}</p>"
+            NodeBuilder.build(:p, escape_html(item)).to_html
           else
             convert_content_to_html(item)
           end
         end
 
         def self.extract_content(nodes)
-          # Extract and convert content nodes
           nodes.map do |node|
             if node.text? && !node.text.strip.empty?
               node.text.strip

--- a/coradoc-html/lib/coradoc/html/converters/include.rb
+++ b/coradoc-html/lib/coradoc/html/converters/include.rb
@@ -3,40 +3,32 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for include directives
       class Include < Base
-        # Convert CoreModel::Block (include) to HTML comment with include directive
-        # Note: HTML doesn't have native include support, so we use a comment
         def self.to_html(include_directive, _options = {})
           return '' unless include_directive
 
-          # Get include path from metadata
-          path = include_directive.metadata&.dig(:path) || ''
-          path = escape_html(path)
+          path = escape_html(include_directive.metadata&.dig(:path) || '')
 
-          # Build include directive as comment
           comment_text = "include::#{path}[]"
 
-          # Add attributes if present
           attrs = include_directive.metadata&.dig(:attributes) || {}
           if attrs && !attrs.empty?
             attrs_str = attrs.map { |k, v| "#{k}=#{v}" }.join(',')
             comment_text = "include::#{path}[#{attrs_str}]" unless attrs_str.empty?
           end
 
-          "<!-- #{comment_text} -->"
+          doc = Nokogiri::HTML::DocumentFragment.parse('')
+          comment = Nokogiri::XML::Comment.new(doc, " #{comment_text} ")
+          doc.add_child(comment)
+          doc.to_html
         end
 
-        # Convert HTML comment with include directive to CoreModel::Block (include)
         def self.to_coradoc(element, _options = {})
           return nil unless element.comment?
 
-          # Check if comment contains include directive
           text = element.text.to_s.strip
           return nil unless text.match?(/^include::/)
 
-          # Parse include directive
-          # Format: include::path[attributes]
           return unless text =~ /^include::([^\[]+)(\[([^\]]*)\])?/
 
           path = ::Regexp.last_match(1).strip
@@ -44,7 +36,6 @@ module Coradoc
 
           attrs = {}
           if attrs_str && !attrs_str.empty?
-            # Parse attributes (simplified - doesn't handle complex cases)
             attrs_str.split(',').each do |attr|
               if attr.include?('=')
                 k, v = attr.split('=', 2)

--- a/coradoc-html/lib/coradoc/html/converters/listing.rb
+++ b/coradoc-html/lib/coradoc/html/converters/listing.rb
@@ -3,36 +3,25 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block (listing) to HTML <pre>
       class Listing < Base
-        # Convert CoreModel::Block (listing) to HTML <pre>
         def self.to_html(listing, _options = {})
           return '' unless listing
 
-          # Build pre attributes
-          attrs = build_attributes(listing)
+          attrs = { class: 'listing' }
+          attrs[:id] = listing.id if listing.id
 
-          # Build title if present
-          title_html = build_title(listing)
-
-          # Process listing content - preserve formatting
           content = process_content(listing.content)
+          pre_node = NodeBuilder.build(:pre, content, **attrs)
 
-          # Combine title and content
-          listing_html = ''
-          listing_html += "#{title_html}\n" if title_html
-          listing_html += %(<pre#{attrs}>#{content}</pre>)
-
-          if title_html
-            %(<div class="listing-block">\n#{listing_html}\n</div>)
+          if listing.title && !listing.title.to_s.empty?
+            title_node = NodeBuilder.build(:div, escape_html(listing.title.to_s), class: 'listing-title')
+            NodeBuilder.build(:div, [title_node, pre_node], class: 'listing-block').to_html
           else
-            listing_html
+            pre_node.to_html
           end
         end
 
-        # Convert HTML <pre> to CoreModel::Block (listing)
         def self.to_coradoc(element, _options = {})
-          # Handle both <pre> and <div class="listing-block"><pre>
           pre_elem = if element.name == 'div' && element['class']&.include?('listing-block')
                        element.at_css('pre')
                      elsif element.name == 'pre'
@@ -43,16 +32,12 @@ module Coradoc
 
           return nil unless pre_elem
 
-          # Extract title if in listing-block wrapper
           title = if element.name == 'div'
                     title_elem = element.at_css('.listing-title')
                     title_elem&.text&.strip
                   end
 
-          # Extract content
           content = pre_elem.text
-
-          # Extract ID if present
           id = pre_elem['id'] || element['id']
 
           Coradoc::CoreModel::SourceBlock.new(
@@ -62,32 +47,12 @@ module Coradoc
           )
         end
 
-        def self.build_attributes(listing)
-          attrs = [%( class="listing")]
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(listing.id)}") if listing.id
-
-          attrs.join
-        end
-
-        def self.build_title(listing)
-          return nil unless listing.title
-
-          title_text = listing.title.to_s
-          return nil if title_text.empty?
-
-          %(<div class="listing-title">#{escape_html(title_text)}</div>)
-        end
-
         def self.process_content(content)
           return '' if content.nil?
 
-          # For listing, preserve the content as-is
           if content.is_a?(String)
             escape_html(content)
           elsif content.is_a?(Array)
-            # Join array items with newlines
             content.map { |line| escape_html(line.to_s) }.join("\n")
           else
             escape_html(content.to_s)

--- a/coradoc-html/lib/coradoc/html/converters/literal.rb
+++ b/coradoc-html/lib/coradoc/html/converters/literal.rb
@@ -3,40 +3,28 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block (literal) to HTML <pre>
       class Literal < Base
-        # Convert CoreModel::Block (literal) to HTML <pre>
         def self.to_html(literal, _options = {})
           return '' unless literal
 
-          # Build pre attributes
-          attrs = build_attributes(literal)
+          attrs = { class: 'literal' }
+          attrs[:id] = literal.id if literal.id
 
-          # Build title if present
-          title_html = build_title(literal)
-
-          # Process literal content - preserve exact formatting
           content = process_content(literal.content)
+          pre_node = NodeBuilder.build(:pre, content, **attrs)
 
-          # Combine title and content
-          literal_html = ''
-          literal_html += "#{title_html}\n" if title_html
-          literal_html += %(<pre#{attrs}>#{content}</pre>)
-
-          if title_html
-            %(<div class="literal-block">\n#{literal_html}\n</div>)
+          if literal.title && !literal.title.to_s.empty?
+            title_node = NodeBuilder.build(:div, escape_html(literal.title.to_s), class: 'literal-title')
+            NodeBuilder.build(:div, [title_node, pre_node], class: 'literal-block').to_html
           else
-            literal_html
+            pre_node.to_html
           end
         end
 
-        # Convert HTML <pre> to CoreModel::Block (literal)
         def self.to_coradoc(element, _options = {})
-          # Handle both <pre> and <div class="literal-block"><pre>
           pre_elem = if element.name == 'div' && element['class']&.include?('literal-block')
                        element.at_css('pre')
                      elsif element.name == 'pre'
-                       # Only convert if it's a literal (no code class)
                        return nil if element['class']&.include?('code')
 
                        element
@@ -46,16 +34,12 @@ module Coradoc
 
           return nil unless pre_elem
 
-          # Extract title if in literal-block wrapper
           title = if element.name == 'div'
                     title_elem = element.at_css('.literal-title')
                     title_elem&.text&.strip
                   end
 
-          # Extract content
           content = pre_elem.text
-
-          # Extract ID if present
           id = pre_elem['id'] || element['id']
 
           Coradoc::CoreModel::LiteralBlock.new(
@@ -65,32 +49,12 @@ module Coradoc
           )
         end
 
-        def self.build_attributes(literal)
-          attrs = [%( class="literal")]
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(literal.id)}") if literal.id
-
-          attrs.join
-        end
-
-        def self.build_title(literal)
-          return nil unless literal.title
-
-          title_text = literal.title.to_s
-          return nil if title_text.empty?
-
-          %(<div class="literal-title">#{escape_html(title_text)}</div>)
-        end
-
         def self.process_content(content)
           return '' if content.nil?
 
-          # For literal, preserve the content exactly as-is
           if content.is_a?(String)
             escape_html(content)
           elsif content.is_a?(Array)
-            # Join array items with newlines
             content.map { |line| escape_html(line.to_s) }.join("\n")
           else
             escape_html(content.to_s)

--- a/coradoc-html/lib/coradoc/html/converters/open.rb
+++ b/coradoc-html/lib/coradoc/html/converters/open.rb
@@ -3,26 +3,21 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block (open) to HTML
       class Open < Base
         def self.to_html(block, _options = {})
           return '' unless block
 
-          # Build content
           content = process_content(block.content)
 
-          # Build attributes
-          attrs = build_attributes(block)
+          attrs = { class: 'openblock' }
+          attrs[:id] = block.id if block.id
 
-          # Wrap in div with openblock class
-          "<div#{attrs}>\n#{content}\n</div>"
+          NodeBuilder.build(:div, content, **attrs).to_html
         end
 
-        # Convert HTML div to CoreModel::Block (open)
         def self.to_coradoc(element, _options = {})
           return nil unless element.name == 'div'
 
-          # Extract content
           content = element.children.map do |node|
             if node.text? && !node.text.strip.empty?
               node.text.strip
@@ -36,22 +31,10 @@ module Coradoc
             end
           end.compact
 
-          # Extract ID if present
-          id = element['id']
-
           Coradoc::CoreModel::OpenBlock.new(
             content: content,
-            id: id
+            id: element['id']
           )
-        end
-
-        def self.build_attributes(block)
-          attrs = []
-          attrs << %( class="openblock")
-
-          attrs << %( id="#{escape_attribute(block.id)}") if block.id
-
-          attrs.join
         end
 
         def self.process_content(content)
@@ -67,7 +50,7 @@ module Coradoc
         def self.convert_item(item)
           case item
           when String
-            "<p>#{escape_html(item)}</p>"
+            NodeBuilder.build(:p, escape_html(item)).to_html
           else
             convert_content_to_html(item)
           end

--- a/coradoc-html/lib/coradoc/html/converters/quote.rb
+++ b/coradoc-html/lib/coradoc/html/converters/quote.rb
@@ -3,60 +3,39 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block (quote) to HTML <blockquote>
       class Quote < Base
-        # Convert CoreModel::Block (quote) to HTML <blockquote>
         def self.to_html(quote, _options = {})
           return '' unless quote
 
-          # Build blockquote attributes
-          attrs = build_attributes(quote)
+          attrs = {}
+          attrs[:id] = quote.id if quote.id
 
-          # Process quote content
           content = process_content(quote.content)
+          children_html = content
 
-          # Build attribution if present
           attribution = build_attribution(quote)
+          children_html += "\n#{attribution}" if attribution
 
-          # Combine content and attribution
-          quote_html = content
-          quote_html += "\n#{attribution}" if attribution
-
-          "<blockquote#{attrs}>\n#{quote_html}\n</blockquote>"
+          NodeBuilder.build(:blockquote, children_html, **attrs).to_html
         end
 
-        # Convert HTML <blockquote> to CoreModel::Block (quote)
         def self.to_coradoc(element, _options = {})
           return nil unless element.name == 'blockquote'
 
-          # Extract content - all children except cite/footer
           content_nodes = element.children.reject do |node|
             %w[cite footer].include?(node.name)
           end
 
           content = extract_content(content_nodes)
 
-          # Extract attribution from <cite> or <footer>
           cite_elem = element.at_css('cite, footer')
           attribution = cite_elem&.text&.strip
 
-          # Extract ID if present
-          id = element['id']
-
           Coradoc::CoreModel::QuoteBlock.new(
             content: content,
-            id: id,
+            id: element['id'],
             attribution: attribution
           )
-        end
-
-        def self.build_attributes(quote)
-          attrs = []
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(quote.id)}") if quote.id
-
-          attrs.join
         end
 
         def self.process_content(content)
@@ -65,7 +44,7 @@ module Coradoc
           if content.is_a?(Array)
             content.map { |item| convert_item(item) }.join("\n")
           elsif content.is_a?(String)
-            "<p>#{escape_html(content)}</p>"
+            NodeBuilder.build(:p, escape_html(content)).to_html
           else
             convert_item(content)
           end
@@ -74,26 +53,21 @@ module Coradoc
         def self.convert_item(item)
           case item
           when String
-            "<p>#{escape_html(item)}</p>"
+            NodeBuilder.build(:p, escape_html(item)).to_html
           else
-            # Use centralized content conversion
             convert_content_to_html(item)
           end
         end
 
         def self.build_attribution(quote)
-          # Check metadata for attribution
           attribution_text = quote.metadata&.dig(:attribution)
           return nil unless attribution_text
+          return nil if attribution_text.to_s.strip.empty?
 
-          attribution_text = attribution_text.to_s.strip
-          return nil if attribution_text.empty?
-
-          %(<footer>#{escape_html(attribution_text)}</footer>)
+          NodeBuilder.build(:footer, escape_html(attribution_text.to_s.strip)).to_html
         end
 
         def self.extract_content(nodes)
-          # Extract and convert content nodes
           nodes.map do |node|
             if node.text? && !node.text.strip.empty?
               node.text.strip

--- a/coradoc-html/lib/coradoc/html/converters/reviewer_comment.rb
+++ b/coradoc-html/lib/coradoc/html/converters/reviewer_comment.rb
@@ -3,37 +3,24 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::AnnotationBlock (reviewer comment) to HTML
       class ReviewerComment < Base
-        # Convert CoreModel::AnnotationBlock (reviewer comment) to HTML
         def self.to_html(comment, _options = {})
           return '' unless comment
 
-          # Build attributes
-          attrs = build_attributes(comment)
+          attrs = { class: 'reviewer-note' }
+          attrs[:id] = comment.id if comment.id
 
-          # Process content
-          content = process_content(comment.content)
+          children = []
 
-          # Parse reviewer info from metadata
+          children << NodeBuilder.build(:span, 'Reviewer Note', class: 'reviewer-note-label')
+
           reviewer_info = extract_reviewer_info(comment.metadata)
+          children << NodeBuilder.build(:fragment, reviewer_info) unless reviewer_info.empty?
 
-          %(<div#{attrs}>
-<span class="reviewer-note-label">Reviewer Note</span>
-#{reviewer_info}
-<div class="reviewer-note-content">
-#{content}
-</div>
-</div>)
-        end
+          content = process_content(comment.content)
+          children << NodeBuilder.build(:div, content, class: 'reviewer-note-content')
 
-        def self.build_attributes(comment)
-          attrs = [%( class="reviewer-note")]
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(comment.id)}") if comment.id
-
-          attrs.join
+          NodeBuilder.build(:div, children, **attrs).to_html
         end
 
         def self.process_content(content)
@@ -60,13 +47,11 @@ module Coradoc
         def self.extract_reviewer_info(metadata)
           return '' if metadata.nil?
 
-          # Extract reviewer info from metadata
           reviewer = metadata[:reviewer]
           return '' unless reviewer
 
-          %(<div class="reviewer-note-metadata">
-<span class="metadata-item">reviewer=#{escape_html(reviewer)}</span>
-</div>)
+          span = NodeBuilder.build(:span, "reviewer=#{escape_html(reviewer)}", class: 'metadata-item')
+          NodeBuilder.build(:div, span, class: 'reviewer-note-metadata').to_html
         end
       end
     end

--- a/coradoc-html/lib/coradoc/html/converters/reviewer_note.rb
+++ b/coradoc-html/lib/coradoc/html/converters/reviewer_note.rb
@@ -3,36 +3,30 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::AnnotationBlock (reviewer note) to HTML <aside>
       class ReviewerNote < Base
-        # Convert CoreModel::AnnotationBlock (reviewer note) to HTML <aside>
         def self.to_html(reviewer_note, options = {})
           return '' unless reviewer_note
 
-          # Build aside attributes with reviewer metadata
           attrs = build_attributes(reviewer_note)
-
-          # Build header with label and visible metadata
           header = build_header(reviewer_note)
-
-          # Process reviewer note content
           content = process_content(reviewer_note.content, options)
 
-          %(<aside#{attrs}>\n#{header}#{content}\n</div>\n</aside>)
+          children = []
+          children << NodeBuilder.build(:fragment, header) unless header.empty?
+          children << NodeBuilder.build(:div, content, class: 'reviewer-note-content')
+
+          NodeBuilder.build(:aside, children, **attrs).to_html
         end
 
-        # Convert HTML <aside> with reviewer data to CoreModel::AnnotationBlock
         def self.to_coradoc(element, _options = {})
           return nil unless element.name == 'aside'
-          return nil unless element['data-reviewer'] # Must have reviewer attribute
+          return nil unless element['data-reviewer']
 
-          # Extract reviewer metadata
           reviewer = element['data-reviewer']
           date = element['data-date']
           from = element['data-from']
           to = element['data-to']
 
-          # Extract content
           content = extract_content(element.children)
 
           Coradoc::CoreModel::AnnotationBlock.new(
@@ -48,48 +42,37 @@ module Coradoc
         end
 
         def self.build_header(reviewer_note)
-          # Build header with label and visible metadata
-          header_parts = []
-          header_parts << %(<div class="reviewer-note-header">)
-          header_parts << %(  <span class="reviewer-note-label">Reviewer's note</span>)
-
-          # Build metadata display if any metadata exists
-          metadata_items = []
           metadata = reviewer_note.metadata || {}
-          metadata_items << %(reviewer=#{escape_html(metadata[:reviewer])}) if metadata[:reviewer]
-          metadata_items << %(date=#{escape_html(metadata[:date])}) if metadata[:date]
-          metadata_items << %(from=#{escape_html(metadata[:from])}) if metadata[:from]
-          metadata_items << %(to=#{escape_html(metadata[:to])}) if metadata[:to]
+
+          children = []
+          children << NodeBuilder.build(:span, "Reviewer's note", class: 'reviewer-note-label')
+
+          metadata_items = []
+          metadata_items << "reviewer=#{escape_html(metadata[:reviewer])}" if metadata[:reviewer]
+          metadata_items << "date=#{escape_html(metadata[:date])}" if metadata[:date]
+          metadata_items << "from=#{escape_html(metadata[:from])}" if metadata[:from]
+          metadata_items << "to=#{escape_html(metadata[:to])}" if metadata[:to]
 
           unless metadata_items.empty?
-            header_parts << %(  <div class="reviewer-note-metadata">)
-            metadata_items.each do |item|
-              header_parts << %(    <span class="metadata-item">#{item}</span>)
-            end
-            header_parts << %(  </div>)
+            spans = metadata_items.map { |item| NodeBuilder.build(:span, item, class: 'metadata-item') }
+            children << NodeBuilder.build(:div, spans, class: 'reviewer-note-metadata')
           end
 
-          header_parts << %(</div>)
-          header_parts << %(<div class="reviewer-note-content">)
-
-          header_parts.join("\n")
+          header = NodeBuilder.build(:div, children, class: 'reviewer-note-header')
+          header.to_html
         end
 
         def self.build_attributes(reviewer_note)
-          attrs = [%( class="reviewer-note")]
+          attrs = { class: 'reviewer-note' }
+          attrs[:id] = reviewer_note.id if reviewer_note.id
 
-          # Add reviewer metadata as data attributes
           metadata = reviewer_note.metadata || {}
+          attrs[:'data-reviewer'] = metadata[:reviewer].to_s if metadata[:reviewer]
+          attrs[:'data-date'] = metadata[:date].to_s if metadata[:date]
+          attrs[:'data-from'] = metadata[:from].to_s if metadata[:from]
+          attrs[:'data-to'] = metadata[:to].to_s if metadata[:to]
 
-          attrs << %( data-reviewer="#{escape_html(metadata[:reviewer])}") if metadata[:reviewer]
-
-          attrs << %( data-date="#{escape_html(metadata[:date])}") if metadata[:date]
-
-          attrs << %( data-from="#{escape_html(metadata[:from])}") if metadata[:from]
-
-          attrs << %( data-to="#{escape_html(metadata[:to])}") if metadata[:to]
-
-          attrs.join
+          attrs
         end
 
         def self.process_content(content, options = {})
@@ -98,7 +81,7 @@ module Coradoc
           if content.is_a?(Array)
             content.map { |item| convert_item(item, options) }.join("\n")
           elsif content.is_a?(String)
-            "<p>#{escape_html(content)}</p>"
+            NodeBuilder.build(:p, escape_html(content)).to_html
           else
             convert_item(content, options)
           end
@@ -107,14 +90,13 @@ module Coradoc
         def self.convert_item(item, _options = {})
           case item
           when String
-            "<p>#{escape_html(item)}</p>"
+            NodeBuilder.build(:p, escape_html(item)).to_html
           else
             convert_content_to_html(item)
           end
         end
 
         def self.extract_content(nodes)
-          # Extract and convert content nodes
           nodes.map do |node|
             if node.text? && !node.text.strip.empty?
               node.text.strip

--- a/coradoc-html/lib/coradoc/html/converters/sidebar.rb
+++ b/coradoc-html/lib/coradoc/html/converters/sidebar.rb
@@ -3,38 +3,29 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block (sidebar) to HTML <aside>
       class Sidebar < Base
-        # Convert CoreModel::Block (sidebar) to HTML <aside>
         def self.to_html(sidebar, _options = {})
           return '' unless sidebar
 
-          # Build aside attributes
-          attrs = build_attributes(sidebar)
+          attrs = { class: 'sidebar' }
+          attrs[:id] = sidebar.id if sidebar.id
 
-          # Build title if present
-          title_html = build_title(sidebar)
+          children = []
 
-          # Process sidebar content
+          children << NodeBuilder.build(:div, escape_html(sidebar.title.to_s), class: 'sidebar-title') if sidebar.title && !sidebar.title.to_s.empty?
+
           content = process_content(sidebar.content)
+          children << content unless content.empty?
 
-          # Combine title and content
-          sidebar_html = ''
-          sidebar_html += "#{title_html}\n" if title_html
-          sidebar_html += content
-
-          %(<aside#{attrs}>\n#{sidebar_html}\n</aside>)
+          NodeBuilder.build(:aside, children, **attrs).to_html
         end
 
-        # Convert HTML <aside> to CoreModel::Block (sidebar)
         def self.to_coradoc(element, _options = {})
           return nil unless element.name == 'aside'
 
-          # Extract title if present
           title_elem = element.at_css('.sidebar-title, h1, h2, h3, h4, h5, h6')
           title = title_elem&.text&.strip
 
-          # Extract content - all children except title
           content_nodes = if title_elem
                             element.children.reject { |node| node == title_elem }
                           else
@@ -43,32 +34,11 @@ module Coradoc
 
           content = extract_content(content_nodes)
 
-          # Extract ID if present
-          id = element['id']
-
           Coradoc::CoreModel::SidebarBlock.new(
             content: content,
             title: title,
-            id: id
+            id: element['id']
           )
-        end
-
-        def self.build_attributes(sidebar)
-          attrs = [%( class="sidebar")]
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(sidebar.id)}") if sidebar.id
-
-          attrs.join
-        end
-
-        def self.build_title(sidebar)
-          return nil unless sidebar.title
-
-          title_text = sidebar.title.to_s
-          return nil if title_text.empty?
-
-          %(<div class="sidebar-title">#{escape_html(title_text)}</div>)
         end
 
         def self.process_content(content)
@@ -77,7 +47,7 @@ module Coradoc
           if content.is_a?(Array)
             content.map { |item| convert_item(item) }.join("\n")
           elsif content.is_a?(String)
-            "<p>#{escape_html(content)}</p>"
+            NodeBuilder.build(:p, escape_html(content)).to_html
           else
             convert_item(content)
           end
@@ -86,14 +56,13 @@ module Coradoc
         def self.convert_item(item)
           case item
           when String
-            "<p>#{escape_html(item)}</p>"
+            NodeBuilder.build(:p, escape_html(item)).to_html
           else
             convert_content_to_html(item)
           end
         end
 
         def self.extract_content(nodes)
-          # Extract and convert content nodes
           nodes.map do |node|
             if node.text? && !node.text.strip.empty?
               node.text.strip

--- a/coradoc-html/lib/coradoc/html/converters/source.rb
+++ b/coradoc-html/lib/coradoc/html/converters/source.rb
@@ -3,39 +3,29 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block (source) to HTML <pre><code>
       class Source < Base
-        # Convert CoreModel::Block (source) to HTML <pre><code>
         def self.to_html(source, _options = {})
           return '' unless source
 
-          # Build title if present
-          title_html = build_title(source)
+          code_attrs = {}
+          lang = source.language
+          code_attrs[:class] = "language-#{lang}" if lang && !lang.empty?
+          code_attrs[:id] = source.id if source.id
 
-          # Build code attributes with language
-          code_attrs = build_code_attributes(source)
-
-          # Build pre attributes
-          pre_attrs = build_pre_attributes(source)
-
-          # Process source content
           content = process_content(source.content)
 
-          # Combine into source block
-          source_html = ''
-          source_html += "#{title_html}\n" if title_html
-          source_html += %(<pre#{pre_attrs}><code#{code_attrs}>#{content}</code></pre>)
+          code_node = NodeBuilder.build(:code, content, **code_attrs)
+          pre_node = NodeBuilder.build(:pre, code_node, class: 'source')
 
-          if title_html
-            %(<div class="source-block">\n#{source_html}\n</div>)
+          if source.title && !source.title.to_s.empty?
+            title_node = NodeBuilder.build(:div, escape_html(source.title.to_s), class: 'source-title')
+            NodeBuilder.build(:div, [title_node, pre_node], class: 'source-block').to_html
           else
-            source_html
+            pre_node.to_html
           end
         end
 
-        # Convert HTML <pre><code> to CoreModel::Block (source)
         def self.to_coradoc(element, _options = {})
-          # Handle <div class="source-block"><pre><code>, <pre><code>, or <code>
           code_elem = if element.name == 'div' && element['class']&.include?('source-block')
                         element.at_css('code')
                       elsif element.name == 'pre'
@@ -48,19 +38,13 @@ module Coradoc
 
           return nil unless code_elem
 
-          # Extract title if in source-block wrapper
           title = if element.name == 'div'
                     title_elem = element.at_css('.source-title')
                     title_elem&.text&.strip
                   end
 
-          # Extract language from class
           language = extract_language(code_elem)
-
-          # Extract content
           content = code_elem.text
-
-          # Extract ID if present
           id = code_elem['id'] || element['id']
 
           Coradoc::CoreModel::SourceBlock.new(
@@ -71,41 +55,12 @@ module Coradoc
           )
         end
 
-        def self.build_code_attributes(source)
-          attrs = []
-
-          # Add language class if present
-          lang = source.language
-
-          attrs << %( class="language-#{escape_attribute(lang)}") if lang && !lang.empty?
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(source.id)}") if source.id
-
-          attrs.join
-        end
-
-        def self.build_pre_attributes(_source)
-          %( class="source")
-        end
-
-        def self.build_title(source)
-          return nil unless source.title
-
-          title_text = source.title.to_s
-          return nil if title_text.empty?
-
-          %(<div class="source-title">#{escape_html(title_text)}</div>)
-        end
-
         def self.process_content(content)
           return '' if content.nil?
 
-          # For source code, preserve the content exactly
           if content.is_a?(String)
             escape_html(content)
           elsif content.is_a?(Array)
-            # Join array items with newlines
             content.map { |line| escape_html(line.to_s) }.join("\n")
           else
             escape_html(content.to_s)
@@ -115,7 +70,6 @@ module Coradoc
         def self.extract_language(element)
           return nil unless element['class']
 
-          # Extract language from class like "language-ruby", "lang-python", etc.
           classes = element['class'].split
           lang_class = classes.find { |c| c.start_with?('language-', 'lang-') }
           return nil unless lang_class
@@ -124,13 +78,7 @@ module Coradoc
         end
       end
 
-      # Converter for SourceCode blocks
-      #
-      # SourceCode models use the `lines` attribute, while Source models use `content`.
-      # This converter inherits from Source and handles the lines attribute properly.
       class SourceCode < Source
-        # The parent Source class already handles both content and lines attributes
-        # after our recent update, so we just need to inherit.
       end
     end
   end

--- a/coradoc-html/lib/coradoc/html/converters/table_cell.rb
+++ b/coradoc-html/lib/coradoc/html/converters/table_cell.rb
@@ -4,41 +4,23 @@ module Coradoc
   module Html
     module Converters
       class TableCell < Base
-        # Convert CoreModel::TableCell to HTML <td> or <th>
-        #
-        # @param cell [Coradoc::CoreModel::TableCell] Table cell model
-        # @param _options [Hash] Conversion options
-        # @return [String] HTML string
         def self.to_html(cell, _options = {})
           return '' unless cell
 
-          # Check if this is a header cell
-          is_header = cell.header == true
-          tag = is_header ? 'th' : 'td'
+          tag = cell.header == true ? :th : :td
 
-          # Build cell attributes
-          attrs = build_attributes(cell)
-
-          # Process cell content
+          attrs = build_attrs(cell)
           content = process_content(cell)
-
-          # Wrap content in style tags if needed
           content = wrap_with_style(content, cell)
 
-          "<#{tag}#{attrs}>#{content}</#{tag}>"
+          NodeBuilder.build(tag, content, **attrs).to_html
         end
 
-        # Convert HTML <td> or <th> to CoreModel::TableCell
         def self.to_coradoc(element, _options = {})
           return nil unless %w[td th].include?(element.name)
 
-          # Determine if this is a header cell
           is_header = element.name == 'th'
-
-          # Extract content - could be text or nested elements
           content = extract_content(element)
-
-          # Extract cell attributes
           attrs = extract_cell_attributes(element)
 
           Coradoc::CoreModel::TableCell.new(
@@ -48,43 +30,34 @@ module Coradoc
           )
         end
 
-        # Build HTML attributes from CoreModel::TableCell
-        def self.build_attributes(cell)
-          attrs = []
-
-          attrs << %( id="#{escape_attribute(cell.id)}") if cell.id
-
-          attrs << %( colspan="#{cell.colspan}") if cell.colspan
-          attrs << %( rowspan="#{cell.rowspan}") if cell.rowspan
+        def self.build_attrs(cell)
+          attrs = {}
+          attrs[:id] = cell.id if cell.id
+          attrs[:colspan] = cell.colspan.to_s if cell.colspan
+          attrs[:rowspan] = cell.rowspan.to_s if cell.rowspan
 
           style_parts = []
+          style_parts << "text-align: #{cell.alignment}" if cell.alignment
+          style_parts << "vertical-align: #{cell.vertical_alignment}" if cell.vertical_alignment
+          attrs[:style] = style_parts.join('; ') if style_parts.any?
 
-          style_parts << "text-align: #{escape_attribute(cell.alignment)}" if cell.alignment
-          style_parts << "vertical-align: #{escape_attribute(cell.vertical_alignment)}" if cell.vertical_alignment
-
-          # Add style attribute if we have any styles
-          attrs << %( style="#{style_parts.join('; ')}") if style_parts.any?
-
-          attrs.join
+          attrs
         end
 
-        # Wrap content with style tags based on cell style
         def self.wrap_with_style(content, cell)
           return content unless cell.style
 
           case cell.style.to_s.downcase
           when 'strong', 's'
-            "<strong>#{content}</strong>"
+            NodeBuilder.build(:strong, content).to_html
           when 'emphasis', 'e'
-            "<em>#{content}</em>"
+            NodeBuilder.build(:em, content).to_html
           when 'monospace', 'm'
-            "<code>#{content}</code>"
+            NodeBuilder.build(:code, content).to_html
           when 'literal', 'l'
-            # Literal content - preserve whitespace
-            "<pre>#{content}</pre>"
+            NodeBuilder.build(:pre, content).to_html
           when 'verse', 'v'
-            # Verse content - preserve formatting
-            "<div class=\"verse\">#{content}</div>"
+            NodeBuilder.build(:div, content, class: 'verse').to_html
           else
             content
           end
@@ -93,7 +66,6 @@ module Coradoc
         def self.process_content(cell)
           return '' if cell.nil?
 
-          # Use renderable_content if available (prefers children over content)
           content = if cell.renderable_content
                       cell.renderable_content
                     elsif cell.children.any?
@@ -116,25 +88,20 @@ module Coradoc
           when String
             escape_html(item)
           else
-            # Use convert_content_to_html for CoreModel types
             convert_content_to_html(item, {})
           end
         end
 
         def self.extract_content(element)
-          # Extract content from the cell
           children = element.children
 
           if children.size == 1 && children.first.text?
-            # Simple text content
             children.first.text
           else
-            # Complex content with nested elements
             children.map do |child|
               if child.text?
                 child.text
               else
-                # Convert HTML element to CoreModel
                 convert_node_to_core(child, {})
               end
             end.compact
@@ -144,49 +111,26 @@ module Coradoc
         def self.extract_cell_attributes(element)
           attrs = {}
 
-          # Extract colspan
           attrs[:colspan] = element['colspan'].to_i if element['colspan']
-
-          # Extract rowspan
           attrs[:rowspan] = element['rowspan'].to_i if element['rowspan']
 
-          # Extract styles from style attribute
           if element['style']
             style = element['style']
 
-            # Horizontal alignment
-            if style.include?('text-align')
-              align = style[/text-align:\s*(\w+)/, 1]
-              attrs[:alignment] = align if align
-            end
+            align = style[/text-align:\s*(\w+)/, 1]
+            attrs[:alignment] = align if align
 
-            # Vertical alignment
-            if style.include?('vertical-align')
-              valign = style[/vertical-align:\s*(\w+)/, 1]
-              attrs[:vertical_alignment] = valign if valign
-            end
+            valign = style[/vertical-align:\s*(\w+)/, 1]
+            attrs[:vertical_alignment] = valign if valign
 
-            # Background color
-            if style.include?('background-color')
-            end
+            color = style[/color:\s*([^;]+)/, 1]
+            attrs[:color] = color.strip if color
 
-            # Text color
-            if style.include?('color:')
-              color = style[/color:\s*([^;]+)/, 1]
-              attrs[:color] = color.strip if color
-            end
+            width = style[/width:\s*([^;]+)/, 1]
+            attrs[:width] = width.strip if width
 
-            # Width
-            if style.include?('width:')
-              width = style[/width:\s*([^;]+)/, 1]
-              attrs[:width] = width.strip if width
-            end
-
-            # Height
-            if style.include?('height:')
-              height = style[/height:\s*([^;]+)/, 1]
-              attrs[:height] = height.strip if height
-            end
+            height = style[/height:\s*([^;]+)/, 1]
+            attrs[:height] = height.strip if height
           end
 
           attrs

--- a/coradoc-html/lib/coradoc/html/converters/table_row.rb
+++ b/coradoc-html/lib/coradoc/html/converters/table_row.rb
@@ -4,40 +4,28 @@ module Coradoc
   module Html
     module Converters
       class TableRow < Base
-        # Convert CoreModel::TableRow to HTML <tr>
         def self.to_html(row, _options = {})
           return '' unless row
 
-          # CoreModel::TableRow uses cells
           cells = row.cells || []
-          columns_html = cells.map do |cell|
+          cells_html = cells.map do |cell|
             TableCell.to_html(cell)
           end.join("\n")
 
-          attrs = build_attributes(row)
+          attrs = {}
+          attrs[:id] = row.id if row.id
 
-          "<tr#{attrs}>\n#{columns_html}\n</tr>"
+          NodeBuilder.build(:tr, cells_html, **attrs).to_html
         end
 
-        # Convert HTML <tr> to CoreModel::TableRow
         def self.to_coradoc(element, _options = {})
           return nil unless element.name == 'tr'
 
-          # Get all cells (both td and th)
           cells = element.css('td, th').map do |cell_elem|
             TableCell.to_coradoc(cell_elem)
           end.compact
 
           Coradoc::CoreModel::TableRow.new(cells: cells)
-        end
-
-        def self.build_attributes(row)
-          attrs = []
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(row.id)}") if row.id
-
-          attrs.join
         end
       end
     end

--- a/coradoc-html/lib/coradoc/html/converters/term.rb
+++ b/coradoc-html/lib/coradoc/html/converters/term.rb
@@ -4,12 +4,8 @@ module Coradoc
   module Html
     module Converters
       autoload :Base, "#{__dir__}/base"
-      # Converter for CoreModel::InlineElement (term) elements
-      #
-      # Terms are used in definition lists and can have types like "acronym",
-      # "symbol", "preferred", etc.
+
       class Term < Base
-        # Convert HTML to CoreModel::InlineElement (term)
         def self.to_coradoc(node, _state = {})
           attrs = extract_node_attributes(node)
 
@@ -28,28 +24,22 @@ module Coradoc
           )
         end
 
-        # Convert CoreModel::InlineElement (term) to HTML
         def self.to_html(term, _state = {})
           term_text = term.content || ''
           term_type = term.target || 'term'
           render_text = term.metadata&.dig(:render_text)
 
-          # Use render_text if available, otherwise use term
           display_text = render_text&.strip&.empty? ? false : render_text
           display_text ||= term_text
 
-          # Build class attribute
-          classes = ['term', "term-#{escape_attribute(term_type)}"]
-          class_attr = classes.join(' ')
+          classes = "term term-#{term_type}"
+          node = NodeBuilder.build(:span, escape_html(display_text), class: classes)
+          node['data-term-ref'] = term_text.to_s
 
-          # Build data attributes
-          data_attrs = []
-          data_attrs << %( data-term-ref="#{escape_attribute(term_text)}")
           lang = term.metadata&.dig(:lang)
-          data_attrs << %( lang="#{escape_attribute(lang)}") if lang && lang != 'en'
+          node['lang'] = lang if lang && lang != 'en'
 
-          # Render as a styled span with term reference
-          %(<span class="#{class_attr}"#{data_attrs.join}>#{escape_html(display_text)}</span>)
+          node.to_html
         end
       end
     end

--- a/coradoc-html/lib/coradoc/html/converters/verse.rb
+++ b/coradoc-html/lib/coradoc/html/converters/verse.rb
@@ -3,97 +3,61 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for CoreModel::Block (verse) to HTML <div class="verse">
       class Verse < Base
-        # Convert CoreModel::Block (verse) to HTML <div class="verse">
         def self.to_html(verse, _options = {})
           return '' unless verse
 
-          # Build div attributes
-          attrs = build_attributes(verse)
+          attrs = { class: 'verse' }
+          attrs[:id] = verse.id if verse.id
 
-          # Build title if present
-          title_html = build_title(verse)
+          children = []
 
-          # Build attribution if present
-          attribution = build_attribution(verse)
+          children << NodeBuilder.build(:div, escape_html(verse.title.to_s), class: 'verse-title') if verse.title && !verse.title.to_s.empty?
 
-          # Process verse content - preserve line breaks
           content = process_content(verse.content)
+          children << NodeBuilder.build(:pre, content, class: 'verse-content')
 
-          # Combine title, content, and attribution
-          verse_html = ''
-          verse_html += "#{title_html}\n" if title_html
-          verse_html += %(<pre class="verse-content">#{content}</pre>)
-          verse_html += "\n#{attribution}" if attribution
+          attribution = build_attribution(verse)
+          children << NodeBuilder.build(:fragment, attribution) if attribution
 
-          %(<div#{attrs}>\n#{verse_html}\n</div>)
+          NodeBuilder.build(:div, children, **attrs).to_html
         end
 
-        # Convert HTML <div class="verse"> to CoreModel::Block (verse)
         def self.to_coradoc(element, _options = {})
           return nil unless element.name == 'div'
           return nil unless element['class']&.include?('verse')
 
-          # Extract title if present
           title_elem = element.at_css('.verse-title')
           title = title_elem&.text&.strip
 
-          # Extract content from <pre class="verse-content">
           content_elem = element.at_css('.verse-content, pre')
           content = content_elem&.text || ''
 
-          # Extract attribution from <cite> or <footer>
           cite_elem = element.at_css('cite, footer')
           attribution = cite_elem&.text&.strip
-
-          # Extract ID if present
-          id = element['id']
 
           Coradoc::CoreModel::VerseBlock.new(
             content: content,
             title: title,
-            id: id,
+            id: element['id'],
             attribution: attribution
           )
-        end
-
-        def self.build_attributes(verse)
-          attrs = [%( class="verse")]
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(verse.id)}") if verse.id
-
-          attrs.join
-        end
-
-        def self.build_title(verse)
-          return nil unless verse.title
-
-          title_text = verse.title.to_s
-          return nil if title_text.empty?
-
-          %(<div class="verse-title">#{escape_html(title_text)}</div>)
         end
 
         def self.build_attribution(verse)
           attribution_text = verse.metadata&.dig(:attribution)
           return nil unless attribution_text
+          return nil if attribution_text.to_s.strip.empty?
 
-          attribution_text = attribution_text.to_s.strip
-          return nil if attribution_text.empty?
-
-          %(<footer>#{escape_html(attribution_text)}</footer>)
+          NodeBuilder.build(:footer, escape_html(attribution_text.to_s.strip)).to_html
         end
 
         def self.process_content(content)
           return '' if content.nil?
 
-          # For verse, preserve the content as-is with line breaks
           if content.is_a?(String)
             escape_html(content)
           elsif content.is_a?(Array)
-            # Join array items with newlines
             content.map { |line| escape_html(line.to_s) }.join("\n")
           else
             escape_html(content.to_s)

--- a/coradoc-html/lib/coradoc/html/converters/video.rb
+++ b/coradoc-html/lib/coradoc/html/converters/video.rb
@@ -3,48 +3,33 @@
 module Coradoc
   module Html
     module Converters
-      # Converter for video elements
       class Video < Base
-        # Convert CoreModel::Block (video) to HTML <video>
         def self.to_html(video, _options = {})
           return '' unless video
 
-          # Build video attributes
-          attrs = build_attributes(video)
-
-          # Get video source from metadata or content
           src = video.metadata&.dig(:src) || video.content
+          attrs = build_video_attrs(video)
 
-          # Build source element
-          source_tag = %(<source src="#{escape_attribute(src)}"#{build_type_attr(src)}>)
+          source_attrs = { src: src }
+          type = build_type_attr(src)
+          source_attrs[:type] = type if type
 
-          # Build optional caption/title
-          caption = video.title
+          source_node = NodeBuilder.build(:source, nil, **source_attrs)
+          fallback = NodeBuilder.text('Your browser does not support the video tag.')
 
-          # Determine if we need a wrapper (for block video with caption)
-          if caption
-            <<~HTML.strip
-              <figure#{build_figure_attrs(video)}>
-                <video#{attrs}>
-                  #{source_tag}
-                  Your browser does not support the video tag.
-                </video>
-                <figcaption>#{escape_html(caption)}</figcaption>
-              </figure>
-            HTML
+          video_node = NodeBuilder.build(:video, [source_node, fallback], **attrs)
+
+          if video.title
+            fig_attrs = {}
+            fig_attrs[:id] = "#{video.id}-figure" if video.id
+            caption = NodeBuilder.build(:figcaption, escape_html(video.title))
+            NodeBuilder.build(:figure, [video_node, caption], **fig_attrs).to_html
           else
-            <<~HTML.strip
-              <video#{attrs}>
-                #{source_tag}
-                Your browser does not support the video tag.
-              </video>
-            HTML
+            video_node.to_html
           end
         end
 
-        # Convert HTML <video> to CoreModel::Block (video)
         def self.to_coradoc(element, _options = {})
-          # Handle both <video> and <figure><video> structures
           video_elem = if element.name == 'figure'
                          element.at_css('video')
                        elsif element.name == 'video'
@@ -55,20 +40,14 @@ module Coradoc
 
           return nil unless video_elem
 
-          # Extract source from <source> tag or src attribute
           src = extract_video_src(video_elem)
           return nil unless src
 
-          # Extract caption if in figure
           caption = if element.name == 'figure'
                       figcaption = element.at_css('figcaption')
                       figcaption&.text&.strip
                     end
 
-          # Extract ID if present
-          id = video_elem['id'] || element['id']
-
-          # Extract video attributes
           metadata = extract_video_metadata(video_elem)
           metadata[:src] = src
 
@@ -76,78 +55,47 @@ module Coradoc
             block_semantic_type: 'video',
             content: src,
             title: caption,
-            id: id,
+            id: video_elem['id'] || element['id'],
             metadata: metadata
           )
         end
 
-        def self.build_attributes(video)
-          attrs = []
-
-          # Extract options from metadata
+        def self.build_video_attrs(video)
+          attrs = {}
           options = video.metadata&.dig(:options) || []
 
-          # Add controls by default (unless nocontrols option is set)
-          has_controls = !options.include?('nocontrols')
-          attrs << ' controls' if has_controls
+          attrs[:controls] = '' unless options.include?('nocontrols')
+          attrs[:autoplay] = '' if options.include?('autoplay')
+          attrs[:loop] = '' if options.include?('loop')
+          attrs[:muted] = '' if options.include?('muted')
 
-          # Add autoplay if specified in options
-          attrs << ' autoplay' if options.include?('autoplay')
-
-          # Add loop if specified in options
-          attrs << ' loop' if options.include?('loop')
-
-          # Add muted if specified in options
-          attrs << ' muted' if options.include?('muted')
-
-          # Add poster if specified
           poster = video.metadata&.dig(:poster)
-          attrs << %( poster="#{escape_attribute(poster)}") if poster
+          attrs[:poster] = poster if poster
 
-          # Add width and height if specified
           width = video.metadata&.dig(:width)
+          attrs[:width] = width if width
+
           height = video.metadata&.dig(:height)
+          attrs[:height] = height if height
 
-          attrs << %( width="#{escape_attribute(width)}") if width
+          attrs[:id] = video.id if video.id
 
-          attrs << %( height="#{escape_attribute(height)}") if height
-
-          # Add ID if present
-          attrs << %( id="#{escape_attribute(video.id)}") if video.id
-
-          attrs.join
+          attrs
         end
 
         def self.build_type_attr(src)
-          # Determine video MIME type from extension
-          ext = File.extname(src).downcase
-          type = case ext
-                 when '.mp4'
-                   'video/mp4'
-                 when '.webm'
-                   'video/webm'
-                 when '.ogg', '.ogv'
-                   'video/ogg'
-                 end
-
-          type ? %( type="#{type}") : ''
-        end
-
-        def self.build_figure_attrs(video)
-          attrs = []
-
-          # Add ID to figure if present
-          attrs << %( id="#{escape_attribute(video.id)}-figure") if video.id
-
-          attrs.join
+          ext = File.extname(src.to_s).downcase
+          case ext
+          when '.mp4' then 'video/mp4'
+          when '.webm' then 'video/webm'
+          when '.ogg', '.ogv' then 'video/ogg'
+          end
         end
 
         def self.extract_video_src(element)
-          # Try to get src from <source> tag first
           source = element.at_css('source')
           return source['src'] if source && source['src']
 
-          # Fall back to src attribute on <video>
           element['src']
         end
 
@@ -155,20 +103,14 @@ module Coradoc
           metadata = {}
           options = []
 
-          # Extract boolean attributes
           options << 'controls' if element.has_attribute?('controls')
           options << 'autoplay' if element.has_attribute?('autoplay')
           options << 'loop' if element.has_attribute?('loop')
           options << 'muted' if element.has_attribute?('muted')
 
           metadata[:options] = options unless options.empty?
-
-          # Extract poster
           metadata[:poster] = element['poster'] if element['poster']
-
-          # Extract dimensions
           metadata[:width] = element['width'] if element['width']
-
           metadata[:height] = element['height'] if element['height']
 
           metadata

--- a/spec/core_model/definition_item_spec.rb
+++ b/spec/core_model/definition_item_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Coradoc::CoreModel::DefinitionItem do
+  describe '.new' do
+    it 'creates a definition item with term and definitions' do
+      item = described_class.new(
+        term: 'API',
+        definitions: ['Application Programming Interface']
+      )
+
+      expect(item.term).to eq('API')
+      expect(item.definitions).to eq(['Application Programming Interface'])
+    end
+
+    it 'creates a definition item with structured term children' do
+      bold = Coradoc::CoreModel::BoldElement.new(content: 'HTML')
+      item = described_class.new(
+        term: 'HTML',
+        definitions: ['HyperText Markup Language'],
+        term_children: [bold],
+        definition_children: ['HyperText Markup Language']
+      )
+
+      expect(item.term_children).to eq([bold])
+      expect(item.definition_children).to eq(['HyperText Markup Language'])
+    end
+
+    it 'defaults term_children and definition_children to empty arrays' do
+      item = described_class.new(term: 'test')
+
+      expect(item.term_children).to eq([])
+      expect(item.definition_children).to eq([])
+    end
+
+    it 'coerces nil children to empty arrays on setter' do
+      item = described_class.new(term: 'test')
+      item.term_children = nil
+      item.definition_children = nil
+
+      expect(item.term_children).to eq([])
+      expect(item.definition_children).to eq([])
+    end
+  end
+
+  describe '#term_renderable' do
+    it 'returns term string when term_children is empty' do
+      item = described_class.new(term: 'API', definitions: ['def'])
+
+      expect(item.term_renderable).to eq('API')
+    end
+
+    it 'returns term string when term_children are all strings' do
+      item = described_class.new(
+        term: 'HTML',
+        definitions: ['def'],
+        term_children: ['HyperText', ' ', 'Markup Language']
+      )
+
+      expect(item.term_renderable).to eq('HTML')
+    end
+
+    it 'returns term_children when they contain InlineElements' do
+      bold = Coradoc::CoreModel::BoldElement.new(content: 'important')
+      item = described_class.new(
+        term: 'important',
+        definitions: ['def'],
+        term_children: [bold]
+      )
+
+      expect(item.term_renderable).to eq([bold])
+    end
+  end
+
+  describe '#definition_renderable' do
+    it 'returns definitions when definition_children is empty' do
+      item = described_class.new(term: 'API', definitions: ['def'])
+
+      expect(item.definition_renderable).to eq(['def'])
+    end
+
+    it 'returns definition_children when they contain InlineElements' do
+      link = Coradoc::CoreModel::LinkElement.new(content: 'click', target: 'https://example.com')
+      item = described_class.new(
+        term: 'link',
+        definitions: ['click here'],
+        definition_children: [link]
+      )
+
+      expect(item.definition_renderable).to eq([link])
+    end
+  end
+
+  describe 'inheritance' do
+    it 'inherits from CoreModel::Base' do
+      expect(described_class.superclass).to eq(Coradoc::CoreModel::Base)
+    end
+  end
+
+  describe '#semantically_equivalent?' do
+    it 'returns true for identical definition items' do
+      item1 = described_class.new(term: 'API', definitions: ['def1'])
+      item2 = described_class.new(term: 'API', definitions: ['def1'])
+
+      expect(item1.semantically_equivalent?(item2)).to be true
+    end
+
+    it 'returns false for different terms' do
+      item1 = described_class.new(term: 'API', definitions: ['def1'])
+      item2 = described_class.new(term: 'REST', definitions: ['def1'])
+
+      expect(item1.semantically_equivalent?(item2)).to be false
+    end
+
+    it 'compares term_children and definition_children' do
+      bold = Coradoc::CoreModel::BoldElement.new(content: 'API')
+      item1 = described_class.new(term: 'API', definitions: ['def'], term_children: [bold])
+      item2 = described_class.new(term: 'API', definitions: ['def'])
+
+      expect(item1.semantically_equivalent?(item2)).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 4 of the model-driven architecture cleanup. Addresses BUGREPORT.model-driven/ bugs 12-15.

## Changes

### Bug 13: Replace `send` with `public_send` in AsciiDoc parser
- `coradoc-adoc/lib/coradoc/asciidoc/parser/base.rb`: 3 `send` calls → `public_send`

### Bug 14: DOCX class-based dispatch
- `coradoc-docx/lib/coradoc/docx/transform/from_core_model.rb`: Replace `case element.element_type` string matching with `when CoreModel::DocumentElement` class dispatch
- Spec updated to use typed subclasses and `block_semantic_type`

### Bug 12: Convert 23 RAW HTML converters to NodeBuilder
- All 23 converter files in `coradoc-html/lib/coradoc/html/converters/` now use `NodeBuilder.build(tag, content, **attrs)` instead of raw string interpolation
- HTML comments use `Nokogiri::XML::Comment`
- Net -648 lines of code (less string manipulation boilerplate)

### Bug 15: CoreModel specs
- New `spec/core_model/definition_item_spec.rb` (13 examples)
- All 14 previously missing classes now have spec coverage (13 via `typed_blocks_spec.rb`, 1 new dedicated file)

### Other
- CLAUDE.md: Added NO VERSION RELEASES convention
- 4 new BUGREPORT files with FIXED status

## Test Results
- Core: 850 passing, 0 failures
- ADOC: 640 passing, 1 pre-existing (VERSION mismatch from GHA)
- HTML: 222 passing, 0 failures, 1 pending
- Markdown: 504 passing, 0 failures
- DOCX: 103 passing, 16 pre-existing failures (reduced from 18)