### PR TITLE
fix: convert endless methods to multi-line form for RDoc compatibility (fixes #195)

### DIFF
--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -122,7 +122,12 @@ jobs:
         if git diff --quiet; then
           echo "No version changes to commit"
         else
-          git add '**/version.rb'
+          git add \
+            coradoc/lib/coradoc/version.rb \
+            coradoc-adoc/lib/coradoc/asciidoc/version.rb \
+            coradoc-docx/lib/coradoc/docx/version.rb \
+            coradoc-html/lib/coradoc/html/version.rb \
+            coradoc-markdown/lib/coradoc/markdown/version.rb
           git commit -m "chore: bump gem versions for release"
           git push origin main
         fi

--- a/coradoc/lib/coradoc/core_model/comment_block.rb
+++ b/coradoc/lib/coradoc/core_model/comment_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Comment block — editorial or hidden comments
     class CommentBlock < Block
-      def self.semantic_type = :comment
+      def self.semantic_type
+        :comment
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/example_block.rb
+++ b/coradoc/lib/coradoc/core_model/example_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Example block — a delimited block for examples
     class ExampleBlock < Block
-      def self.semantic_type = :example
+      def self.semantic_type
+        :example
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/horizontal_rule_block.rb
+++ b/coradoc/lib/coradoc/core_model/horizontal_rule_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Horizontal rule — a thematic break between sections
     class HorizontalRuleBlock < Block
-      def self.semantic_type = :horizontal_rule
+      def self.semantic_type
+        :horizontal_rule
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/inline_element.rb
+++ b/coradoc/lib/coradoc/core_model/inline_element.rb
@@ -12,14 +12,12 @@ module Coradoc
 
       include ChildrenContent
 
-      class << self
-        def format_type
-          nil
-        end
+      def self.format_type
+        nil
+      end
 
-        def format_type_class(type)
-          FORMAT_TYPE_CLASS_MAP[type] || InlineElement
-        end
+      def self.format_type_class(type)
+        FORMAT_TYPE_CLASS_MAP[type] || InlineElement
       end
 
       def resolve_format_type
@@ -50,71 +48,105 @@ module Coradoc
     # Typed InlineElement subclasses
 
     class BoldElement < InlineElement
-      def self.format_type = 'bold'
+      def self.format_type
+        'bold'
+      end
     end
 
     class ItalicElement < InlineElement
-      def self.format_type = 'italic'
+      def self.format_type
+        'italic'
+      end
     end
 
     class MonospaceElement < InlineElement
-      def self.format_type = 'monospace'
+      def self.format_type
+        'monospace'
+      end
     end
 
     class UnderlineElement < InlineElement
-      def self.format_type = 'underline'
+      def self.format_type
+        'underline'
+      end
     end
 
     class StrikethroughElement < InlineElement
-      def self.format_type = 'strikethrough'
+      def self.format_type
+        'strikethrough'
+      end
     end
 
     class SubscriptElement < InlineElement
-      def self.format_type = 'subscript'
+      def self.format_type
+        'subscript'
+      end
     end
 
     class SuperscriptElement < InlineElement
-      def self.format_type = 'superscript'
+      def self.format_type
+        'superscript'
+      end
     end
 
     class HighlightElement < InlineElement
-      def self.format_type = 'highlight'
+      def self.format_type
+        'highlight'
+      end
     end
 
     class LinkElement < InlineElement
-      def self.format_type = 'link'
+      def self.format_type
+        'link'
+      end
     end
 
     class CrossReferenceElement < InlineElement
-      def self.format_type = 'xref'
+      def self.format_type
+        'xref'
+      end
     end
 
     class StemElement < InlineElement
-      def self.format_type = 'stem'
+      def self.format_type
+        'stem'
+      end
     end
 
     class FootnoteElement < InlineElement
-      def self.format_type = 'footnote'
+      def self.format_type
+        'footnote'
+      end
     end
 
     class HardLineBreakElement < InlineElement
-      def self.format_type = 'hard_line_break'
+      def self.format_type
+        'hard_line_break'
+      end
     end
 
     class TextElement < InlineElement
-      def self.format_type = 'text'
+      def self.format_type
+        'text'
+      end
     end
 
     class SpanElement < InlineElement
-      def self.format_type = 'span'
+      def self.format_type
+        'span'
+      end
     end
 
     class TermElement < InlineElement
-      def self.format_type = 'term'
+      def self.format_type
+        'term'
+      end
     end
 
     class LineBreakElement < InlineElement
-      def self.format_type = 'line_break'
+      def self.format_type
+        'line_break'
+      end
     end
 
     FORMAT_TYPE_CLASS_MAP = {

--- a/coradoc/lib/coradoc/core_model/listing_block.rb
+++ b/coradoc/lib/coradoc/core_model/listing_block.rb
@@ -2,12 +2,14 @@
 
 module Coradoc
   module CoreModel
-    # Listing block — a delimited block for listing/content without source language
+    # Listing block -- a delimited block for listing/content without source language
     #
     # Distinct from SourceBlock: a listing has no language annotation.
     # When a language is present, SourceBlock should be used instead.
     class ListingBlock < Block
-      def self.semantic_type = :listing
+      def self.semantic_type
+        :listing
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/literal_block.rb
+++ b/coradoc/lib/coradoc/core_model/literal_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Literal block — a delimited block for preformatted literal text
     class LiteralBlock < Block
-      def self.semantic_type = :literal
+      def self.semantic_type
+        :literal
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/open_block.rb
+++ b/coradoc/lib/coradoc/core_model/open_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Open block — a generic container block with no special rendering
     class OpenBlock < Block
-      def self.semantic_type = :open
+      def self.semantic_type
+        :open
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/paragraph_block.rb
+++ b/coradoc/lib/coradoc/core_model/paragraph_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Paragraph block — a block of prose text
     class ParagraphBlock < Block
-      def self.semantic_type = :paragraph
+      def self.semantic_type
+        :paragraph
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/pass_block.rb
+++ b/coradoc/lib/coradoc/core_model/pass_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Pass-through block — raw content passed through without processing
     class PassBlock < Block
-      def self.semantic_type = :pass
+      def self.semantic_type
+        :pass
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/quote_block.rb
+++ b/coradoc/lib/coradoc/core_model/quote_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Quote block — a delimited block for quotations
     class QuoteBlock < Block
-      def self.semantic_type = :quote
+      def self.semantic_type
+        :quote
+      end
 
       attribute :attribution, :string
     end

--- a/coradoc/lib/coradoc/core_model/reviewer_block.rb
+++ b/coradoc/lib/coradoc/core_model/reviewer_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Reviewer comment block — a block for reviewer annotations
     class ReviewerBlock < AnnotationBlock
-      def self.semantic_type = :reviewer
+      def self.semantic_type
+        :reviewer
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/sidebar_block.rb
+++ b/coradoc/lib/coradoc/core_model/sidebar_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Sidebar block — a delimited block for sidebars
     class SidebarBlock < Block
-      def self.semantic_type = :sidebar
+      def self.semantic_type
+        :sidebar
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/source_block.rb
+++ b/coradoc/lib/coradoc/core_model/source_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Specialized block for source code listings
     class SourceBlock < Block
-      def self.semantic_type = :source_code
+      def self.semantic_type
+        :source_code
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/structural_element.rb
+++ b/coradoc/lib/coradoc/core_model/structural_element.rb
@@ -31,10 +31,21 @@ module Coradoc
         level || 1
       end
 
-      def section? = false
-      def document? = false
-      def preamble? = false
-      def header? = false
+      def section?
+        false
+      end
+
+      def document?
+        false
+      end
+
+      def preamble?
+        false
+      end
+
+      def header?
+        false
+      end
 
       # Derived element_type string for backward compatibility with
       # templates and legacy consumers. Subclasses override this.
@@ -42,10 +53,8 @@ module Coradoc
         self.class.element_type_name
       end
 
-      class << self
-        def element_type_name
-          nil
-        end
+      def self.element_type_name
+        nil
       end
 
       private
@@ -57,37 +66,45 @@ module Coradoc
 
     # Root document element
     class DocumentElement < StructuralElement
-      def document? = true
+      def document?
+        true
+      end
 
-      class << self
-        def element_type_name = 'document'
+      def self.element_type_name
+        'document'
       end
     end
 
     # Section with a heading at a specific level
     class SectionElement < StructuralElement
-      def section? = true
+      def section?
+        true
+      end
 
-      class << self
-        def element_type_name = 'section'
+      def self.element_type_name
+        'section'
       end
     end
 
     # Preamble content before the first section heading
     class PreambleElement < StructuralElement
-      def preamble? = true
+      def preamble?
+        true
+      end
 
-      class << self
-        def element_type_name = 'preamble'
+      def self.element_type_name
+        'preamble'
       end
     end
 
     # Header / title block of a document
     class HeaderElement < StructuralElement
-      def header? = true
+      def header?
+        true
+      end
 
-      class << self
-        def element_type_name = 'header'
+      def self.element_type_name
+        'header'
       end
     end
   end

--- a/coradoc/lib/coradoc/core_model/verse_block.rb
+++ b/coradoc/lib/coradoc/core_model/verse_block.rb
@@ -4,7 +4,9 @@ module Coradoc
   module CoreModel
     # Verse block — a block for verse/poetry with optional attribution
     class VerseBlock < Block
-      def self.semantic_type = :verse
+      def self.semantic_type
+        :verse
+      end
 
       attribute :attribution, :string
     end


### PR DESCRIPTION
## Summary

Fixes #195 — gem installation failure on Windows caused by RDoc generating deeply nested documentation paths that exceed MAX_PATH (260 characters).

### Root Cause

Ruby's endless method syntax (`def self.name = expr`) causes RDoc's parser to not properly close class scope. Subsequent class declarations appear nested inside the previous class, creating paths like:

```
Coradoc/CoreModel/BoldElement/ItalicElement/MonospaceElement/.../LineBreakElement/
```

These deeply nested paths exceed Windows MAX_PATH, preventing `gem install` on Windows.

### Changes

1. **Convert all endless methods to multi-line form** across 16 CoreModel files:
   - `InlineElement` — 17 `format_type` class methods + 2 utility class methods
   - `StructuralElement` — 4 predicate methods + 4 `element_type_name` class methods
   - 13 Block subclasses — `semantic_type` class methods

2. **Fix `release-all.yml`** — scope `git add` to specific gem version files instead of `**/version.rb` glob that accidentally matched `vendor/` gem files.

### Verification

- RDoc now generates flat `Coradoc/CoreModel/` directory structure (no nesting)
- All specs pass: coradoc (850), coradoc-adoc (640), coradoc-html (222), coradoc-markdown (502)