### PR TITLE
fix: add missing format gem requires in compare-baseline CI step

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -119,6 +119,9 @@ jobs:
             echo "Comparing with baseline..."
             bundle exec ruby -e "
               require 'coradoc'
+              require 'coradoc/asciidoc'
+              require 'coradoc/html'
+              require 'coradoc/markdown'
               require 'coradoc/performance_regression'
 
               results = Coradoc::PerformanceRegression.compare_with_baseline('baseline/results.json', iterations: 3)


### PR DESCRIPTION
Fixes the compare-baseline CI job failure: undefined method parse for module Coradoc::Markdown.

The compare-baseline job only required coradoc and coradoc/performance_regression, but the performance regression module calls Coradoc::Markdown.parse and Coradoc::Html.serialize_static. The format spoke gems were not loaded.

Added missing require statements to match the benchmark job imports.