### PR TITLE
feat: add coradoc-mirror gem for ProseMirror-compatible JSON/YAML rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'coradoc-adoc', path: './coradoc-adoc'
 gem 'coradoc-docx', path: './coradoc-docx'
 gem 'coradoc-html', path: './coradoc-html'
 gem 'coradoc-markdown', path: './coradoc-markdown'
+gem 'coradoc-mirror', path: './coradoc-mirror'
 
 gem 'lutaml-model', github: 'lutaml/lutaml-model', branch: 'main'
 gem 'lutaml-xsd'

--- a/coradoc-mirror/Rakefile
+++ b/coradoc-mirror/Rakefile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/coradoc-mirror/coradoc-mirror.gemspec
+++ b/coradoc-mirror/coradoc-mirror.gemspec
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "lib/coradoc/mirror/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "coradoc-mirror"
+  spec.version = Coradoc::Mirror::VERSION
+  spec.authors = ["Ribose Inc."]
+  spec.email = ["open.source@ribose.com"]
+
+  spec.summary = "ProseMirror-compatible JSON document model for Coradoc"
+  spec.description = "Transforms Coradoc CoreModel documents into ProseMirror-compatible " \
+                     "JSON/YAML suitable for rich frontend rendering with Vue.js, React, " \
+                     "or any ProseMirror-based editor."
+  spec.homepage = "https://github.com/metanorma/coradoc"
+  spec.license = "MIT"
+
+  spec.required_ruby_version = ">= 3.3.0"
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/metanorma/coradoc"
+  spec.metadata["changelog_uri"] = "https://github.com/metanorma/coradoc/releases"
+
+  spec.files = Dir.chdir(__dir__) do
+    Dir["lib/**/*.rb"]
+  end
+
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "coradoc", "~> 2.0"
+
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "simplecov"
+  spec.metadata["rubygems_mfa_required"] = "true"
+end

--- a/coradoc-mirror/lib/coradoc-mirror.rb
+++ b/coradoc-mirror/lib/coradoc-mirror.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "coradoc"
+require "coradoc/mirror"
+
+# Side-effect: registers output processors with Coradoc::Output pipeline.
+# Side-effect: registers format modules with Coradoc registry.
+# These must use require (not autoload) because they have load-time side effects.
+require "coradoc/mirror/output"
+require "coradoc/mirror/mirror_json_format"
+require "coradoc/mirror/mirror_yaml_format"
+
+# Ensure Coradoc error classes are loaded (autoloaded via Coradoc::Error).
+Coradoc::Error

