### PR TITLE
refactor: remove deep_dup from AsciidocMapping (inherits from lutaml-model)

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/model/serialization/asciidoc_mapping.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/serialization/asciidoc_mapping.rb
@@ -31,12 +31,6 @@ module Coradoc
             )
           end
 
-          def deep_dup
-            duped = self.class.new
-            duped.mappings = Lutaml::Model::Utils.deep_dup(@mappings)
-            duped
-          end
-
           private
 
           def add_mapping(name, to, **options)


### PR DESCRIPTION
## Summary

Removes the  method from  now that [lutaml-model#701](https://github.com/lutaml/lutaml-model/pull/701) has merged.

### Why

lutaml-model PR #701 adds , , and  to the  base class.  only has  state (no extra instance variables), so the inherited  handles everything correctly.

### Testing
- coradoc-adoc: 648 specs, 0 failures
- coradoc core: 860 specs, 0 failures