### PR TITLE
fix: make word-to-markdown optional to fix Windows Ruby 4.0 load failure

### DIFF
--- a/lib/coradoc/input/docx.rb
+++ b/lib/coradoc/input/docx.rb
@@ -1,10 +1,30 @@
-require "word-to-markdown"
 require "coradoc/input/html"
 require "fileutils"
 
 module Coradoc
   module Input
     module Docx
+      WORD_TO_MARKDOWN_MISSING_MSG =
+        "DOCX input requires the 'word-to-markdown' gem, " \
+        "which is unavailable on this platform. " \
+        "See https://github.com/metanorma/coradoc/issues/192".freeze
+
+      def self.windows_ruby4?
+        Gem.win_platform? &&
+          Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("4.0")
+      end
+
+      WORD_TO_MARKDOWN_AVAILABLE = if windows_ruby4?
+                                     false
+                                   else
+                                     begin
+                                       require "word-to-markdown"
+                                       true
+                                     rescue LoadError
+                                       false
+                                     end
+                                   end
+
       def self.processor_id
         :docx
       end
@@ -13,7 +33,14 @@ module Coradoc
         %w[.docx .doc].any? { |i| filename.downcase.end_with?(i) }
       end
 
+      def self.assert_word_to_markdown!
+        return if WORD_TO_MARKDOWN_AVAILABLE
+
+        raise LoadError, WORD_TO_MARKDOWN_MISSING_MSG
+      end
+
       def self.processor_execute(input, options = {})
+        assert_word_to_markdown!
         image_dir = Dir.mktmpdir
         options = options.merge(sourcedir: image_dir)
         doc = WordToMarkdown.new(input, image_dir)

--- a/lib/coradoc/version.rb
+++ b/lib/coradoc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coradoc
-  VERSION = "1.1.7"
+  VERSION = "1.1.8"
 end

--- a/spec/coradoc/input/html/lib/reverse_adoc_spec.rb
+++ b/spec/coradoc/input/html/lib/reverse_adoc_spec.rb
@@ -61,10 +61,10 @@ describe Coradoc::Input::Html do
         end.from([]).to(result))
     end
   end
-
   # TODO: fix github actions integration with libreoffice, currently it hangs
   # when trying to use soffice binary
-  unless Gem::Platform.local.os == "darwin" && !ENV["GITHUB_ACTION"].nil?
+  macos_ci = Gem::Platform.local.os == "darwin" && !ENV["GITHUB_ACTION"].nil?
+  unless !defined?(WordToMarkdown) || Gem.win_platform? || macos_ci
     context "when docx file input" do
       subject(:convert) do
         Coradoc::Input::Html.convert(
@@ -73,7 +73,9 @@ describe Coradoc::Input::Html do
         )
       end
       let(:input) do
-        WordToMarkdown.new("spec/coradoc/input/html/assets/external_images.docx",
+        docx_path = "spec/coradoc/input/html/assets/" \
+                    "external_images.docx"
+        WordToMarkdown.new(docx_path,
                            Coradoc::Input::Html.config.sourcedir)
       end
       it_behaves_like "converting source with external images included",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ end
 # Input::HTML:
 require "coradoc/input/html"
 require "coradoc/input/html/html_converter"
-require "word-to-markdown"
+begin; require "word-to-markdown"; rescue LoadError; nil; end
 
 Dir[File.join("spec", "**", "support", "**", "*.rb")]
   .each { |f| require File.join(".", f) }


### PR DESCRIPTION
Closes #192

On Windows with Ruby 4.0, `win32ole` was extracted from the stdlib. The `word-to-markdown` dependency chain (`word-to-markdown` → `sys-proctable` → `win32ole`) causes coradoc to fail at load time, even for users who don't use DOCX input.

**Changes:**
- Wrap `require "word-to-markdown"` in `begin/rescue LoadError` so coradoc loads successfully on all platforms
- Raise a clear error message when DOCX input is actually used but the dependency is unavailable
- Bump version to 1.1.8