--- a/coradoc-mirror/lib/coradoc/mirror.rb
+++ b/coradoc-mirror/lib/coradoc/mirror.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Coradoc
+  module Mirror
+    class Error < StandardError; end
+
+    autoload :VERSION, "#{__dir__}/mirror/version"
+    autoload :Node, "#{__dir__}/mirror/node"
+    autoload :Mark, "#{__dir__}/mirror/mark"
+    autoload :Transformer, "#{__dir__}/mirror/transformer"
+    autoload :CoreModelToMirror, "#{__dir__}/mirror/core_model_to_mirror"
+    autoload :MirrorToCoreModel, "#{__dir__}/mirror/mirror_to_core_model"
+    autoload :HandlerRegistry, "#{__dir__}/mirror/handler_registry"
+    autoload :Handlers, "#{__dir__}/mirror/handlers"
+    # MirrorJsonFormat and MirrorYamlFormat are loaded via require in
+    # coradoc-mirror.rb (side-effect: register_format calls).
+
+    # Build the default handler registry with all built-in handlers.
+    #
+    # Third-party code can add handlers to extend the registry without
+    # modifying this method (OCP). Each handler maps a CoreModel class
+    # to a handler module/class that produces Mirror nodes.
+    #
+    # @return [HandlerRegistry]
+    def self.default_registry
+      registry = HandlerRegistry.new
+
+      # ── Structural ──
+      registry.register(CoreModel::DocumentElement, Handlers::Structural,
+                        method_name: :document)
+      registry.register(CoreModel::SectionElement, Handlers::Structural,
+                        method_name: :section)
+      registry.register(CoreModel::PreambleElement, Handlers::Structural,
+                        method_name: :preamble)
+      registry.register(CoreModel::HeaderElement, Handlers::Structural,
+                        method_name: :header)
+
+      # ── Paragraphs ──
+      registry.register(CoreModel::ParagraphBlock, Handlers::Paragraph)
+
+      # ── Code / Preformatted ──
+      registry.register(CoreModel::SourceBlock, Handlers::CodeBlock,
+                        method_name: :source)
+      registry.register(CoreModel::ListingBlock, Handlers::CodeBlock,
+                        method_name: :listing)
+      registry.register(CoreModel::LiteralBlock, Handlers::CodeBlock,
+                        method_name: :literal)
+      registry.register(CoreModel::PassBlock, Handlers::CodeBlock,
+                        method_name: :pass)
+
+      # ── Blocks ──
+      registry.register(CoreModel::QuoteBlock, Handlers::Blockquote)
+      registry.register(CoreModel::ExampleBlock, Handlers::Example)
+      registry.register(CoreModel::SidebarBlock, Handlers::Sidebar)
+      registry.register(CoreModel::OpenBlock, Handlers::OpenBlock)
+      registry.register(CoreModel::VerseBlock, Handlers::Verse)
+      registry.register(CoreModel::CommentBlock, Handlers::Comment)
+      registry.register(CoreModel::HorizontalRuleBlock, Handlers::HorizontalRule)
+      registry.register(CoreModel::ReviewerBlock, Handlers::Reviewer)
+
+      # ── Annotations / Admonitions ──
+      registry.register(CoreModel::AnnotationBlock, Handlers::Admonition)
+
+      # ── Lists ──
+      registry.register(CoreModel::ListBlock, Handlers::List)
+      registry.register(CoreModel::DefinitionList, Handlers::DefinitionList)
+
+      # ── Tables ──
+      registry.register(CoreModel::Table, Handlers::Table)
+
+      # ── Images ──
+      registry.register(CoreModel::Image, Handlers::Image)
+
+      # ── Inline ──
+      registry.register(CoreModel::InlineElement, Handlers::Inline)
+      registry.register(CoreModel::TextContent, Handlers::Inline,
+                        method_name: :text_content)
+
+      # ── Bibliography ──
+      registry.register(CoreModel::Bibliography, Handlers::Bibliography)
+
+      # ── Footnotes ──
+      registry.register(CoreModel::Footnote, Handlers::Footnote)
+      registry.register(CoreModel::FootnoteReference, Handlers::Footnote,
+                        method_name: :reference)
+
+      # ── TOC ──
+      registry.register(CoreModel::Toc, Handlers::Toc)
+
+      # ── Generic Block (catch-all for unrecognized block types) ──
+      registry.register(CoreModel::Block, Handlers::GenericBlock)
+
+      registry
+    end
+
+    # Convenience: transform a CoreModel document to Mirror JSON in one call.
+    #
+    # @param document [CoreModel::Base] CoreModel document
+    # @param registry [HandlerRegistry] handler registry (defaults to built-in)
+    # @return [Node::Document] mirror document root
+    def self.transform(document, registry: default_registry)
+      CoreModelToMirror.new(registry: registry).call(document)
+    end
+
+    # Convenience: transform and serialize to JSON string.
+    #
+    # @param document [CoreModel::Base] CoreModel document
+    # @param pretty [Boolean] pretty-print JSON (default: false)
+    # @param registry [HandlerRegistry] handler registry
+    # @return [String] JSON string
+    def self.to_json(document, pretty: false, registry: default_registry)
+      node = transform(document, registry: registry)
+      node.to_json(pretty: pretty)
+    end
+
+    # Convenience: transform and serialize to YAML string.
+    #
+    # @param document [CoreModel::Base] CoreModel document
+    # @param registry [HandlerRegistry] handler registry
+    # @return [String] YAML string
+    def self.to_yaml(document, registry: default_registry)
+      node = transform(document, registry: registry)
+      node.to_yaml
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/core_model_to_mirror.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/core_model_to_mirror.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    class CoreModelToMirror
+      attr_reader :registry
+
+      def initialize(registry: Coradoc::Mirror.default_registry)
+        @registry = registry
+        @footnote_counter = 0
+        @footnotes = []
+      end
+
+      def call(document)
+        @footnote_counter = 0
+        @footnotes = []
+
+        content = extract_content(document)
+        fn_block = flush_footnotes
+        content << fn_block if fn_block
+
+        attrs = build_document_attrs(document)
+        Node::Document.new(
+          title: attrs[:title],
+          id: attrs[:id],
+          content: content,
+        )
+      end
+
+      def extract_content(element)
+        children = element_children(element)
+
+        if children && !children.empty?
+          content = []
+          children.each do |child|
+            handle_element(child, content)
+          end
+          content.compact
+        elsif element_has_text_content?(element)
+          process_inline_content(element)
+        else
+          []
+        end
+      end
+
+      def process_inline_content(element)
+        Handlers::Inline.process(element, context: self)
+      end
+
+      def text_node(text, marks: [])
+        Node::Text.new(text: text, marks: marks)
+      end
+
+      def register_footnote(footnote)
+        @footnote_counter += 1
+        num = @footnote_counter
+        fn_id = footnote.id || "fn-#{num}"
+        ref_id = "fn-ref-#{num}"
+
+        fn_content = if footnote.content
+                       [text_node(footnote.content)]
+                     else
+                       []
+                     end
+
+        @footnotes << {
+          id: fn_id,
+          ref_id: ref_id,
+          number: num,
+          content: fn_content,
+        }
+
+        Node::FootnoteMarker.new(id: fn_id, ref_id: ref_id, number: num)
+      end
+
+      def resolve_footnote_reference(ref)
+        target_id = ref.id
+        fn_entry = @footnotes.find { |fn| fn[:id] == target_id } if target_id
+
+        if fn_entry
+          Node::FootnoteMarker.new(
+            id: fn_entry[:id],
+            ref_id: "fn-ref-#{fn_entry[:number]}-dup-#{@footnote_counter}",
+            number: fn_entry[:number],
+          )
+        else
+          text_node("[#{target_id || "footnote"}]")
+        end
+      end
+
+      def flush_footnotes
+        return nil if @footnotes.empty?
+
+        entries = @footnotes.map do |fn|
+          Node::FootnoteEntry.new(
+            id: fn[:id],
+            ref_id: fn[:ref_id],
+            number: fn[:number],
+            content: fn[:content],
+          )
+        end
+
+        @footnotes = []
+        Node::Footnotes.new(content: entries)
+      end
+
+      private
+
+      def element_has_text_content?(element)
+        element.is_a?(CoreModel::Block) &&
+          element.content &&
+          !element.content.to_s.empty?
+      end
+
+      def element_children(element)
+        if element.is_a?(CoreModel::StructuralElement) ||
+           element.is_a?(CoreModel::InlineElement) ||
+           element.is_a?(CoreModel::TableCell)
+          children = element.children
+          return children if children && !children.empty?
+        elsif element.is_a?(CoreModel::Block)
+          children = element.children
+          return children if children && !children.empty?
+        end
+
+        if element.is_a?(CoreModel::ListBlock)
+          element.items
+        elsif element.is_a?(CoreModel::DefinitionList)
+          element.items
+        elsif element.is_a?(CoreModel::Table)
+          element.rows
+        elsif element.is_a?(CoreModel::Bibliography)
+          element.entries
+        else
+          nil
+        end
+      end
+
+      def handle_element(element, content)
+        result = @registry.handle(element, context: self)
+        return unless result
+
+        value, concat = result
+        return unless value
+
+        if concat
+          content.concat(Array(value))
+        else
+          content << value
+        end
+      end
+
+      def build_document_attrs(document)
+        attrs = {}
+        attrs[:title] = document.title if document.title
+        attrs[:id] = document.id if document.id
+
+        if document.is_a?(CoreModel::DocumentElement) &&
+           document.attributes &&
+           document.attributes.is_a?(CoreModel::Metadata)
+          document.attributes.to_h.each do |key, value|
+            attrs[key.to_sym] = value
+          end
+        end
+
+        attrs
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handler_registry.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handler_registry.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    # Open registry mapping CoreModel classes to handler modules.
+    #
+    # Replaces closed case/when dispatch with an extensible registry.
+    # Third-party gems can register additional handlers without modifying
+    # core classes (OCP).
+    #
+    # @example Registering a handler
+    #   registry = Coradoc::Mirror.default_registry
+    #   registry.register(MyCustomBlock, MyHandler)
+    #
+    # @example Creating a custom registry
+    #   registry = Coradoc::Mirror::HandlerRegistry.new
+    #   registry.register(Coradoc::CoreModel::ParagraphBlock, MyParagraphHandler)
+    #
+    class HandlerRegistry
+      # Structured entry for a registered handler.
+      Entry = Struct.new(:handler, :method_name, :concat, :extra_kwargs,
+                         keyword_init: true)
+
+      def initialize
+        @handlers = {}
+      end
+
+      # Register a handler for a CoreModel class.
+      #
+      # @param model_class [Class] CoreModel class to handle
+      # @param handler [Module, Class, Proc] handler implementation.
+      #   If a Module/Class, +method_name+ is called on it.
+      #   If a Proc, called directly with (element, context:).
+      # @param method_name [Symbol] method to call on handler (default: :call)
+      # @param concat [Boolean] if true, handler result is an array to
+      #   concat into content rather than a single item to append
+      # @param extra_kwargs [Hash] additional keyword arguments passed
+      #   to the handler
+      def register(model_class, handler, method_name: :call, concat: false,
+                   extra_kwargs: {})
+        @handlers[model_class] = Entry.new(
+          handler: handler,
+          method_name: method_name,
+          concat: concat,
+          extra_kwargs: extra_kwargs,
+        )
+      end
+
+      # Find the handler entry for a given CoreModel element.
+      #
+      # Walks the element's class ancestors to find the most specific
+      # registered handler. This allows registering a handler for a
+      # base class (e.g., Block) that applies to all subclasses,
+      # while also registering specific handlers for subclasses.
+      #
+      # @param element [CoreModel::Base] element to find handler for
+      # @return [Entry, nil]
+      def entry_for(element)
+        # Exact class match first
+        entry = @handlers[element.class]
+        return entry if entry
+
+        # Walk ancestors for inherited handler (most specific first)
+        element.class.ancestors.each do |ancestor|
+          next if ancestor == element.class
+          break if ancestor == Object || ancestor == BasicObject
+
+          entry = @handlers[ancestor]
+          return entry if entry
+        end
+
+        nil
+      end
+
+      # Check if a handler is registered for a CoreModel class.
+      #
+      # @param model_class [Class]
+      # @return [Boolean]
+      def registered?(model_class)
+        @handlers.key?(model_class)
+      end
+
+      # Invoke the handler for a given element.
+      #
+      # @param element [CoreModel::Base] element to handle
+      # @param context [CoreModelToMirror] transformer context
+      # @return [Array(result, concat_flag), nil] handler result or nil
+      def handle(element, context:)
+        entry = entry_for(element)
+        return nil unless entry
+
+        kwargs = { context: context }.merge(entry.extra_kwargs || {})
+
+        result = case entry.handler
+                 when Proc
+                   entry.handler.call(element, context)
+                 else
+                   entry.handler.public_send(entry.method_name, element, **kwargs)
+                 end
+
+        [result, entry.concat]
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    # Handler modules for transforming CoreModel types to Mirror nodes.
+    #
+    # Each handler is a module/class that responds to +call(element, context:)+,
+    # where +element+ is a CoreModel instance and +context+ is the
+    # CoreModelToMirror transformer providing shared helpers.
+    #
+    # New handlers are added by creating a new module file and registering
+    # it in +Coradoc::Mirror.default_registry+ — no existing code changes (OCP).
+    module Handlers
+      autoload :Structural, "#{__dir__}/handlers/structural"
+      autoload :Paragraph, "#{__dir__}/handlers/paragraph"
+      autoload :CodeBlock, "#{__dir__}/handlers/code_block"
+      autoload :Blockquote, "#{__dir__}/handlers/blockquote"
+      autoload :Example, "#{__dir__}/handlers/example"
+      autoload :Sidebar, "#{__dir__}/handlers/sidebar"
+      autoload :OpenBlock, "#{__dir__}/handlers/open_block"
+      autoload :Verse, "#{__dir__}/handlers/verse"
+      autoload :Comment, "#{__dir__}/handlers/comment"
+      autoload :HorizontalRule, "#{__dir__}/handlers/horizontal_rule"
+      autoload :Reviewer, "#{__dir__}/handlers/reviewer"
+      autoload :Admonition, "#{__dir__}/handlers/admonition"
+      autoload :List, "#{__dir__}/handlers/list"
+      autoload :DefinitionList, "#{__dir__}/handlers/definition_list"
+      autoload :Table, "#{__dir__}/handlers/table"
+      autoload :Image, "#{__dir__}/handlers/image"
+      autoload :Inline, "#{__dir__}/handlers/inline"
+      autoload :Bibliography, "#{__dir__}/handlers/bibliography"
+      autoload :Footnote, "#{__dir__}/handlers/footnote"
+      autoload :Toc, "#{__dir__}/handlers/toc"
+      autoload :GenericBlock, "#{__dir__}/handlers/generic_block"
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/admonition.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/admonition.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Admonition
+        def self.call(element, context:)
+          content = context.extract_content(element)
+          return nil if content.empty?
+
+          Node::Admonition.new(
+            id: element.id,
+            admonition_type: element.annotation_type,
+            title: element.title,
+            label: element.annotation_label,
+            content: content,
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/bibliography.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/bibliography.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Bibliography
+        def self.call(element, context:)
+          entries = Array(element.entries).filter_map do |entry|
+            build_entry(entry, context)
+          end
+          return nil if entries.empty?
+
+          Node::Bibliography.new(
+            id: element.id,
+            title: element.title,
+            level: element.level,
+            content: entries,
+          )
+        end
+
+        class << self
+          private
+
+          def build_entry(entry, context)
+            text = entry.display_text
+            return nil if text.nil? || text.empty?
+
+            Node::BibliographyEntry.new(
+              anchor_name: entry.anchor_name,
+              document_id: entry.document_id,
+              url: entry.url,
+              content: [context.text_node(text)],
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/blockquote.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/blockquote.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Blockquote
+        def self.call(element, context:)
+          content = context.extract_content(element)
+          return nil if content.empty?
+
+          Node::Blockquote.new(
+            attribution: element.attribution,
+            content: content,
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/code_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/code_block.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module CodeBlock
+        def self.source(element, context:)
+          build_code_block(element, context)
+        end
+
+        def self.listing(element, context:)
+          build_code_block(element, context)
+        end
+
+        def self.literal(element, context:)
+          build_code_block(element, context)
+        end
+
+        def self.pass(element, context:)
+          build_code_block(element, context, passthrough: true)
+        end
+
+        class << self
+          private
+
+          def build_code_block(element, context, passthrough: false)
+            text = extract_text(element)
+            Node::CodeBlock.new(
+              id: element.id,
+              title: element.title,
+              language: element.language,
+              passthrough: passthrough || nil,
+              content: [context.text_node(text)],
+            )
+          end
+
+          def extract_text(element)
+            if element.is_a?(CoreModel::Block) && element.content && !element.content.to_s.empty?
+              element.flat_text || element.content.to_s
+            elsif element.is_a?(CoreModel::Block) && element.lines && !element.lines.empty?
+              Array(element.lines).join("\n")
+            else
+              ""
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/comment.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/comment.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      # Handles CommentBlock → omitted (comments are not rendered).
+      module Comment
+        def self.call(_element, context:)
+          nil
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/definition_list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/definition_list.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module DefinitionList
+        def self.call(element, context:)
+          entries = Array(element.items).flat_map do |item|
+            definition_entry(item, context)
+          end
+          return nil if entries.empty?
+
+          Node::DefinitionList.new(id: element.id, content: entries)
+        end
+
+        class << self
+          private
+
+          def definition_entry(item, context)
+            term_node = build_term(item, context)
+            desc_node = build_description(item, context)
+            return nil unless term_node || desc_node
+
+            [term_node, desc_node].compact
+          end
+
+          def build_term(item, context)
+            term_text = item.term
+            return nil unless term_text && !term_text.to_s.empty?
+
+            term_children = item.term_children if item.is_a?(CoreModel::DefinitionItem)
+            if term_children && !term_children.empty?
+              inline_nodes = term_children.flat_map do |child|
+                Handlers::Inline.process_child(child, context)
+              end
+              return Node::DefinitionTerm.new(content: inline_nodes) unless inline_nodes.empty?
+            end
+
+            Node::DefinitionTerm.new(content: [context.text_node(term_text.to_s)])
+          end
+
+          def build_description(item, context)
+            definitions = item.definitions
+            return nil unless definitions && !definitions.empty?
+
+            desc_nodes = definitions.map do |defn|
+              context.text_node(defn.to_s)
+            end
+
+            def_children = item.definition_children if item.is_a?(CoreModel::DefinitionItem)
+            if def_children && !def_children.empty?
+              def_children.each do |child|
+                nodes = Handlers::Inline.process_child(child, context)
+                desc_nodes.concat(Array(nodes)) if nodes && !nodes.empty?
+              end
+            end
+
+            return nil if desc_nodes.empty?
+
+            Node::DefinitionDescription.new(content: desc_nodes)
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/example.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/example.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Example
+        def self.call(element, context:)
+          content = context.extract_content(element)
+          return nil if content.empty?
+
+          Node::Example.new(
+            id: element.id,
+            title: element.title,
+            content: content,
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/footnote.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/footnote.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      # Handles Footnote and FootnoteReference.
+      module Footnote
+        def self.call(element, context:)
+          context.register_footnote(element)
+        end
+
+        def self.reference(element, context:)
+          context.resolve_footnote_reference(element)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/generic_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/generic_block.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module GenericBlock
+        def self.call(element, context:)
+          semantic_type = element.resolve_semantic_type
+          content = context.extract_content(element)
+          return nil if content.empty?
+
+          Node::GenericBlock.new(
+            id: element.id,
+            title: element.title,
+            semantic_type: semantic_type&.to_s,
+            content: content,
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/horizontal_rule.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/horizontal_rule.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      # Handles HorizontalRuleBlock → horizontal_rule node.
+      module HorizontalRule
+        def self.call(_element, context:)
+          Node::HorizontalRule.new
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/image.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/image.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Image
+        def self.call(element, context:)
+          Node::Image.new(
+            id: element.id,
+            src: element.src,
+            alt: element.alt,
+            title: element.title,
+            caption: element.caption,
+            width: element.width,
+            height: element.height,
+            inline: element.inline || nil,
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Inline
+        # Classification of inline handlers.
+        SIMPLE_MARK_TYPES = {
+          CoreModel::BoldElement => Mark::Bold,
+          CoreModel::ItalicElement => Mark::Italic,
+          CoreModel::MonospaceElement => Mark::Monospace,
+          CoreModel::UnderlineElement => Mark::Underline,
+          CoreModel::StrikethroughElement => Mark::Strikethrough,
+          CoreModel::SubscriptElement => Mark::Subscript,
+          CoreModel::SuperscriptElement => Mark::Superscript,
+          CoreModel::HighlightElement => Mark::Highlight,
+          CoreModel::TermElement => Mark::Bold,
+        }.freeze
+
+        def self.process(element, context:)
+          return [] unless element
+
+          children = inline_children_for(element)
+
+          children.flat_map do |child|
+            process_child(child, context)
+          end
+        end
+
+        def self.process_child(child, context)
+          case child
+          when CoreModel::TextContent
+            return [] if child.text.nil? || child.text.empty?
+            [context.text_node(child.text)]
+          when CoreModel::InlineElement
+            [dispatch_inline(child, context)].compact
+          when CoreModel::FootnoteReference
+            [context.resolve_footnote_reference(child)]
+          when CoreModel::Block, CoreModel::StructuralElement
+            result = context.registry.handle(child, context: context)
+            return [] unless result
+
+            value, concat = result
+            return [] unless value
+
+            if concat
+              Array(value)
+            else
+              [value].compact
+            end
+          when CoreModel::Image
+            [Handlers::Image.call(child, context: context)]
+          else
+            []
+          end
+        end
+
+        def self.call(element, context:)
+          dispatch_inline(element, context)
+        end
+
+        def self.text_content(element, context:)
+          return nil if element.text.nil? || element.text.empty?
+          context.text_node(element.text)
+        end
+
+        class << self
+          private
+
+          def inline_children_for(element)
+            if element.is_a?(CoreModel::InlineElement) ||
+               element.is_a?(CoreModel::Block) ||
+               element.is_a?(CoreModel::TableCell) ||
+               element.is_a?(CoreModel::StructuralElement)
+              children = element.children
+              return children if children && !children.empty?
+            end
+
+            if element.is_a?(CoreModel::InlineElement) ||
+               element.is_a?(CoreModel::Block)
+              content = element.content
+              return [CoreModel::TextContent.new(text: content.to_s)] if content && !content.to_s.empty?
+            end
+
+            []
+          end
+
+          def dispatch_inline(element, context)
+            mark_class = SIMPLE_MARK_TYPES[element.class]
+            return build_simple_mark(element, context, mark_class) if mark_class
+
+            case element
+            when CoreModel::LinkElement
+              build_link_mark(element, context)
+            when CoreModel::CrossReferenceElement
+              build_xref_mark(element, context)
+            when CoreModel::StemElement
+              build_stem_mark(element, context)
+            when CoreModel::SpanElement
+              build_span_mark(element, context)
+            when CoreModel::FootnoteElement
+              build_footnote_node(element, context)
+            when CoreModel::HardLineBreakElement
+              Node::SoftBreak.new
+            when CoreModel::LineBreakElement
+              Node::SoftBreak.new
+            when CoreModel::TextElement
+              build_text_only(element, context)
+            when CoreModel::InlineElement
+              handle_generic_inline(element, context)
+            end
+          end
+
+          def handle_generic_inline(element, context)
+            text = element.content.to_s
+            return nil if text.empty?
+
+            context.text_node(text)
+          end
+
+          def build_simple_mark(element, context, mark_class)
+            text = extract_inline_text(element)
+            return nil if text.empty?
+            context.text_node(text, marks: [mark_class.new])
+          end
+
+          def build_link_mark(element, context)
+            text = extract_inline_text(element)
+            text = element.target.to_s if text.empty? && element.target
+            return nil if text.empty?
+
+            context.text_node(text, marks: [Mark::Link.new(href: element.target)])
+          end
+
+          def build_xref_mark(element, context)
+            text = extract_inline_text(element)
+            target = element.target
+
+            display_text = text.empty? ? (target || "") : text
+            return nil if display_text.empty?
+
+            context.text_node(display_text, marks: [Mark::CrossReference.new(
+              target: target,
+              resolved: text.empty? ? nil : text,
+            )])
+          end
+
+          def build_stem_mark(element, context)
+            text = extract_inline_text(element)
+            return nil if text.empty?
+
+            context.text_node(text, marks: [Mark::Stem.new(stem_type: element.stem_type)])
+          end
+
+          def build_span_mark(element, context)
+            text = extract_inline_text(element)
+            return nil if text.empty?
+
+            role = element.attr("role")
+            context.text_node(text, marks: [Mark::Span.new(role: role)])
+          end
+
+          def build_footnote_node(element, context)
+            footnote = nil
+            if element.is_a?(CoreModel::InlineElement) && element.content
+              fn_id = element.attr("id")
+              footnote = CoreModel::Footnote.new(
+                id: fn_id,
+                content: element.content.to_s,
+              )
+            end
+
+            context.register_footnote(footnote)
+          end
+
+          def build_text_only(element, context)
+            text = extract_inline_text(element)
+            return nil if text.empty?
+            context.text_node(text)
+          end
+
+          def extract_inline_text(element)
+            return element.content.to_s if element.content && !element.content.to_s.empty?
+
+            if element.is_a?(CoreModel::InlineElement) && element.nested_elements
+              return element.nested_elements.map { |nested| extract_inline_text(nested) }.join
+            end
+
+            if (element.is_a?(CoreModel::InlineElement) || element.is_a?(CoreModel::Block)) && element.children && !element.children.empty?
+              return element.children.map do |child|
+                case child
+                when CoreModel::TextContent then child.text.to_s
+                when CoreModel::InlineElement then extract_inline_text(child)
+                else ""
+                end
+              end.join
+            end
+
+            ""
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/list.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module List
+        def self.call(element, context:)
+          items = Array(element.items).filter_map do |item|
+            list_item(item, context: context)
+          end
+          return nil if items.empty?
+
+          node_class = ordered?(element) ? Node::OrderedList : Node::BulletList
+          node_class.new(
+            id: element.id,
+            start: element.is_a?(CoreModel::ListBlock) ? element.start : nil,
+            content: items,
+          )
+        end
+
+        class << self
+          private
+
+          def list_item(item, context:)
+            content = build_item_content(item, context)
+            return nil if content.empty?
+
+            Node::ListItem.new(id: item.id, content: content)
+          end
+
+          def build_item_content(item, context)
+            content = []
+
+            has_children = item.is_a?(CoreModel::ListItem) &&
+                           item.children && !item.children.empty?
+
+            if has_children
+              item.children.each do |child|
+                node = dispatch_child(child, context)
+                content << node if node
+              end
+            elsif item.content && !item.content.to_s.empty?
+              content << context.text_node(item.content.to_s)
+            end
+
+            if item.is_a?(CoreModel::ListItem) && item.nested_list
+              nested = Handlers::List.call(item.nested_list, context: context)
+              content << nested if nested
+            end
+
+            content
+          end
+
+          def dispatch_child(child, context)
+            case child
+            when CoreModel::TextContent
+              return nil if child.text.nil? || child.text.empty?
+              context.text_node(child.text)
+            when CoreModel::InlineElement
+              Handlers::Inline.call(child, context: context)
+            when CoreModel::Block, CoreModel::StructuralElement
+              result = context.registry.handle(child, context: context)
+              result&.first
+            end
+          end
+
+          def ordered?(element)
+            element.marker_type == "ordered"
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/open_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/open_block.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module OpenBlock
+        def self.call(element, context:)
+          content = context.extract_content(element)
+          return nil if content.empty?
+
+          Node::OpenBlock.new(content: content)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/paragraph.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/paragraph.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Paragraph
+        def self.call(element, context:)
+          content = context.process_inline_content(element)
+          return nil if content.empty?
+
+          Node::Paragraph.new(content: content)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/reviewer.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/reviewer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      # Handles ReviewerBlock → omitted (reviewer notes are not rendered).
+      module Reviewer
+        def self.call(_element, context:)
+          nil
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/sidebar.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/sidebar.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Sidebar
+        def self.call(element, context:)
+          content = context.extract_content(element)
+          return nil if content.empty?
+
+          Node::Sidebar.new(
+            id: element.id,
+            title: element.title,
+            content: content,
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/structural.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/structural.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Structural
+        def self.document(element, context:)
+          content = context.extract_content(element)
+          Node::Document.new(
+            title: element.title,
+            id: element.id,
+            content: content,
+          )
+        end
+
+        def self.section(element, context:)
+          content = context.extract_content(element)
+          Node::Section.new(
+            id: element.id,
+            title: element.title,
+            level: element.heading_level,
+            content: content,
+          )
+        end
+
+        def self.preamble(element, context:)
+          content = context.extract_content(element)
+          Node::Preamble.new(content: content)
+        end
+
+        def self.header(element, context:)
+          content = context.extract_content(element)
+          Node::Header.new(
+            title: element.title,
+            level: element.heading_level,
+            content: content,
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/table.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/table.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Table
+        def self.call(element, context:)
+          rows = Array(element.rows)
+          return nil if rows.empty?
+
+          head_rows, body_rows = partition_rows(rows)
+
+          content = []
+          content << build_table_head(head_rows, context) unless head_rows.empty?
+          content << build_table_body(body_rows, context) unless body_rows.empty?
+
+          return nil if content.empty?
+
+          Node::Table.new(
+            id: element.id,
+            title: element.title,
+            width: element.width,
+            content: content,
+          )
+        end
+
+        class << self
+          private
+
+          def partition_rows(rows)
+            head = rows.select { |r| r.is_a?(CoreModel::TableRow) && r.header }
+            body = rows.reject { |r| r.is_a?(CoreModel::TableRow) && r.header }
+            [head, body]
+          end
+
+          def build_table_head(rows, context)
+            content = rows.map { |r| build_table_row(r, context) }
+            Node::TableHead.new(content: content)
+          end
+
+          def build_table_body(rows, context)
+            content = rows.map { |r| build_table_row(r, context) }
+            Node::TableBody.new(content: content)
+          end
+
+          def build_table_row(row, context)
+            cells = Array(row.cells).map { |c| build_table_cell(c, context) }
+            Node::TableRow.new(content: cells)
+          end
+
+          def build_table_cell(cell, context)
+            content = build_cell_content(cell, context)
+            Node::TableCell.new(
+              colspan: cell.colspan,
+              rowspan: cell.rowspan,
+              alignment: cell.alignment,
+              header: cell.header || nil,
+              content: content,
+            )
+          end
+
+          def build_cell_content(cell, context)
+            if cell.is_a?(CoreModel::TableCell) && cell.children && !cell.children.empty?
+              return cell.children.flat_map do |child|
+                Handlers::Inline.process_child(child, context)
+              end
+            end
+
+            text = cell.content
+            return [] if text.nil? || text.to_s.empty?
+
+            [context.text_node(text.to_s)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/toc.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/toc.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Toc
+        def self.call(element, context:)
+          entries = if element.is_a?(CoreModel::Toc) && element.entries
+                      Array(element.entries).filter_map do |entry|
+                        build_entry(entry, context)
+                      end
+                    else
+                      []
+                    end
+
+          Node::Toc.new(
+            title: element.title,
+            content: entries,
+          )
+        end
+
+        class << self
+          private
+
+          def build_entry(entry, context)
+            children = if entry.is_a?(CoreModel::TocEntry) && entry.children
+                         entry.children.filter_map { |c| build_entry(c, context) }
+                       else
+                         []
+                       end
+
+            content = [context.text_node(entry.title.to_s)] unless children.any?
+            content ||= children
+
+            Node::TocEntry.new(
+              id: entry.is_a?(CoreModel::TocEntry) ? entry.id : nil,
+              title: entry.is_a?(CoreModel::TocEntry) ? entry.title : nil,
+              level: entry.is_a?(CoreModel::TocEntry) ? entry.level : nil,
+              content: content,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/verse.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/verse.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Verse
+        def self.call(element, context:)
+          text = if element.content && !element.content.to_s.empty?
+                   element.flat_text || element.content.to_s
+                 else
+                   ""
+                 end
+
+          Node::Verse.new(
+            attribution: element.attribution,
+            content: [context.text_node(text)],
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/mark.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mark.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    # ProseMirror-compatible inline mark (formatting annotation).
+    #
+    # Marks decorate inline text nodes with formatting semantics like
+    # bold, italic, link, etc. They are serialized as:
+    #
+    #   { "type": "bold" }
+    #   { "type": "link", "attrs": { "href": "..." } }
+    #
+    # New mark types are added by subclassing Mark — no modification of
+    # existing code needed (OCP).
+    #
+    class Mark
+      PM_TYPE = "mark"
+
+      class << self
+        def mark_attr(*names)
+          @mark_attr_names ||= []
+          @mark_attr_names |= names
+          attr_accessor(*names)
+        end
+
+        def mark_attr_names
+          @mark_attr_names ||= []
+        end
+      end
+
+      def initialize(type: nil)
+        @type_override = type
+        self.class.mark_attr_names.each do |name|
+          public_send(:"#{name}=", nil)
+        end
+      end
+
+      def type
+        @type_override || self.class::PM_TYPE
+      end
+
+      def to_h
+        result = { "type" => type }
+        attrs = serialize_attrs
+        result["attrs"] = attrs unless attrs.empty?
+        result
+      end
+
+      alias to_hash to_h
+
+      def to_json(**options)
+        to_h.to_json(options)
+      end
+
+      def self.from_h(hash)
+        return nil unless hash
+
+        type_str = hash["type"]
+        mark_class = MARKS[type_str]
+
+        if mark_class && mark_class != self
+          mark_class.from_h(hash)
+        else
+          attrs = hash["attrs"] || {}
+          base = mark_class || self
+          kwargs = build_kwargs(base, attrs)
+          kwargs[:type] = type_str if mark_class.nil?
+          base.new(**kwargs)
+        end
+      end
+
+      # Auto-registry: maps PM_TYPE → class for all declared subclasses.
+      MARKS = {}
+
+      # ── Mark type subclasses ────────────────────────────────────
+
+      class Bold < Mark
+        PM_TYPE = "bold"
+      end
+
+      class Italic < Mark
+        PM_TYPE = "italic"
+      end
+
+      class Monospace < Mark
+        PM_TYPE = "code"
+      end
+
+      class Underline < Mark
+        PM_TYPE = "underline"
+      end
+
+      class Strikethrough < Mark
+        PM_TYPE = "strikethrough"
+      end
+
+      class Subscript < Mark
+        PM_TYPE = "subscript"
+      end
+
+      class Superscript < Mark
+        PM_TYPE = "superscript"
+      end
+
+      class Highlight < Mark
+        PM_TYPE = "highlight"
+      end
+
+      class Link < Mark
+        PM_TYPE = "link"
+        mark_attr :href
+
+        def initialize(href: nil)
+          super()
+          @href = href
+        end
+
+        def self.from_h(hash)
+          return nil unless hash
+
+          attrs = hash["attrs"] || {}
+          new(href: attrs[:href] || attrs["href"])
+        end
+      end
+
+      class CrossReference < Mark
+        PM_TYPE = "xref"
+        mark_attr :target, :resolved
+
+        def initialize(target: nil, resolved: nil)
+          super()
+          @target = target
+          @resolved = resolved
+        end
+      end
+
+      class Stem < Mark
+        PM_TYPE = "stem"
+        mark_attr :stem_type
+
+        def initialize(stem_type: nil)
+          super()
+          @stem_type = stem_type
+        end
+      end
+
+      class Span < Mark
+        PM_TYPE = "span"
+        mark_attr :role
+
+        def initialize(role: nil)
+          super()
+          @role = role
+        end
+      end
+
+      # Auto-register all mark subclasses by PM_TYPE.
+      constants.each do |name|
+        klass = const_get(name)
+        next unless klass.is_a?(Class) && klass < Mark && klass::PM_TYPE != "mark"
+
+        MARKS[klass::PM_TYPE] = klass
+      end
+
+      private
+
+      def serialize_attrs
+        self.class.mark_attr_names.each_with_object({}) do |name, hash|
+          value = public_send(name)
+          hash[name.to_s] = value unless value.nil?
+        end
+      end
+
+      def self.build_kwargs(klass, attrs)
+        return {} if attrs.empty?
+
+        symbolized = attrs.transform_keys(&:to_sym)
+        klass.mark_attr_names.each_with_object({}) do |name, kwargs|
+          kwargs[name] = symbolized[name] if symbolized.key?(name)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/mirror_json_format.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mirror_json_format.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Coradoc
+  module Mirror
+    # Format module for mirror JSON output.
+    #
+    # Registers with Coradoc so the CLI can discover it:
+    #   Coradoc.convert(text, from: :asciidoc, to: :mirror_json)
+    #   coradoc convert doc.adoc -t mirror_json
+    module MirrorJsonFormat
+      class << self
+        # Output-only format — parsing from mirror JSON is not supported via
+        # the format registry. Use Mirror::Node.from_h directly.
+        def parse_to_core(input, options = {})
+          raise Coradoc::UnsupportedFormatError,
+                "Parsing from mirror JSON is not supported via the format registry. " \
+                "Use Coradoc::Mirror::Node.from_h(JSON.parse(input)) directly."
+        end
+
+        # Accept CoreModel, serialize to Mirror JSON.
+        def serialize(document, options = {})
+          pretty = options[:pretty] != false
+          node = Coradoc::Mirror.transform(document)
+          node.to_json(pretty: pretty)
+        end
+
+        def serialize?
+          true
+        end
+
+        def handles_model?(_model)
+          false
+        end
+      end
+    end
+  end
+end
+
+Coradoc.register_format(:mirror_json, Coradoc::Mirror::MirrorJsonFormat,
+                        extensions: %w[.mirror.json])

--- a/coradoc-mirror/lib/coradoc/mirror/mirror_to_core_model.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mirror_to_core_model.rb
@@ -1,0 +1,393 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    class MirrorToCoreModel
+      # Dispatch table: Mirror node type string → builder lambda.
+      # New node types are supported by adding entries (OCP).
+      TYPE_BUILDERS = {
+        "doc" => ->(t, n) { t.build_document(n) },
+        "section" => ->(t, n) { t.build_section(n) },
+        "header" => ->(t, n) { t.build_header(n) },
+        "preamble" => ->(t, n) { t.build_preamble(n) },
+        "paragraph" => ->(t, n) { t.build_paragraph(n) },
+        "code_block" => ->(t, n) { t.build_code_block(n) },
+        "blockquote" => ->(t, n) { t.build_blockquote(n) },
+        "example" => ->(t, n) { t.build_example(n) },
+        "sidebar" => ->(t, n) { t.build_sidebar(n) },
+        "open_block" => ->(t, n) { t.build_open_block(n) },
+        "verse" => ->(t, n) { t.build_verse(n) },
+        "horizontal_rule" => ->(t, _n) { t.build_horizontal_rule },
+        "admonition" => ->(t, n) { t.build_admonition(n) },
+        "bullet_list" => ->(t, n) { t.build_bullet_list(n) },
+        "ordered_list" => ->(t, n) { t.build_ordered_list(n) },
+        "list_item" => ->(t, n) { t.build_list_item(n) },
+        "definition_list" => ->(t, n) { t.build_definition_list(n) },
+        "definition_term" => ->(t, n) { t.build_definition_term(n) },
+        "definition_description" => ->(t, n) { t.build_definition_description(n) },
+        "image" => ->(t, n) { t.build_image(n) },
+        "table" => ->(t, n) { t.build_table(n) },
+        "table_head" => ->(t, n) { t.build_table_head(n) },
+        "table_body" => ->(t, n) { t.build_table_body(n) },
+        "table_row" => ->(t, n) { t.build_table_row(n) },
+        "table_cell" => ->(t, n) { t.build_table_cell(n) },
+        "bibliography" => ->(t, n) { t.build_bibliography(n) },
+        "biblio_entry" => ->(t, n) { t.build_biblio_entry(n) },
+        "footnotes" => ->(_t, _n) { nil },
+        "footnote_entry" => ->(t, n) { t.build_footnote_entry(n) },
+        "toc" => ->(t, n) { t.build_toc(n) },
+        "toc_entry" => ->(t, n) { t.build_toc_entry(n) },
+        "text" => ->(t, n) { t.build_text(n) },
+        "soft_break" => ->(t, _n) { t.build_soft_break },
+      }.freeze
+
+      def call(mirror_node)
+        build_node(mirror_node)
+      end
+
+      def build_node(node)
+        builder = TYPE_BUILDERS[node.type]
+        raise Error, "Unknown mirror node type: #{node.type}" unless builder
+
+        builder.call(self, node)
+      end
+
+      def build_content(node)
+        return [] unless node.content
+
+        node.content.filter_map { |child| build_node(child) }
+      end
+
+      # ── Structural ──
+
+      def build_document(node)
+        CoreModel::DocumentElement.new(
+          title: node.title,
+          id: node.id,
+          children: build_content(node),
+        )
+      end
+
+      def build_section(node)
+        CoreModel::SectionElement.new(
+          title: node.title,
+          level: node.level,
+          id: node.id,
+          children: build_content(node),
+        )
+      end
+
+      def build_header(node)
+        CoreModel::HeaderElement.new(
+          title: node.title,
+          level: node.level,
+          children: build_content(node),
+        )
+      end
+
+      def build_preamble(node)
+        CoreModel::PreambleElement.new(
+          children: build_content(node),
+        )
+      end
+
+      # ── Blocks ──
+
+      def build_paragraph(node)
+        children = build_inline_children(node)
+        CoreModel::ParagraphBlock.new(children: children)
+      end
+
+      def build_code_block(node)
+        text = extract_text(node)
+        CoreModel::SourceBlock.new(
+          content: text,
+          language: node.language,
+          title: node.title,
+        )
+      end
+
+      def build_blockquote(node)
+        CoreModel::QuoteBlock.new(
+          attribution: node.attribution,
+          children: build_content(node),
+        )
+      end
+
+      def build_example(node)
+        CoreModel::ExampleBlock.new(
+          title: node.title,
+          children: build_content(node),
+        )
+      end
+
+      def build_sidebar(node)
+        CoreModel::SidebarBlock.new(
+          title: node.title,
+          children: build_content(node),
+        )
+      end
+
+      def build_open_block(node)
+        CoreModel::OpenBlock.new(
+          children: build_content(node),
+        )
+      end
+
+      def build_verse(node)
+        text = extract_text(node)
+        CoreModel::VerseBlock.new(
+          content: text,
+          attribution: node.attribution,
+        )
+      end
+
+      def build_horizontal_rule
+        CoreModel::HorizontalRuleBlock.new
+      end
+
+      def build_admonition(node)
+        content = build_content(node)
+        text = content.map { |c| c.is_a?(CoreModel::InlineElement) ? c.content.to_s : "" }.join
+
+        CoreModel::AnnotationBlock.new(
+          annotation_type: node.admonition_type,
+          content: text,
+        )
+      end
+
+      # ── Lists ──
+
+      def build_bullet_list(node)
+        items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
+        CoreModel::ListBlock.new(
+          marker_type: "unordered",
+          items: items,
+        )
+      end
+
+      def build_ordered_list(node)
+        items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
+        CoreModel::ListBlock.new(
+          marker_type: "ordered",
+          items: items,
+        )
+      end
+
+      def build_list_item(node)
+        children = build_inline_children(node)
+        text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : "" }.join
+
+        nested_list = nil
+        node.content&.each do |child|
+          next unless child.is_a?(Node)
+          if child.type == "bullet_list" || child.type == "ordered_list"
+            nested_list = build_node(child)
+          end
+        end
+
+        CoreModel::ListItem.new(
+          content: text,
+          children: children.empty? ? children : children,
+          nested_list: nested_list,
+        )
+      end
+
+      def build_definition_list(node)
+        terms = []
+        descriptions = []
+        node.content&.each do |child|
+          next unless child.is_a?(Node)
+          case child.type
+          when "definition_term"
+            terms << build_node(child)
+          when "definition_description"
+            descriptions << build_node(child)
+          end
+        end
+
+        items = terms.zip(descriptions).map do |term, desc|
+          CoreModel::DefinitionItem.new(
+            term: term.is_a?(CoreModel::InlineElement) ? term.content : term.to_s,
+            definitions: [desc.is_a?(CoreModel::InlineElement) ? desc.content : desc.to_s],
+          )
+        end
+
+        CoreModel::DefinitionList.new(items: items)
+      end
+
+      def build_definition_term(node)
+        children = build_inline_children(node)
+        text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : "" }.join
+        CoreModel::InlineElement.new(content: text)
+      end
+
+      def build_definition_description(node)
+        children = build_inline_children(node)
+        text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : "" }.join
+        CoreModel::InlineElement.new(content: text)
+      end
+
+      # ── Media ──
+
+      def build_image(node)
+        CoreModel::Image.new(
+          src: node.src,
+          alt: node.alt,
+          title: node.title,
+          caption: node.caption,
+          width: node.width,
+          height: node.height,
+        )
+      end
+
+      # ── Tables ──
+
+      def build_table(node)
+        rows = []
+        node.content&.each do |child|
+          next unless child.is_a?(Node)
+          case child.type
+          when "table_head", "table_body"
+            child.content&.each do |row_node|
+              rows << build_node(row_node) if row_node.is_a?(Node)
+            end
+          end
+        end
+
+        CoreModel::Table.new(
+          title: node.title,
+          rows: rows,
+        )
+      end
+
+      def build_table_head(node)
+        build_content(node).first || CoreModel::TableRow.new
+      end
+
+      def build_table_body(node)
+        build_content(node).first || CoreModel::TableRow.new
+      end
+
+      def build_table_row(node)
+        cells = build_content(node).select { |c| c.is_a?(CoreModel::TableCell) }
+        CoreModel::TableRow.new(cells: cells)
+      end
+
+      def build_table_cell(node)
+        text = extract_text(node)
+        CoreModel::TableCell.new(
+          content: text,
+          header: node.header || false,
+          colspan: node.colspan,
+          rowspan: node.rowspan,
+          alignment: node.alignment,
+        )
+      end
+
+      # ── Bibliography ──
+
+      def build_bibliography(node)
+        entries = build_content(node).select { |c| c.is_a?(CoreModel::BibliographyEntry) }
+        CoreModel::Bibliography.new(
+          title: node.title,
+          entries: entries,
+        )
+      end
+
+      def build_biblio_entry(node)
+        text = extract_text(node)
+        CoreModel::BibliographyEntry.new(
+          anchor_name: node.anchor_name,
+          document_id: node.document_id,
+          ref_text: text,
+        )
+      end
+
+      # ── Footnotes ──
+
+      def build_footnote_entry(node)
+        text = extract_text(node)
+        CoreModel::Footnote.new(
+          id: node.id,
+          content: text,
+        )
+      end
+
+      # ── TOC ──
+
+      def build_toc(node)
+        CoreModel::Toc.new
+      end
+
+      def build_toc_entry(node)
+        CoreModel::TocEntry.new(
+          id: node.id,
+          title: node.title,
+        )
+      end
+
+      # ── Inline ──
+
+      def build_text(node)
+        text = node.text || ""
+        marks = node.marks || []
+
+        return CoreModel::TextContent.new(text: text) if marks.empty?
+
+        marks.reduce(CoreModel::TextContent.new(text: text)) do |current, mark|
+          apply_mark(current, mark)
+        end
+      end
+
+      def build_soft_break
+        CoreModel::LineBreakElement.new
+      end
+
+      # ── Helpers ──
+
+      def apply_mark(inner, mark)
+        case mark.type
+        when "bold" then CoreModel::BoldElement.new(children: Array(inner))
+        when "italic" then CoreModel::ItalicElement.new(children: Array(inner))
+        when "code" then CoreModel::MonospaceElement.new(children: Array(inner))
+        when "underline" then CoreModel::UnderlineElement.new(children: Array(inner))
+        when "strikethrough" then CoreModel::StrikethroughElement.new(children: Array(inner))
+        when "subscript" then CoreModel::SubscriptElement.new(children: Array(inner))
+        when "superscript" then CoreModel::SuperscriptElement.new(children: Array(inner))
+        when "highlight" then CoreModel::HighlightElement.new(children: Array(inner))
+        when "link"
+          CoreModel::LinkElement.new(
+            target: mark.href,
+            children: Array(inner),
+          )
+        when "xref"
+          CoreModel::CrossReferenceElement.new(
+            target: mark.target,
+            children: Array(inner),
+          )
+        else
+          inner
+        end
+      end
+
+      def build_inline_children(node)
+        return [] unless node.content
+
+        node.content.filter_map do |child|
+          next unless child.is_a?(Node)
+          build_node(child)
+        end
+      end
+
+      def extract_text(node)
+        return node.text.to_s if node.is_a?(Node::Text)
+        return "" unless node.content
+
+        node.content.filter_map do |child|
+          child.is_a?(Node) ? extract_text(child) : ""
+        end.join
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/mirror_yaml_format.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mirror_yaml_format.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module Coradoc
+  module Mirror
+    # Format module for mirror YAML output.
+    #
+    # Registers with Coradoc so the CLI can discover it:
+    #   Coradoc.convert(text, from: :asciidoc, to: :mirror_yaml)
+    #   coradoc convert doc.adoc -t mirror_yaml
+    module MirrorYamlFormat
+      class << self
+        # Output-only format — parsing from mirror YAML is not supported via
+        # the format registry. Use Mirror::Node.from_h directly.
+        def parse_to_core(input, options = {})
+          raise Coradoc::UnsupportedFormatError,
+                "Parsing from mirror YAML is not supported via the format registry. " \
+                "Use Coradoc::Mirror::Node.from_h(YAML.safe_load(input)) directly."
+        end
+
+        # Accept CoreModel, serialize to Mirror YAML.
+        def serialize(document, options = {})
+          node = Coradoc::Mirror.transform(document)
+          node.to_yaml
+        end
+
+        def serialize?
+          true
+        end
+
+        def handles_model?(_model)
+          false
+        end
+      end
+    end
+  end
+end
+
+Coradoc.register_format(:mirror_yaml, Coradoc::Mirror::MirrorYamlFormat,
+                        extensions: %w[.mirror.yaml .mirror.yml])

--- a/coradoc-mirror/lib/coradoc/mirror/node.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/node.rb
@@ -1,0 +1,367 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Coradoc
+  module Mirror
+    # ProseMirror-compatible document node.
+    #
+    # Every node has a +type+, optional typed attributes, optional +content+
+    # (child nodes), and optional +marks+ (inline formatting). Serializes to
+    # the canonical ProseMirror JSON format:
+    #
+    #   { "type": "paragraph", "content": [...], "attrs": {...}, "marks": [...] }
+    #
+    # Subclasses declare typed attributes via +node_attr+ and a +PM_TYPE+
+    # constant for their canonical type string. New node types are added by
+    # subclassing Node — no modification of existing code needed (OCP).
+    #
+    class Node
+      PM_TYPE = "node"
+
+      attr_accessor :content, :marks
+
+      class << self
+        # Declare a typed attribute for this node type.
+        #
+        # Generates an +attr_accessor+ and tracks the name for serialization
+        # and deserialization. Attributes default to +nil+ unless +default:+
+        # is specified.
+        def node_attr(*names, default: nil)
+          @node_attr_names ||= []
+          @node_attr_defaults ||= {}
+
+          names.each do |name|
+            @node_attr_names << name
+            @node_attr_defaults[name] = default
+          end
+
+          attr_accessor(*names)
+        end
+
+        # Ordered list of attribute names declared via +node_attr+.
+        def node_attr_names
+          @node_attr_names ||= []
+        end
+
+        # Default values for declared attributes.
+        def node_attr_defaults
+          @node_attr_defaults ||= {}
+        end
+      end
+
+      def initialize(type: nil, content: [], marks: [], **attrs)
+        @type_override = type
+        @content = content || []
+        @marks = marks || []
+
+        self.class.node_attr_names.each do |name|
+          value = if attrs.key?(name)
+                    attrs[name]
+                  else
+                    default = self.class.node_attr_defaults[name]
+                    default.is_a?(Proc) ? default.call : default
+                  end
+          public_send(:"#{name}=", value)
+        end
+      end
+
+      def type
+        @type_override || self.class::PM_TYPE
+      end
+
+      # Serialize to ProseMirror-compatible Hash.
+      def to_h
+        result = { "type" => type }
+        attrs = serialize_attrs
+        result["attrs"] = attrs unless attrs.empty?
+        result["marks"] = marks.map(&:to_h) unless marks.empty?
+        unless content.empty?
+          items = content.is_a?(Array) ? content : [content]
+          result["content"] = items.map(&:to_h)
+        end
+        result
+      end
+
+      alias to_hash to_h
+
+      def to_json(pretty: false, **options)
+        if pretty
+          JSON.pretty_generate(to_h, options)
+        else
+          to_h.to_json(options)
+        end
+      end
+
+      def to_yaml
+        YAML.dump(to_h)
+      end
+
+      # Reconstruct a Node tree from a ProseMirror-compatible Hash.
+      def self.from_h(hash)
+        return nil unless hash
+
+        type_str = hash["type"]
+        klass = NODES[type_str]
+
+        if klass && klass != self
+          klass.from_h(hash)
+        else
+          base = klass || self
+          content = (hash["content"] || []).map { |c| Node.from_h(c) }
+          marks = (hash["marks"] || []).map { |m| Mark.from_h(m) }
+
+          attrs = hash["attrs"] || {}
+          kwargs = build_kwargs(base, attrs)
+          kwargs[:content] = content
+          kwargs[:marks] = marks
+          kwargs[:type] = type_str if klass.nil?
+
+          base.new(**kwargs)
+        end
+      end
+
+      # Collect all text content from this node and its descendants.
+      def text_content
+        return "" unless content
+
+        content.map do |item|
+          item.is_a?(Node) ? item.text_content : ""
+        end.join
+      end
+
+      # Auto-registry: maps PM_TYPE → class for all declared subclasses.
+      NODES = {}
+
+      # ── Node type subclasses ────────────────────────────────────
+
+      class Text < Node
+        PM_TYPE = "text"
+
+        node_attr :text
+
+        def initialize(text: "", **kwargs)
+          super(**kwargs)
+          @text = text
+        end
+
+        def to_h
+          result = super
+          result["text"] = text.to_s
+          result
+        end
+
+        def text_content
+          text.to_s
+        end
+
+        def self.from_h(hash)
+          return nil unless hash
+
+          new(
+            text: hash["text"] || "",
+            attrs: (hash["attrs"] || {}).transform_keys(&:to_sym),
+            marks: (hash["marks"] || []).map { |m| Mark.from_h(m) },
+          )
+        end
+      end
+
+      class Document < Node
+        PM_TYPE = "doc"
+        node_attr :title, :id
+      end
+
+      class Paragraph < Node
+        PM_TYPE = "paragraph"
+      end
+
+      class Heading < Node
+        PM_TYPE = "heading"
+        node_attr :level
+      end
+
+      class Section < Node
+        PM_TYPE = "section"
+        node_attr :title, :id, :level
+      end
+
+      class Preamble < Node
+        PM_TYPE = "preamble"
+      end
+
+      class Header < Node
+        PM_TYPE = "header"
+        node_attr :title, :level
+      end
+
+      class CodeBlock < Node
+        PM_TYPE = "code_block"
+        node_attr :language, :title, :passthrough
+      end
+
+      class Blockquote < Node
+        PM_TYPE = "blockquote"
+        node_attr :attribution
+      end
+
+      class Example < Node
+        PM_TYPE = "example"
+        node_attr :title, :id
+      end
+
+      class Sidebar < Node
+        PM_TYPE = "sidebar"
+        node_attr :title, :id
+      end
+
+      class OpenBlock < Node
+        PM_TYPE = "open_block"
+      end
+
+      class Verse < Node
+        PM_TYPE = "verse"
+        node_attr :attribution
+      end
+
+      class HorizontalRule < Node
+        PM_TYPE = "horizontal_rule"
+      end
+
+      class BulletList < Node
+        PM_TYPE = "bullet_list"
+        node_attr :id, :start
+      end
+
+      class OrderedList < Node
+        PM_TYPE = "ordered_list"
+        node_attr :id, :start
+      end
+
+      class ListItem < Node
+        PM_TYPE = "list_item"
+        node_attr :id
+      end
+
+      class DefinitionList < Node
+        PM_TYPE = "definition_list"
+        node_attr :id
+      end
+
+      class DefinitionTerm < Node
+        PM_TYPE = "definition_term"
+      end
+
+      class DefinitionDescription < Node
+        PM_TYPE = "definition_description"
+      end
+
+      class Image < Node
+        PM_TYPE = "image"
+        node_attr :src, :alt, :title, :caption, :width, :height, :inline
+      end
+
+      class Table < Node
+        PM_TYPE = "table"
+        node_attr :title, :id, :width
+      end
+
+      class TableHead < Node
+        PM_TYPE = "table_head"
+      end
+
+      class TableBody < Node
+        PM_TYPE = "table_body"
+      end
+
+      class TableRow < Node
+        PM_TYPE = "table_row"
+      end
+
+      class TableCell < Node
+        PM_TYPE = "table_cell"
+        node_attr :colspan, :rowspan, :alignment, :header
+      end
+
+      class Admonition < Node
+        PM_TYPE = "admonition"
+        node_attr :admonition_type, :title, :label, :id
+      end
+
+      class Bibliography < Node
+        PM_TYPE = "bibliography"
+        node_attr :title, :id, :level
+      end
+
+      class BibliographyEntry < Node
+        PM_TYPE = "biblio_entry"
+        node_attr :anchor_name, :document_id, :url
+      end
+
+      class Footnotes < Node
+        PM_TYPE = "footnotes"
+      end
+
+      class FootnoteMarker < Node
+        PM_TYPE = "footnote_marker"
+        node_attr :id, :ref_id, :number
+      end
+
+      class FootnoteEntry < Node
+        PM_TYPE = "footnote_entry"
+        node_attr :id, :ref_id, :number
+      end
+
+      class Toc < Node
+        PM_TYPE = "toc"
+        node_attr :title
+      end
+
+      class TocEntry < Node
+        PM_TYPE = "toc_entry"
+        node_attr :id, :title, :level
+      end
+
+      class ThematicBreak < Node
+        PM_TYPE = "thematic_break"
+      end
+
+      class SoftBreak < Node
+        PM_TYPE = "soft_break"
+      end
+
+      # Generic typed block for unrecognized semantic types.
+      class GenericBlock < Node
+        PM_TYPE = "generic_block"
+        node_attr :semantic_type, :title, :id
+      end
+
+      # Auto-register all nested subclasses by PM_TYPE.
+      constants.each do |name|
+        klass = const_get(name)
+        next unless klass.is_a?(Class) && klass < Node && klass::PM_TYPE != "node"
+
+        NODES[klass::PM_TYPE] = klass
+      end
+
+      private
+
+      def serialize_attrs
+        self.class.node_attr_names.each_with_object({}) do |name, hash|
+          value = public_send(name)
+          hash[name.to_s] = value unless value.nil?
+        end
+      end
+
+      # Build keyword arguments from a ProseMirror attrs hash,
+      # matching only attributes declared via +node_attr+ on the class.
+      def self.build_kwargs(klass, attrs)
+        return {} if attrs.empty?
+
+        symbolized = attrs.transform_keys(&:to_sym)
+        klass.node_attr_names.each_with_object({}) do |name, kwargs|
+          kwargs[name] = symbolized[name] if symbolized.key?(name)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/output.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/output.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "json"
+require "yaml"
+
+module Coradoc
+  module Mirror
+    # Output processors that integrate with the Coradoc::Output pipeline.
+    #
+    # Enables:
+    #   Coradoc.serialize(doc, to: :mirror_json)
+    #   Coradoc.serialize(doc, to: :mirror_yaml)
+    module Output
+      # JSON output processor for the Coradoc::Output pipeline.
+      class MirrorJson
+        class << self
+          def processor_id
+            :mirror_json
+          end
+
+          def processor_match?(filename)
+            filename.downcase.end_with?(".mirror.json")
+          end
+
+          def processor_execute(input, options = {})
+            pretty = options[:pretty] != false
+            input.each_with_object({}) do |(filename, document), result|
+              node = Coradoc::Mirror.transform(document)
+              result[filename] = node.to_json(pretty: pretty)
+            end
+          end
+        end
+      end
+
+      # YAML output processor for the Coradoc::Output pipeline.
+      class MirrorYaml
+        class << self
+          def processor_id
+            :mirror_yaml
+          end
+
+          def processor_match?(filename)
+            filename.downcase.end_with?(".mirror.yaml", ".mirror.yml")
+          end
+
+          def processor_execute(input, options = {})
+            input.each_with_object({}) do |(filename, document), result|
+              node = Coradoc::Mirror.transform(document)
+              result[filename] = node.to_yaml
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+# Register with the Coradoc::Output pipeline if available.
+if defined?(Coradoc::Output)
+  Coradoc::Output.define(Coradoc::Mirror::Output::MirrorJson)
+  Coradoc::Output.define(Coradoc::Mirror::Output::MirrorYaml)
+end

--- a/coradoc-mirror/lib/coradoc/mirror/transformer.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/transformer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    # Bidirectional facade for CoreModel ↔ Mirror transformation.
+    #
+    # Delegates to CoreModelToMirror (forward) and MirrorToCoreModel (reverse).
+    #
+    # @example Forward transformation
+    #   transformer = Coradoc::Mirror::Transformer.new
+    #   mirror_doc = transformer.from_core_model(document)
+    #
+    # @example Reverse transformation
+    #   core_doc = transformer.to_core_model(mirror_doc)
+    #
+    class Transformer
+      def initialize(registry: Coradoc::Mirror.default_registry)
+        @registry = registry
+      end
+
+      # Convert CoreModel document to Mirror node tree.
+      #
+      # @param document [CoreModel::Base] CoreModel document
+      # @return [Node::Document] mirror document root
+      def from_core_model(document)
+        CoreModelToMirror.new(registry: @registry).call(document)
+      end
+
+      # Convert Mirror node tree to CoreModel document.
+      #
+      # @param mirror_node [Node] mirror document root
+      # @return [CoreModel::Base] CoreModel document
+      def to_core_model(mirror_node)
+        MirrorToCoreModel.new.call(mirror_node)
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/version.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    VERSION = "0.1.0"
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/core_model_to_mirror_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/core_model_to_mirror_spec.rb
@@ -1,0 +1,505 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+
+RSpec.describe Coradoc::Mirror::CoreModelToMirror do
+  let(:registry) { Coradoc::Mirror.default_registry }
+  let(:transformer) { described_class.new(registry: registry) }
+
+  def make_section(title: "Section", level: 1, children: [], id: nil)
+    Coradoc::CoreModel::SectionElement.new(
+      title: title,
+      level: level,
+      children: children,
+      id: id,
+    )
+  end
+
+  def make_paragraph(text, id: nil)
+    Coradoc::CoreModel::ParagraphBlock.new(
+      content: text,
+      id: id,
+    )
+  end
+
+  def make_document(title: "Doc", children: [])
+    Coradoc::CoreModel::DocumentElement.new(
+      title: title,
+      children: children,
+    )
+  end
+
+  describe "#call" do
+    it "transforms a simple document with title" do
+      doc = make_document(title: "My Document")
+      result = transformer.call(doc)
+
+      expect(result).to be_a(Coradoc::Mirror::Node::Document)
+      expect(result.title).to eq("My Document")
+    end
+
+    it "transforms a document with sections" do
+      doc = make_document(title: "Doc", children: [
+        make_section(title: "Introduction", level: 1, children: [
+          make_paragraph("Hello world"),
+        ]),
+      ])
+      result = transformer.call(doc)
+
+      expect(result.content.length).to eq(1)
+      section = result.content.first
+      expect(section).to be_a(Coradoc::Mirror::Node::Section)
+      expect(section.title).to eq("Introduction")
+      expect(section.level).to eq(1)
+
+      para = section.content.first
+      expect(para).to be_a(Coradoc::Mirror::Node::Paragraph)
+      expect(para.content.first.text).to eq("Hello world")
+    end
+
+    it "produces valid JSON" do
+      doc = make_document(title: "Test", children: [
+        make_paragraph("Content"),
+      ])
+      result = transformer.call(doc)
+      json = result.to_json
+
+      parsed = JSON.parse(json)
+      expect(parsed["type"]).to eq("doc")
+      expect(parsed["attrs"]["title"]).to eq("Test")
+    end
+  end
+
+  describe "block transformations" do
+    it "transforms source block" do
+      block = Coradoc::CoreModel::SourceBlock.new(
+        content: "def hello; end",
+        language: "ruby",
+      )
+      doc = make_document(children: [block])
+      result = transformer.call(doc)
+
+      code = result.content.first
+      expect(code).to be_a(Coradoc::Mirror::Node::CodeBlock)
+      expect(code.language).to eq("ruby")
+      expect(code.content.first.text).to eq("def hello; end")
+    end
+
+    it "transforms quote block" do
+      block = Coradoc::CoreModel::QuoteBlock.new(
+        content: "To be or not to be",
+        attribution: "Shakespeare",
+      )
+      doc = make_document(children: [block])
+      result = transformer.call(doc)
+
+      quote = result.content.first
+      expect(quote).to be_a(Coradoc::Mirror::Node::Blockquote)
+      expect(quote.attribution).to eq("Shakespeare")
+    end
+
+    it "transforms example block" do
+      block = Coradoc::CoreModel::ExampleBlock.new(
+        content: "Example content",
+        title: "Example 1",
+      )
+      doc = make_document(children: [block])
+      result = transformer.call(doc)
+
+      example = result.content.first
+      expect(example).to be_a(Coradoc::Mirror::Node::Example)
+      expect(example.title).to eq("Example 1")
+    end
+
+    it "transforms sidebar block" do
+      block = Coradoc::CoreModel::SidebarBlock.new(content: "Side info")
+      doc = make_document(children: [block])
+      result = transformer.call(doc)
+
+      sidebar = result.content.first
+      expect(sidebar).to be_a(Coradoc::Mirror::Node::Sidebar)
+    end
+
+    it "transforms open block" do
+      block = Coradoc::CoreModel::OpenBlock.new(content: "Open content")
+      doc = make_document(children: [block])
+      result = transformer.call(doc)
+
+      open = result.content.first
+      expect(open).to be_a(Coradoc::Mirror::Node::OpenBlock)
+    end
+
+    it "transforms verse block" do
+      block = Coradoc::CoreModel::VerseBlock.new(
+        content: "Roses are red",
+        attribution: "Anonymous",
+      )
+      doc = make_document(children: [block])
+      result = transformer.call(doc)
+
+      verse = result.content.first
+      expect(verse).to be_a(Coradoc::Mirror::Node::Verse)
+      expect(verse.attribution).to eq("Anonymous")
+    end
+
+    it "transforms horizontal rule" do
+      block = Coradoc::CoreModel::HorizontalRuleBlock.new
+      doc = make_document(children: [block])
+      result = transformer.call(doc)
+
+      hr = result.content.first
+      expect(hr).to be_a(Coradoc::Mirror::Node::HorizontalRule)
+    end
+
+    it "skips comment blocks" do
+      block = Coradoc::CoreModel::CommentBlock.new(content: "Hidden")
+      doc = make_document(children: [block])
+      result = transformer.call(doc)
+
+      expect(result.content).to be_empty
+    end
+
+    it "skips reviewer blocks" do
+      block = Coradoc::CoreModel::ReviewerBlock.new(content: "Review")
+      doc = make_document(children: [block])
+      result = transformer.call(doc)
+
+      expect(result.content).to be_empty
+    end
+
+    it "transforms annotation / admonition block" do
+      block = Coradoc::CoreModel::AnnotationBlock.new(
+        annotation_type: "note",
+        content: "This is a note",
+      )
+      doc = make_document(children: [block])
+      result = transformer.call(doc)
+
+      admonition = result.content.first
+      expect(admonition).to be_a(Coradoc::Mirror::Node::Admonition)
+      expect(admonition.admonition_type).to eq("note")
+    end
+  end
+
+  describe "list transformations" do
+    it "transforms unordered list" do
+      list = Coradoc::CoreModel::ListBlock.new(
+        marker_type: "unordered",
+        items: [
+          Coradoc::CoreModel::ListItem.new(content: "First"),
+          Coradoc::CoreModel::ListItem.new(content: "Second"),
+        ],
+      )
+      doc = make_document(children: [list])
+      result = transformer.call(doc)
+
+      ul = result.content.first
+      expect(ul).to be_a(Coradoc::Mirror::Node::BulletList)
+      expect(ul.content.length).to eq(2)
+      expect(ul.content.first).to be_a(Coradoc::Mirror::Node::ListItem)
+      expect(ul.content.first.content.first.text).to eq("First")
+    end
+
+    it "transforms ordered list" do
+      list = Coradoc::CoreModel::ListBlock.new(
+        marker_type: "ordered",
+        items: [
+          Coradoc::CoreModel::ListItem.new(content: "Step 1"),
+          Coradoc::CoreModel::ListItem.new(content: "Step 2"),
+        ],
+      )
+      doc = make_document(children: [list])
+      result = transformer.call(doc)
+
+      ol = result.content.first
+      expect(ol).to be_a(Coradoc::Mirror::Node::OrderedList)
+      expect(ol.content.length).to eq(2)
+    end
+
+    it "transforms list with nested list" do
+      inner = Coradoc::CoreModel::ListBlock.new(
+        marker_type: "unordered",
+        items: [Coradoc::CoreModel::ListItem.new(content: "Nested")],
+      )
+      list = Coradoc::CoreModel::ListBlock.new(
+        marker_type: "unordered",
+        items: [
+          Coradoc::CoreModel::ListItem.new(
+            content: "Parent",
+            nested_list: inner,
+          ),
+        ],
+      )
+      doc = make_document(children: [list])
+      result = transformer.call(doc)
+
+      ul = result.content.first
+      item = ul.content.first
+      nested = item.content.last
+      expect(nested).to be_a(Coradoc::Mirror::Node::BulletList)
+    end
+
+    it "transforms definition list" do
+      dl = Coradoc::CoreModel::DefinitionList.new(
+        items: [
+          Coradoc::CoreModel::DefinitionItem.new(
+            term: "API",
+            definitions: ["Application Programming Interface"],
+          ),
+        ],
+      )
+      doc = make_document(children: [dl])
+      result = transformer.call(doc)
+
+      mirror_dl = result.content.first
+      expect(mirror_dl).to be_a(Coradoc::Mirror::Node::DefinitionList)
+      expect(mirror_dl.content.length).to eq(2) # term + description
+      expect(mirror_dl.content.first).to be_a(Coradoc::Mirror::Node::DefinitionTerm)
+      expect(mirror_dl.content.last).to be_a(Coradoc::Mirror::Node::DefinitionDescription)
+    end
+  end
+
+  describe "table transformation" do
+    it "transforms table with header and body" do
+      table = Coradoc::CoreModel::Table.new(
+        title: "Data",
+        rows: [
+          Coradoc::CoreModel::TableRow.new(
+            header: true,
+            cells: [
+              Coradoc::CoreModel::TableCell.new(content: "Name", header: true),
+              Coradoc::CoreModel::TableCell.new(content: "Value", header: true),
+            ],
+          ),
+          Coradoc::CoreModel::TableRow.new(
+            cells: [
+              Coradoc::CoreModel::TableCell.new(content: "Foo"),
+              Coradoc::CoreModel::TableCell.new(content: "Bar"),
+            ],
+          ),
+        ],
+      )
+      doc = make_document(children: [table])
+      result = transformer.call(doc)
+
+      mirror_table = result.content.first
+      expect(mirror_table).to be_a(Coradoc::Mirror::Node::Table)
+      expect(mirror_table.title).to eq("Data")
+      expect(mirror_table.content.length).to eq(2) # head + body
+
+      head = mirror_table.content.first
+      expect(head).to be_a(Coradoc::Mirror::Node::TableHead)
+      body = mirror_table.content.last
+      expect(body).to be_a(Coradoc::Mirror::Node::TableBody)
+    end
+  end
+
+  describe "image transformation" do
+    it "transforms image with all attributes" do
+      image = Coradoc::CoreModel::Image.new(
+        src: "images/diagram.png",
+        alt: "Diagram",
+        caption: "Figure 1",
+        width: "800px",
+      )
+      doc = make_document(children: [image])
+      result = transformer.call(doc)
+
+      mirror_img = result.content.first
+      expect(mirror_img).to be_a(Coradoc::Mirror::Node::Image)
+      expect(mirror_img.src).to eq("images/diagram.png")
+      expect(mirror_img.alt).to eq("Diagram")
+      expect(mirror_img.caption).to eq("Figure 1")
+      expect(mirror_img.width).to eq("800px")
+    end
+  end
+
+  describe "inline element transformation" do
+    it "transforms bold text" do
+      bold = Coradoc::CoreModel::BoldElement.new(content: "important")
+      para = Coradoc::CoreModel::ParagraphBlock.new(children: [bold])
+      doc = make_document(children: [para])
+      result = transformer.call(doc)
+
+      para_node = result.content.first
+      text_node = para_node.content.first
+      expect(text_node).to be_a(Coradoc::Mirror::Node::Text)
+      expect(text_node.text).to eq("important")
+      expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::Bold)
+    end
+
+    it "transforms italic text" do
+      italic = Coradoc::CoreModel::ItalicElement.new(content: "emphasis")
+      para = Coradoc::CoreModel::ParagraphBlock.new(children: [italic])
+      doc = make_document(children: [para])
+      result = transformer.call(doc)
+
+      text_node = result.content.first.content.first
+      expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::Italic)
+    end
+
+    it "transforms monospace text" do
+      mono = Coradoc::CoreModel::MonospaceElement.new(content: "code")
+      para = Coradoc::CoreModel::ParagraphBlock.new(children: [mono])
+      doc = make_document(children: [para])
+      result = transformer.call(doc)
+
+      text_node = result.content.first.content.first
+      expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::Monospace)
+    end
+
+    it "transforms link" do
+      link = Coradoc::CoreModel::LinkElement.new(
+        content: "Click here",
+        target: "https://example.com",
+      )
+      para = Coradoc::CoreModel::ParagraphBlock.new(children: [link])
+      doc = make_document(children: [para])
+      result = transformer.call(doc)
+
+      text_node = result.content.first.content.first
+      expect(text_node.text).to eq("Click here")
+      expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::Link)
+      expect(text_node.marks.first.href).to eq("https://example.com")
+    end
+
+    it "transforms cross-reference" do
+      xref = Coradoc::CoreModel::CrossReferenceElement.new(
+        content: "Section 1",
+        target: "section-1",
+      )
+      para = Coradoc::CoreModel::ParagraphBlock.new(children: [xref])
+      doc = make_document(children: [para])
+      result = transformer.call(doc)
+
+      text_node = result.content.first.content.first
+      expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::CrossReference)
+      expect(text_node.marks.first.target).to eq("section-1")
+    end
+
+    it "transforms subscript and superscript" do
+      sub = Coradoc::CoreModel::SubscriptElement.new(content: "2")
+      sup = Coradoc::CoreModel::SuperscriptElement.new(content: "nd")
+      para = Coradoc::CoreModel::ParagraphBlock.new(children: [sub, sup])
+      doc = make_document(children: [para])
+      result = transformer.call(doc)
+
+      nodes = result.content.first.content
+      expect(nodes[0].marks.first).to be_a(Coradoc::Mirror::Mark::Subscript)
+      expect(nodes[1].marks.first).to be_a(Coradoc::Mirror::Mark::Superscript)
+    end
+
+    it "transforms highlight" do
+      highlight = Coradoc::CoreModel::HighlightElement.new(content: "noted")
+      para = Coradoc::CoreModel::ParagraphBlock.new(children: [highlight])
+      doc = make_document(children: [para])
+      result = transformer.call(doc)
+
+      text_node = result.content.first.content.first
+      expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::Highlight)
+    end
+
+    it "transforms text content" do
+      text = Coradoc::CoreModel::TextContent.new(text: "plain text")
+      para = Coradoc::CoreModel::ParagraphBlock.new(children: [text])
+      doc = make_document(children: [para])
+      result = transformer.call(doc)
+
+      text_node = result.content.first.content.first
+      expect(text_node.text).to eq("plain text")
+      expect(text_node.marks).to be_empty
+    end
+  end
+
+  describe "bibliography transformation" do
+    it "transforms bibliography with entries" do
+      bib = Coradoc::CoreModel::Bibliography.new(
+        title: "References",
+        entries: [
+          Coradoc::CoreModel::BibliographyEntry.new(
+            anchor_name: "ISO712",
+            document_id: "ISO 712",
+            ref_text: "Cereals and cereal products",
+          ),
+        ],
+      )
+      doc = make_document(children: [bib])
+      result = transformer.call(doc)
+
+      mirror_bib = result.content.first
+      expect(mirror_bib).to be_a(Coradoc::Mirror::Node::Bibliography)
+      expect(mirror_bib.title).to eq("References")
+      entry = mirror_bib.content.first
+      expect(entry).to be_a(Coradoc::Mirror::Node::BibliographyEntry)
+      expect(entry.document_id).to eq("ISO 712")
+    end
+  end
+
+  describe "footnote transformation" do
+    it "transforms footnote and collects at document end" do
+      fn = Coradoc::CoreModel::Footnote.new(id: "fn1", content: "A footnote.")
+      para = make_paragraph("Text with footnote")
+      doc = make_document(children: [para, fn])
+      result = transformer.call(doc)
+
+      # Last content should be footnotes block
+      footnotes = result.content.last
+      expect(footnotes).to be_a(Coradoc::Mirror::Node::Footnotes)
+      entry = footnotes.content.first
+      expect(entry).to be_a(Coradoc::Mirror::Node::FootnoteEntry)
+      expect(entry.number).to eq(1)
+    end
+  end
+
+  describe "kitchen sink" do
+    it "transforms a complex document with multiple element types" do
+      doc = make_document(title: "Kitchen Sink", children: [
+        make_section(title: "Overview", level: 1, children: [
+          make_paragraph("Welcome to the test document."),
+          Coradoc::CoreModel::SourceBlock.new(
+            content: "puts 'hello'",
+            language: "ruby",
+          ),
+          Coradoc::CoreModel::ListBlock.new(
+            marker_type: "unordered",
+            items: [
+              Coradoc::CoreModel::ListItem.new(content: "Item 1"),
+              Coradoc::CoreModel::ListItem.new(content: "Item 2"),
+            ],
+          ),
+        ]),
+        make_section(title: "Details", level: 2, children: [
+          Coradoc::CoreModel::AnnotationBlock.new(
+            annotation_type: "warning",
+            content: "Be careful!",
+          ),
+          Coradoc::CoreModel::Image.new(
+            src: "diagram.png",
+            alt: "Architecture",
+          ),
+        ]),
+      ])
+
+      result = transformer.call(doc)
+      json = result.to_json(pretty: true)
+      parsed = JSON.parse(json)
+
+      # Verify structure
+      expect(parsed["type"]).to eq("doc")
+      expect(parsed["attrs"]["title"]).to eq("Kitchen Sink")
+      expect(parsed["content"].length).to eq(2)
+
+      # Section 1
+      s1 = parsed["content"][0]
+      expect(s1["type"]).to eq("section")
+      expect(s1["attrs"]["title"]).to eq("Overview")
+      expect(s1["content"].length).to eq(3)
+
+      # Section 2
+      s2 = parsed["content"][1]
+      expect(s2["type"]).to eq("section")
+      expect(s2["attrs"]["title"]).to eq("Details")
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/handler_registry_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handler_registry_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Coradoc::Mirror::HandlerRegistry do
+  describe "#register and #entry_for" do
+    it "finds a registered handler by exact class" do
+      registry = described_class.new
+      handler = ->(el, ctx) { el }
+      registry.register(Coradoc::CoreModel::ParagraphBlock, handler)
+
+      entry = registry.entry_for(Coradoc::CoreModel::ParagraphBlock.new)
+      expect(entry.handler).to eq(handler)
+    end
+
+    it "finds a handler via ancestor walk" do
+      registry = described_class.new
+      handler = ->(el, ctx) { el }
+      registry.register(Coradoc::CoreModel::Block, handler)
+
+      # SourceBlock inherits from Block
+      entry = registry.entry_for(Coradoc::CoreModel::SourceBlock.new)
+      expect(entry.handler).to eq(handler)
+    end
+
+    it "prefers exact match over ancestor" do
+      registry = described_class.new
+      base_handler = ->(el, ctx) { :base }
+      specific_handler = ->(el, ctx) { :specific }
+      registry.register(Coradoc::CoreModel::Block, base_handler)
+      registry.register(Coradoc::CoreModel::SourceBlock, specific_handler)
+
+      entry = registry.entry_for(Coradoc::CoreModel::SourceBlock.new)
+      expect(entry.handler).to eq(specific_handler)
+    end
+
+    it "returns nil for unregistered class" do
+      registry = described_class.new
+      entry = registry.entry_for(Coradoc::CoreModel::ParagraphBlock.new)
+      expect(entry).to be_nil
+    end
+  end
+
+  describe "#registered?" do
+    it "returns true for registered class" do
+      registry = described_class.new
+      registry.register(Coradoc::CoreModel::Block, ->(el, ctx) { el })
+      expect(registry.registered?(Coradoc::CoreModel::Block)).to be true
+    end
+
+    it "returns false for unregistered class" do
+      registry = described_class.new
+      expect(registry.registered?(Coradoc::CoreModel::Block)).to be false
+    end
+  end
+
+  describe "#handle" do
+    it "dispatches to handler and returns result with concat flag" do
+      registry = described_class.new
+      handler = Module.new do
+        def self.call(element, context:)
+          "handled: #{element.class}"
+        end
+      end
+      registry.register(Coradoc::CoreModel::ParagraphBlock, handler)
+
+      element = Coradoc::CoreModel::ParagraphBlock.new
+      result = registry.handle(element, context: nil)
+      expect(result).to eq(["handled: Coradoc::CoreModel::ParagraphBlock", false])
+    end
+
+    it "dispatches to Proc handler" do
+      registry = described_class.new
+      handler = ->(element, context) { "proc: #{element.class}" }
+      registry.register(Coradoc::CoreModel::Block, handler)
+
+      element = Coradoc::CoreModel::Block.new
+      result = registry.handle(element, context: nil)
+      expect(result).to eq(["proc: Coradoc::CoreModel::Block", false])
+    end
+
+    it "dispatches to specific method name" do
+      registry = described_class.new
+      handler = Module.new do
+        def self.convert(element, context:)
+          "converted"
+        end
+      end
+      registry.register(Coradoc::CoreModel::Block, handler, method_name: :convert)
+
+      element = Coradoc::CoreModel::Block.new
+      result = registry.handle(element, context: nil)
+      expect(result).to eq(["converted", false])
+    end
+
+    it "passes extra_kwargs to handler" do
+      registry = described_class.new
+      handler = Module.new do
+        def self.call(element, context:, extra_option: nil)
+          "extra: #{extra_option}"
+        end
+      end
+      registry.register(Coradoc::CoreModel::Block, handler, extra_kwargs: { extra_option: "yes" })
+
+      element = Coradoc::CoreModel::Block.new
+      result = registry.handle(element, context: nil)
+      expect(result).to eq(["extra: yes", false])
+    end
+
+    it "returns nil for unregistered element" do
+      registry = described_class.new
+      element = Coradoc::CoreModel::Block.new
+      result = registry.handle(element, context: nil)
+      expect(result).to be_nil
+    end
+
+    it "supports concat flag" do
+      registry = described_class.new
+      handler = ->(element, context) { [1, 2, 3] }
+      registry.register(Coradoc::CoreModel::Block, handler, concat: true)
+
+      element = Coradoc::CoreModel::Block.new
+      result = registry.handle(element, context: nil)
+      expect(result).to eq([[1, 2, 3], true])
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/generic_block_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/generic_block_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Mirror::Handlers::GenericBlock do
+  let(:context) { Coradoc::Mirror::CoreModelToMirror.new }
+
+  describe ".call" do
+    it "returns nil if content is empty" do
+      block_class = Class.new(Coradoc::CoreModel::Block)
+      element = block_class.new
+
+      result = described_class.call(element, context: context)
+      expect(result).to be_nil
+    end
+
+    it "creates a generic block node with semantic type" do
+      block_class = Class.new(Coradoc::CoreModel::Block) do
+        def resolve_semantic_type
+          :test_type
+        end
+      end
+
+      element = block_class.new(
+        id: "block-1",
+        title: "Test Block",
+        children: [Coradoc::CoreModel::TextContent.new(text: "Some text")]
+      )
+
+      result = described_class.call(element, context: context)
+
+      expect(result).to be_a(Coradoc::Mirror::Node::GenericBlock)
+      expect(result.id).to eq("block-1")
+      expect(result.title).to eq("Test Block")
+      expect(result.semantic_type).to eq("test_type")
+      expect(result.content.length).to eq(1)
+      expect(result.content.first.type).to eq("text")
+      expect(result.content.first.text).to eq("Some text")
+    end
+
+    it "creates a generic block node without semantic type" do
+      block_class = Class.new(Coradoc::CoreModel::Block) do
+        def resolve_semantic_type
+          nil
+        end
+      end
+
+      element = block_class.new(
+        children: [Coradoc::CoreModel::TextContent.new(text: "Some text")]
+      )
+
+      result = described_class.call(element, context: context)
+
+      expect(result).to be_a(Coradoc::Mirror::Node::GenericBlock)
+      expect(result.id).to be_nil
+      expect(result.title).to be_nil
+      expect(result.semantic_type).to be_nil
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/inline_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/inline_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Mirror::Handlers::Inline do
+  let(:context) { Coradoc::Mirror::CoreModelToMirror.new }
+
+  describe ".process" do
+    it "processes simple marks" do
+      bold = Coradoc::CoreModel::BoldElement.new(content: "bold text")
+      element = Coradoc::CoreModel::ParagraphBlock.new(
+        children: [bold]
+      )
+      
+      nodes = described_class.process(element, context: context)
+      expect(nodes.length).to eq(1)
+      expect(nodes.first.type).to eq("text")
+      expect(nodes.first.text).to eq("bold text")
+      expect(nodes.first.marks.first.type).to eq("bold")
+    end
+
+    it "processes text content" do
+      text = Coradoc::CoreModel::TextContent.new(text: "plain text")
+      element = Coradoc::CoreModel::ParagraphBlock.new(
+        children: [text]
+      )
+      
+      nodes = described_class.process(element, context: context)
+      expect(nodes.length).to eq(1)
+      expect(nodes.first.type).to eq("text")
+      expect(nodes.first.text).to eq("plain text")
+    end
+
+    it "processes semantic marks like links" do
+      link = Coradoc::CoreModel::LinkElement.new(
+        target: "https://example.com",
+        content: "Example"
+      )
+      element = Coradoc::CoreModel::ParagraphBlock.new(
+        children: [link]
+      )
+      
+      nodes = described_class.process(element, context: context)
+      expect(nodes.length).to eq(1)
+      expect(nodes.first.type).to eq("text")
+      expect(nodes.first.text).to eq("Example")
+      expect(nodes.first.marks.first.type).to eq("link")
+      expect(nodes.first.marks.first.href).to eq("https://example.com")
+    end
+  end
+
+  describe ".text_content" do
+    it "returns nil for empty text" do
+      text = Coradoc::CoreModel::TextContent.new(text: "")
+      node = described_class.text_content(text, context: context)
+      expect(node).to be_nil
+    end
+
+    it "returns text node" do
+      text = Coradoc::CoreModel::TextContent.new(text: "hello")
+      node = described_class.text_content(text, context: context)
+      expect(node.type).to eq("text")
+      expect(node.text).to eq("hello")
+    end
+  end
+
+  describe ".call" do
+    it "handles inline element directly" do
+      italic = Coradoc::CoreModel::ItalicElement.new(content: "italic text")
+      node = described_class.call(italic, context: context)
+      
+      expect(node.type).to eq("text")
+      expect(node.text).to eq("italic text")
+      expect(node.marks.first.type).to eq("italic")
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/structural_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/structural_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Mirror::Handlers::Structural do
+  let(:context) { Coradoc::Mirror::CoreModelToMirror.new }
+
+  describe ".document" do
+    it "creates a document node" do
+      element = Coradoc::CoreModel::DocumentElement.new(
+        title: "Test Document",
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: "Content")]
+      )
+
+      node = described_class.document(element, context: context)
+      expect(node).to be_a(Coradoc::Mirror::Node::Document)
+      expect(node.type).to eq("doc")
+      expect(node.title).to eq("Test Document")
+      expect(node.content.length).to eq(1)
+    end
+  end
+
+  describe ".section" do
+    it "creates a section node" do
+      element = Coradoc::CoreModel::SectionElement.new(
+        id: "sec-1",
+        title: "Test Section",
+        level: 2,
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: "Content")]
+      )
+      
+      node = described_class.section(element, context: context)
+      expect(node).to be_a(Coradoc::Mirror::Node::Section)
+      expect(node.type).to eq("section")
+      expect(node.id).to eq("sec-1")
+      expect(node.title).to eq("Test Section")
+      expect(node.level).to eq(2)
+      expect(node.content.length).to eq(1)
+    end
+  end
+
+  describe ".preamble" do
+    it "creates a preamble node" do
+      element = Coradoc::CoreModel::PreambleElement.new(
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: "Content")]
+      )
+
+      node = described_class.preamble(element, context: context)
+      expect(node).to be_a(Coradoc::Mirror::Node::Preamble)
+      expect(node.type).to eq("preamble")
+      expect(node.content.length).to eq(1)
+    end
+  end
+
+  describe ".header" do
+    it "creates a header node" do
+      element = Coradoc::CoreModel::HeaderElement.new(
+        title: "Main Title",
+        level: 1,
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: "Author info")]
+      )
+      
+      node = described_class.header(element, context: context)
+      expect(node).to be_a(Coradoc::Mirror::Node::Header)
+      expect(node.type).to eq("header")
+      expect(node.title).to eq("Main Title")
+      expect(node.level).to eq(1)
+      expect(node.content.length).to eq(1)
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/toc_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/toc_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+RSpec.describe Coradoc::Mirror::Handlers::Toc do
+  let(:context) { Coradoc::Mirror::CoreModelToMirror.new }
+
+  describe ".call" do
+    it "creates a toc node with entries" do
+      entry1 = Coradoc::CoreModel::TocEntry.new(
+        id: "sec-1",
+        title: "Section 1",
+        level: 1
+      )
+      
+      entry2 = Coradoc::CoreModel::TocEntry.new(
+        id: "sec-1-1",
+        title: "Section 1.1",
+        level: 2
+      )
+      
+      entry1.children = [entry2]
+      
+      element = Coradoc::CoreModel::Toc.new(
+        title: "Table of Contents",
+        entries: [entry1]
+      )
+      
+      node = described_class.call(element, context: context)
+      expect(node).to be_a(Coradoc::Mirror::Node::Toc)
+      expect(node.type).to eq("toc")
+      expect(node.title).to eq("Table of Contents")
+      expect(node.content.length).to eq(1)
+      
+      entry_node = node.content.first
+      expect(entry_node).to be_a(Coradoc::Mirror::Node::TocEntry)
+      expect(entry_node.id).to eq("sec-1")
+      expect(entry_node.title).to eq("Section 1")
+      expect(entry_node.level).to eq(1)
+      
+      sub_entry_node = entry_node.content.first
+      expect(sub_entry_node).to be_a(Coradoc::Mirror::Node::TocEntry)
+      expect(sub_entry_node.id).to eq("sec-1-1")
+    end
+
+    it "creates empty toc node if no entries" do
+      element = Coradoc::CoreModel::Toc.new(title: "Empty TOC")
+      
+      node = described_class.call(element, context: context)
+      expect(node.type).to eq("toc")
+      expect(node.title).to eq("Empty TOC")
+      expect(node.content).to be_empty
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/integration_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/integration_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "yaml"
+
+RSpec.describe "End-to-end integration" do
+  describe "YAML output" do
+    it "produces valid YAML output" do
+      doc = Coradoc::CoreModel::DocumentElement.new(
+        title: "YAML Test",
+        children: [
+          Coradoc::CoreModel::ParagraphBlock.new(content: "Hello"),
+        ],
+      )
+
+      yaml = Coradoc::Mirror.to_yaml(doc)
+      parsed = YAML.safe_load(yaml)
+      expect(parsed["type"]).to eq("doc")
+      expect(parsed["attrs"]["title"]).to eq("YAML Test")
+    end
+
+    it "round-trips YAML serialization" do
+      doc = Coradoc::CoreModel::DocumentElement.new(
+        title: "YAML Round Trip",
+        children: [
+          Coradoc::CoreModel::SectionElement.new(
+            title: "Section",
+            level: 1,
+            children: [
+              Coradoc::CoreModel::ParagraphBlock.new(content: "Text"),
+            ],
+          ),
+        ],
+      )
+
+      yaml = Coradoc::Mirror.to_yaml(doc)
+      mirror_node = Coradoc::Mirror::Node.from_h(YAML.safe_load(yaml))
+      expect(mirror_node).to be_a(Coradoc::Mirror::Node::Document)
+      expect(mirror_node.title).to eq("YAML Round Trip")
+    end
+  end
+
+  describe "Transformer facade" do
+    it "supports forward and reverse transformation" do
+      transformer = Coradoc::Mirror::Transformer.new
+
+      doc = Coradoc::CoreModel::DocumentElement.new(
+        title: "Test",
+        children: [
+          Coradoc::CoreModel::ParagraphBlock.new(content: "Content"),
+        ],
+      )
+
+      mirror = transformer.from_core_model(doc)
+      expect(mirror).to be_a(Coradoc::Mirror::Node::Document)
+
+      restored = transformer.to_core_model(mirror)
+      expect(restored).to be_a(Coradoc::CoreModel::DocumentElement)
+      expect(restored.title).to eq("Test")
+    end
+  end
+
+  describe "JSON round-trip" do
+    it "serializes and deserializes through JSON" do
+      original = Coradoc::CoreModel::DocumentElement.new(
+        title: "JSON Round Trip",
+        children: [
+          Coradoc::CoreModel::SectionElement.new(
+            title: "Intro",
+            level: 1,
+            id: "intro",
+            children: [
+              Coradoc::CoreModel::ParagraphBlock.new(content: "Hello"),
+            ],
+          ),
+        ],
+      )
+
+      json = Coradoc::Mirror.to_json(original, pretty: true)
+      parsed = JSON.parse(json)
+
+      # Reconstruct from JSON
+      mirror_node = Coradoc::Mirror::Node.from_h(parsed)
+      expect(mirror_node).to be_a(Coradoc::Mirror::Node::Document)
+      expect(mirror_node.title).to eq("JSON Round Trip")
+    end
+  end
+
+  describe "with AsciiDoc", if: Gem.loaded_specs.key?("coradoc-adoc") do
+    before(:each) do
+      require "coradoc/asciidoc"
+    end
+
+    it "transforms a complete AsciiDoc document to mirror JSON" do
+      adoc = <<~ADOC
+        = Integration Test
+        Author Name
+
+        == Introduction
+
+        This has *bold* and _italic_ text.
+
+        === Details
+
+        [source,ruby]
+        ----
+        def hello
+          puts "world"
+        end
+        ----
+
+        * Item one
+        * Item two
+
+        NOTE: Pay attention to this.
+      ADOC
+
+      doc = Coradoc.parse(adoc, format: :asciidoc)
+      mirror = Coradoc::Mirror.transform(doc)
+
+      expect(mirror).to be_a(Coradoc::Mirror::Node::Document)
+      expect(mirror.title).to eq("Integration Test")
+
+      json = mirror.to_json(pretty: true)
+      parsed = JSON.parse(json)
+      expect(parsed["type"]).to eq("doc")
+      expect(parsed["content"].length).to be >= 2
+
+      sections = parsed["content"].select { |c| c["type"] == "section" }
+      expect(sections.length).to be >= 1
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/mark_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mark_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Coradoc::Mirror::Mark do
+  describe "construction" do
+    it "creates a mark with type" do
+      mark = described_class.new
+      expect(mark.type).to eq("mark")
+    end
+
+    it "uses PM_TYPE as default type" do
+      mark = described_class.new
+      expect(mark.type).to eq("mark")
+    end
+  end
+
+  describe "serialization" do
+    it "serializes to hash" do
+      mark = Coradoc::Mirror::Mark::Bold.new
+      expect(mark.to_h).to eq({ "type" => "bold" })
+    end
+
+    it "includes attrs when present" do
+      mark = Coradoc::Mirror::Mark::Link.new(href: "https://example.com")
+      expect(mark.to_h).to eq({
+        "type" => "link",
+        "attrs" => { "href" => "https://example.com" },
+      })
+    end
+  end
+
+  describe "deserialization" do
+    it "reconstructs from hash" do
+      hash = { "type" => "bold" }
+      mark = described_class.from_h(hash)
+      expect(mark).to be_a(Coradoc::Mirror::Mark::Bold)
+    end
+
+    it "returns nil for nil input" do
+      expect(described_class.from_h(nil)).to be_nil
+    end
+
+    it "handles unknown types as generic Mark" do
+      hash = { "type" => "custom_mark" }
+      mark = described_class.from_h(hash)
+      expect(mark).to be_a(described_class)
+      expect(mark.type).to eq("custom_mark")
+    end
+
+    it "deserializes link with href" do
+      hash = {
+        "type" => "link",
+        "attrs" => { "href" => "https://example.com" },
+      }
+      mark = described_class.from_h(hash)
+      expect(mark).to be_a(Coradoc::Mirror::Mark::Link)
+    end
+  end
+
+  describe "mark type subclasses" do
+    it "registers all subclasses in MARKS map" do
+      marks = described_class::MARKS
+      expect(marks["bold"]).to eq(Coradoc::Mirror::Mark::Bold)
+      expect(marks["italic"]).to eq(Coradoc::Mirror::Mark::Italic)
+      expect(marks["code"]).to eq(Coradoc::Mirror::Mark::Monospace)
+      expect(marks["link"]).to eq(Coradoc::Mirror::Mark::Link)
+      expect(marks["xref"]).to eq(Coradoc::Mirror::Mark::CrossReference)
+      expect(marks["highlight"]).to eq(Coradoc::Mirror::Mark::Highlight)
+      expect(marks["subscript"]).to eq(Coradoc::Mirror::Mark::Subscript)
+      expect(marks["superscript"]).to eq(Coradoc::Mirror::Mark::Superscript)
+    end
+
+    it "Link stores href in attrs" do
+      mark = Coradoc::Mirror::Mark::Link.new(href: "https://example.com")
+      expect(mark.href).to eq("https://example.com")
+      hash = mark.to_h
+      expect(hash["attrs"]["href"]).to eq("https://example.com")
+    end
+
+    it "CrossReference stores target in attrs" do
+      mark = Coradoc::Mirror::Mark::CrossReference.new(target: "section-1")
+      expect(mark.target).to eq("section-1")
+    end
+
+    it "Stem stores stem_type in attrs" do
+      mark = Coradoc::Mirror::Mark::Stem.new(stem_type: "latex")
+      expect(mark.stem_type).to eq("latex")
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/mirror_json_format_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mirror_json_format_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+require "json"
+
+RSpec.describe Coradoc::Mirror::MirrorJsonFormat do
+  let(:document) do
+    Coradoc::CoreModel::DocumentElement.new(
+      title: "Test",
+      children: [
+        Coradoc::CoreModel::ParagraphBlock.new(content: "Hello")
+      ]
+    )
+  end
+
+  describe ".serialize" do
+    it "serializes a CoreModel document to Mirror JSON" do
+      json = described_class.serialize(document)
+      parsed = JSON.parse(json)
+      
+      expect(parsed["type"]).to eq("doc")
+      expect(parsed["attrs"]["title"]).to eq("Test")
+      expect(parsed["content"].first["type"]).to eq("paragraph")
+    end
+  end
+
+  describe ".parse_to_core" do
+    it "raises UnsupportedFormatError" do
+      expect {
+        described_class.parse_to_core("{}")
+      }.to raise_error(Coradoc::UnsupportedFormatError, /Parsing from mirror JSON is not supported/)
+    end
+  end
+
+  describe ".serialize?" do
+    it "returns true" do
+      expect(described_class.serialize?).to be true
+    end
+  end
+
+  describe ".handles_model?" do
+    it "returns false" do
+      expect(described_class.handles_model?(Object.new)).to be false
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/mirror_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mirror_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Coradoc::Mirror do
+  describe ".default_registry" do
+    it "returns a HandlerRegistry with core handlers" do
+      registry = described_class.default_registry
+      expect(registry).to be_a(Coradoc::Mirror::HandlerRegistry)
+
+      # Verify key registrations
+      expect(registry.registered?(Coradoc::CoreModel::DocumentElement)).to be true
+      expect(registry.registered?(Coradoc::CoreModel::SectionElement)).to be true
+      expect(registry.registered?(Coradoc::CoreModel::ParagraphBlock)).to be true
+      expect(registry.registered?(Coradoc::CoreModel::SourceBlock)).to be true
+      expect(registry.registered?(Coradoc::CoreModel::ListBlock)).to be true
+      expect(registry.registered?(Coradoc::CoreModel::Table)).to be true
+      expect(registry.registered?(Coradoc::CoreModel::Image)).to be true
+      expect(registry.registered?(Coradoc::CoreModel::AnnotationBlock)).to be true
+    end
+  end
+
+  describe ".transform" do
+    it "transforms a CoreModel document to mirror in one call" do
+      doc = Coradoc::CoreModel::DocumentElement.new(
+        title: "Quick Test",
+        children: [
+          Coradoc::CoreModel::ParagraphBlock.new(content: "Hello"),
+        ],
+      )
+
+      result = described_class.transform(doc)
+      expect(result).to be_a(Coradoc::Mirror::Node::Document)
+      expect(result.title).to eq("Quick Test")
+    end
+  end
+
+  describe ".to_json" do
+    it "transforms and serializes to JSON" do
+      doc = Coradoc::CoreModel::DocumentElement.new(
+        title: "JSON Test",
+        children: [
+          Coradoc::CoreModel::ParagraphBlock.new(content: "World"),
+        ],
+      )
+
+      json = described_class.to_json(doc)
+      parsed = JSON.parse(json)
+      expect(parsed["type"]).to eq("doc")
+      expect(parsed["attrs"]["title"]).to eq("JSON Test")
+    end
+
+    it "produces pretty JSON when requested" do
+      doc = Coradoc::CoreModel::DocumentElement.new(title: "Pretty")
+      json = described_class.to_json(doc, pretty: true)
+      expect(json).to include("\n")
+      expect(json).to include("  ")
+    end
+  end
+
+  describe "VERSION" do
+    it "has a version constant" do
+      expect(Coradoc::Mirror::VERSION).to match(/\A\d+\.\d+\.\d+\z/)
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/mirror_to_core_model_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mirror_to_core_model_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "yaml"
+
+RSpec.describe Coradoc::Mirror::MirrorToCoreModel do
+  let(:reverse) { described_class.new }
+
+  describe "round-trip: CoreModel → Mirror → CoreModel" do
+    it "round-trips a simple document with title and paragraphs" do
+      original = Coradoc::CoreModel::DocumentElement.new(
+        title: "Round Trip",
+        children: [
+          Coradoc::CoreModel::ParagraphBlock.new(
+            content: "Hello world",
+          ),
+        ],
+      )
+
+      mirror = Coradoc::Mirror.transform(original)
+      restored = reverse.call(mirror)
+
+      expect(restored).to be_a(Coradoc::CoreModel::DocumentElement)
+      expect(restored.title).to eq("Round Trip")
+      expect(restored.children).not_to be_empty
+    end
+
+    it "round-trips sections with levels" do
+      original = Coradoc::CoreModel::DocumentElement.new(
+        title: "Doc",
+        children: [
+          Coradoc::CoreModel::SectionElement.new(
+            title: "Section One",
+            level: 1,
+            id: "section-one",
+            children: [
+              Coradoc::CoreModel::ParagraphBlock.new(content: "Content"),
+            ],
+          ),
+        ],
+      )
+
+      mirror = Coradoc::Mirror.transform(original)
+      restored = reverse.call(mirror)
+
+      section = restored.children.first
+      expect(section).to be_a(Coradoc::CoreModel::SectionElement)
+      expect(section.title).to eq("Section One")
+      expect(section.level).to eq(1)
+      expect(section.id).to eq("section-one")
+    end
+
+    it "round-trips code blocks with language" do
+      original = Coradoc::CoreModel::SourceBlock.new(
+        content: "puts 'hi'",
+        language: "ruby",
+      )
+
+      mirror = Coradoc::Mirror.transform(
+        Coradoc::CoreModel::DocumentElement.new(children: [original]),
+      )
+      restored = reverse.call(mirror)
+      code = restored.children.first
+
+      expect(code).to be_a(Coradoc::CoreModel::SourceBlock)
+      expect(code.language).to eq("ruby")
+    end
+
+    it "round-trips unordered lists" do
+      original = Coradoc::CoreModel::ListBlock.new(
+        marker_type: "unordered",
+        items: [
+          Coradoc::CoreModel::ListItem.new(content: "First"),
+          Coradoc::CoreModel::ListItem.new(content: "Second"),
+        ],
+      )
+
+      mirror = Coradoc::Mirror.transform(
+        Coradoc::CoreModel::DocumentElement.new(children: [original]),
+      )
+      restored = reverse.call(mirror)
+      list = restored.children.first
+
+      expect(list).to be_a(Coradoc::CoreModel::ListBlock)
+      expect(list.marker_type).to eq("unordered")
+      expect(list.items.length).to eq(2)
+    end
+
+    it "round-trips images" do
+      original = Coradoc::CoreModel::Image.new(
+        src: "photo.png",
+        alt: "Photo",
+        caption: "Figure 1",
+      )
+
+      mirror = Coradoc::Mirror.transform(
+        Coradoc::CoreModel::DocumentElement.new(children: [original]),
+      )
+      restored = reverse.call(mirror)
+      image = restored.children.first
+
+      expect(image).to be_a(Coradoc::CoreModel::Image)
+      expect(image.src).to eq("photo.png")
+      expect(image.alt).to eq("Photo")
+      expect(image.caption).to eq("Figure 1")
+    end
+
+    it "round-trips bold text marks" do
+      bold = Coradoc::CoreModel::BoldElement.new(content: "important")
+      original = Coradoc::CoreModel::ParagraphBlock.new(children: [bold])
+
+      mirror = Coradoc::Mirror.transform(
+        Coradoc::CoreModel::DocumentElement.new(children: [original]),
+      )
+      restored = reverse.call(mirror)
+      para = restored.children.first
+
+      expect(para).to be_a(Coradoc::CoreModel::Block)
+    end
+
+    it "round-trips tables" do
+      original = Coradoc::CoreModel::Table.new(
+        rows: [
+          Coradoc::CoreModel::TableRow.new(
+            cells: [
+              Coradoc::CoreModel::TableCell.new(content: "A"),
+              Coradoc::CoreModel::TableCell.new(content: "B"),
+            ],
+          ),
+        ],
+      )
+
+      mirror = Coradoc::Mirror.transform(
+        Coradoc::CoreModel::DocumentElement.new(children: [original]),
+      )
+      restored = reverse.call(mirror)
+      table = restored.children.first
+
+      expect(table).to be_a(Coradoc::CoreModel::Table)
+      expect(table.rows.length).to eq(1)
+    end
+  end
+
+  describe "error handling" do
+    it "raises error for unknown node type" do
+      node = Coradoc::Mirror::Node.new(type: "completely_unknown_type")
+      expect { reverse.call(node) }.to raise_error(Coradoc::Mirror::Error, /Unknown mirror node type/)
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/node_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/node_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Coradoc::Mirror::Node do
+  describe "construction" do
+    it "creates a basic node with type" do
+      node = described_class.new(type: "custom")
+      expect(node.type).to eq("custom")
+      expect(node.content).to eq([])
+      expect(node.marks).to eq([])
+    end
+
+    it "uses PM_TYPE as default type" do
+      node = described_class.new
+      expect(node.type).to eq("node")
+    end
+  end
+
+  describe "typed attributes" do
+    it "Document has title and id accessors" do
+      doc = described_class::Document.new(title: "My Doc", id: "doc-1")
+      expect(doc.title).to eq("My Doc")
+      expect(doc.id).to eq("doc-1")
+    end
+
+    it "Section has title, id, level accessors" do
+      section = described_class::Section.new(title: "Intro", id: "s1", level: 2)
+      expect(section.title).to eq("Intro")
+      expect(section.id).to eq("s1")
+      expect(section.level).to eq(2)
+    end
+
+    it "CodeBlock has language, title, passthrough accessors" do
+      code = described_class::CodeBlock.new(language: "ruby", title: "Example", passthrough: true)
+      expect(code.language).to eq("ruby")
+      expect(code.title).to eq("Example")
+      expect(code.passthrough).to be true
+    end
+
+    it "Image has src, alt, caption, width, height accessors" do
+      img = described_class::Image.new(src: "img.png", alt: "Alt", caption: "Cap", width: "100")
+      expect(img.src).to eq("img.png")
+      expect(img.alt).to eq("Alt")
+      expect(img.caption).to eq("Cap")
+      expect(img.width).to eq("100")
+      expect(img.height).to be_nil
+    end
+
+    it "TableCell has colspan, rowspan, alignment, header accessors" do
+      cell = described_class::TableCell.new(colspan: 2, header: true, alignment: "center")
+      expect(cell.colspan).to eq(2)
+      expect(cell.header).to be true
+      expect(cell.alignment).to eq("center")
+      expect(cell.rowspan).to be_nil
+    end
+  end
+
+  describe "serialization" do
+    it "serializes to hash with only non-empty fields" do
+      node = described_class.new(type: "paragraph")
+      expect(node.to_h).to eq({ "type" => "paragraph" })
+    end
+
+    it "includes typed attrs when set" do
+      node = described_class::Heading.new(level: 1)
+      expect(node.to_h).to eq({
+        "type" => "heading",
+        "attrs" => { "level" => 1 },
+      })
+    end
+
+    it "omits nil attrs" do
+      node = described_class::Section.new(title: "Intro")
+      expect(node.to_h).to eq({
+        "type" => "section",
+        "attrs" => { "title" => "Intro" },
+      })
+    end
+
+    it "includes content when present" do
+      child = described_class::Text.new(text: "hello")
+      node = described_class::Paragraph.new(content: [child])
+      hash = node.to_h
+      expect(hash["content"]).to be_an(Array)
+      expect(hash["content"].length).to eq(1)
+    end
+
+    it "includes marks when present" do
+      mark = Coradoc::Mirror::Mark::Bold.new
+      node = described_class::Text.new(text: "bold", marks: [mark])
+      hash = node.to_h
+      expect(hash["marks"]).to be_an(Array)
+    end
+
+    it "serializes to JSON" do
+      node = described_class::Paragraph.new
+      json = node.to_json
+      expect(JSON.parse(json)).to eq({ "type" => "paragraph" })
+    end
+
+    it "serializes to pretty JSON" do
+      node = described_class::Paragraph.new
+      json = node.to_json(pretty: true)
+      expect(json).to include("\n")
+    end
+
+    it "serializes to YAML" do
+      node = described_class::Section.new(id: "p1")
+      yaml = node.to_yaml
+      parsed = YAML.safe_load(yaml)
+      expect(parsed["type"]).to eq("section")
+      expect(parsed["attrs"]["id"]).to eq("p1")
+    end
+
+    it "aliases to_hash to to_h" do
+      node = described_class.new(type: "test")
+      expect(node.to_hash).to eq(node.to_h)
+    end
+  end
+
+  describe "deserialization" do
+    it "reconstructs typed nodes from hash" do
+      hash = {
+        "type" => "section",
+        "attrs" => { "title" => "Intro", "level" => 1 },
+        "content" => [
+          { "type" => "paragraph", "content" => [
+            { "type" => "text", "text" => "Hello" },
+          ]},
+        ],
+      }
+
+      node = described_class.from_h(hash)
+      expect(node).to be_a(described_class::Section)
+      expect(node.title).to eq("Intro")
+      expect(node.level).to eq(1)
+      expect(node.content.length).to eq(1)
+
+      para = node.content.first
+      expect(para).to be_a(described_class::Paragraph)
+      expect(para.content.first).to be_a(described_class::Text)
+      expect(para.content.first.text).to eq("Hello")
+    end
+
+    it "returns nil for nil input" do
+      expect(described_class.from_h(nil)).to be_nil
+    end
+
+    it "handles unknown types as generic Node" do
+      hash = { "type" => "unknown_custom_type" }
+      node = described_class.from_h(hash)
+      expect(node).to be_a(described_class)
+      expect(node.type).to eq("unknown_custom_type")
+    end
+  end
+
+  describe "text_content" do
+    it "returns empty string for node with no content" do
+      node = described_class.new
+      expect(node.text_content).to eq("")
+    end
+
+    it "collects text from descendants" do
+      text = described_class::Text.new(text: "Hello ")
+      text2 = described_class::Text.new(text: "World")
+      para = described_class::Paragraph.new(content: [text, text2])
+      expect(para.text_content).to eq("Hello World")
+    end
+  end
+
+  describe "node type subclasses" do
+    it "registers all subclasses in NODES map" do
+      expect(described_class::NODES["doc"]).to eq(described_class::Document)
+      expect(described_class::NODES["paragraph"]).to eq(described_class::Paragraph)
+      expect(described_class::NODES["heading"]).to eq(described_class::Heading)
+      expect(described_class::NODES["code_block"]).to eq(described_class::CodeBlock)
+      expect(described_class::NODES["blockquote"]).to eq(described_class::Blockquote)
+      expect(described_class::NODES["bullet_list"]).to eq(described_class::BulletList)
+      expect(described_class::NODES["ordered_list"]).to eq(described_class::OrderedList)
+      expect(described_class::NODES["list_item"]).to eq(described_class::ListItem)
+      expect(described_class::NODES["image"]).to eq(described_class::Image)
+      expect(described_class::NODES["table"]).to eq(described_class::Table)
+      expect(described_class::NODES["section"]).to eq(described_class::Section)
+      expect(described_class::NODES["admonition"]).to eq(described_class::Admonition)
+    end
+
+    it "Text node has text attribute" do
+      node = described_class::Text.new(text: "Hello")
+      expect(node.text).to eq("Hello")
+      expect(node.to_h["text"]).to eq("Hello")
+      expect(node.text_content).to eq("Hello")
+    end
+
+    it "Text node deserializes with marks" do
+      hash = {
+        "type" => "text",
+        "text" => "bold text",
+        "marks" => [{ "type" => "bold" }],
+      }
+      node = described_class::Text.from_h(hash)
+      expect(node.text).to eq("bold text")
+      expect(node.marks.length).to eq(1)
+      expect(node.marks.first).to be_a(Coradoc::Mirror::Mark::Bold)
+    end
+
+    it "round-trips through serialization" do
+      doc = described_class::Document.new(
+        title: "Test",
+        content: [
+          described_class::Section.new(
+            level: 1,
+            title: "Intro",
+            content: [
+              described_class::Paragraph.new(
+                content: [
+                  described_class::Text.new(
+                    text: "Hello ",
+                    marks: [Coradoc::Mirror::Mark::Bold.new],
+                  ),
+                  described_class::Text.new(text: "world"),
+                ],
+              ),
+            ],
+          ),
+        ],
+      )
+
+      json = doc.to_json(pretty: true)
+      parsed = described_class.from_h(JSON.parse(json))
+
+      expect(parsed).to be_a(described_class::Document)
+      expect(parsed.title).to eq("Test")
+      expect(parsed.content.length).to eq(1)
+      section = parsed.content.first
+      expect(section).to be_a(described_class::Section)
+      expect(section.content.first.content.first.marks.first).to be_a(Coradoc::Mirror::Mark::Bold)
+    end
+  end
+end

--- a/coradoc-mirror/spec/spec_helper.rb
+++ b/coradoc-mirror/spec/spec_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+  add_filter "/spec/"
+  minimum_coverage 0
+end
+
+require "coradoc-mirror"
+require "json"
+require "yaml"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.disable_monkey_patching!
+  config.warnings = true
+
+  config.default_formatter = "doc" if config.files_to_run.one?
+
+  config.profile_examples = 10
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
## Summary

New gem `coradoc-mirror` that transforms Coradoc CoreModel documents into ProseMirror-compatible JSON/YAML for frontend rendering (Vue.js, React, or any ProseMirror-based editor).

## Architecture

- **Node / Mark** — ProseMirror-style node tree with typed attribute DSL (`node_attr` / `mark_attr`) providing typed accessors + serialization metadata. 30+ Node subclasses, 10+ Mark subclasses. Auto-registers via `NODES`/`MARKS` hashes.
- **HandlerRegistry** — OCP-compliant registry mapping CoreModel classes → handler modules via ancestor walk. Extensible without modifying existing code.
- **CoreModelToMirror** — Forward transformer using handler dispatch.
- **MirrorToCoreModel** — Reverse transformer with lambda-based `TYPE_BUILDERS` dispatch table for round-trip support.
- **Output pipeline** — Integrates with `Coradoc::Output` for JSON/YAML format registration.
- **21 handler modules** — One per CoreModel concern (structural, blocks, lists, tables, inline, etc.)

## Usage

```ruby
doc = Coradoc.parse(adoc_text, format: :asciidoc)
json = Coradoc::Mirror.to_json(doc, pretty: true)
yaml = Coradoc::Mirror.to_yaml(doc)

# Bidirectional round-trip
t = Coradoc::Mirror::Transformer.new
mirror = t.from_core_model(doc)
restored = t.to_core_model(mirror)
```

## Code quality

- Zero `require_relative` in lib code (autoload throughout)
- Zero `instance_variable_set/get`, `.send()`, `respond_to?`
- Zero `double()` in specs (real model instances)
- 116 specs, 84.67% line coverage
- OCP, MECE, model-driven design throughout

## Commits

1. **Gem scaffold + Gemfile entry** — gemspec, Rakefile, entry point
2. **Node and Mark models** — typed attribute DSL, 40+ subclasses, JSON/YAML serialization
3. **Transformers + registry + output pipeline** — CoreModelToMirror, MirrorToCoreModel, Transformer facade
4. **21 handler modules** — structural, blocks, lists, tables, inline, reference handlers
5. **Spec suite** — 116 examples covering models, handlers, registry, integration, round-trip
