### PR TITLE
refactor(mirror): OCP/MECE quality pass for coradoc-mirror

### DIFF
--- a/coradoc-mirror/Rakefile
+++ b/coradoc-mirror/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rspec/core/rake_task"
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/coradoc-mirror/coradoc-mirror.gemspec
+++ b/coradoc-mirror/coradoc-mirror.gemspec
@@ -1,38 +1,38 @@
 # frozen_string_literal: true
 
-require_relative "lib/coradoc/mirror/version"
+require_relative 'lib/coradoc/mirror/version'
 
 Gem::Specification.new do |spec|
-  spec.name = "coradoc-mirror"
+  spec.name = 'coradoc-mirror'
   spec.version = Coradoc::Mirror::VERSION
-  spec.authors = ["Ribose Inc."]
-  spec.email = ["open.source@ribose.com"]
+  spec.authors = ['Ribose Inc.']
+  spec.email = ['open.source@ribose.com']
 
-  spec.summary = "ProseMirror-compatible JSON document model for Coradoc"
-  spec.description = "Transforms Coradoc CoreModel documents into ProseMirror-compatible " \
-                     "JSON/YAML suitable for rich frontend rendering with Vue.js, React, " \
-                     "or any ProseMirror-based editor."
-  spec.homepage = "https://github.com/metanorma/coradoc"
-  spec.license = "MIT"
+  spec.summary = 'ProseMirror-compatible JSON document model for Coradoc'
+  spec.description = 'Transforms Coradoc CoreModel documents into ProseMirror-compatible ' \
+                     'JSON/YAML suitable for rich frontend rendering with Vue.js, React, ' \
+                     'or any ProseMirror-based editor.'
+  spec.homepage = 'https://github.com/metanorma/coradoc'
+  spec.license = 'MIT'
 
-  spec.required_ruby_version = ">= 3.3.0"
+  spec.required_ruby_version = '>= 3.3.0'
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/metanorma/coradoc"
-  spec.metadata["changelog_uri"] = "https://github.com/metanorma/coradoc/releases"
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = 'https://github.com/metanorma/coradoc'
+  spec.metadata['changelog_uri'] = 'https://github.com/metanorma/coradoc/releases'
 
   spec.files = Dir.chdir(__dir__) do
-    Dir["lib/**/*.rb"]
+    Dir['lib/**/*.rb']
   end
 
-  spec.bindir = "exe"
+  spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "coradoc", "~> 2.0"
+  spec.add_dependency 'coradoc', '~> 2.0'
 
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rspec-its"
-  spec.add_development_dependency "simplecov"
-  spec.metadata["rubygems_mfa_required"] = "true"
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec-its'
+  spec.add_development_dependency 'simplecov'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/coradoc-mirror/lib/coradoc-mirror.rb
+++ b/coradoc-mirror/lib/coradoc-mirror.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require "coradoc"
-require "coradoc/mirror"
+require 'coradoc'
+require 'coradoc/mirror'
 
 # Side-effect: registers output processors with Coradoc::Output pipeline.
 # Side-effect: registers format modules with Coradoc registry.
 # These must use require (not autoload) because they have load-time side effects.
-require "coradoc/mirror/output"
-require "coradoc/mirror/mirror_json_format"
-require "coradoc/mirror/mirror_yaml_format"
+require 'coradoc/mirror/output'
+require 'coradoc/mirror/mirror_json_format'
+require 'coradoc/mirror/mirror_yaml_format'
 
 # Ensure Coradoc error classes are loaded (autoloaded via Coradoc::Error).
 Coradoc::Error

--- a/coradoc-mirror/lib/coradoc/mirror.rb
+++ b/coradoc-mirror/lib/coradoc/mirror.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "json"
+require 'json'
 
 module Coradoc
   module Mirror

--- a/coradoc-mirror/lib/coradoc/mirror/core_model_to_mirror.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/core_model_to_mirror.rb
@@ -2,8 +2,23 @@
 
 module Coradoc
   module Mirror
+    # Transforms CoreModel documents into ProseMirror-compatible Mirror nodes.
+    #
+    # Uses a HandlerRegistry for OCP-compliant dispatch: each CoreModel type
+    # maps to a handler module/class that produces the corresponding Mirror node.
     class CoreModelToMirror
       attr_reader :registry
+
+      # Typed struct for pending footnote data (model-driven, not hash bags).
+      FootnoteData = Struct.new(:id, :ref_id, :number, :content, keyword_init: true)
+
+      # Maps element types to their children accessors.
+      COLLECTION_ACCESSORS = {
+        CoreModel::ListBlock => :items,
+        CoreModel::DefinitionList => :items,
+        CoreModel::Table => :rows,
+        CoreModel::Bibliography => :entries
+      }.freeze
 
       def initialize(registry: Coradoc::Mirror.default_registry)
         @registry = registry
@@ -23,7 +38,7 @@ module Coradoc
         Node::Document.new(
           title: attrs[:title],
           id: attrs[:id],
-          content: content,
+          content: content
         )
       end
 
@@ -32,9 +47,7 @@ module Coradoc
 
         if children && !children.empty?
           content = []
-          children.each do |child|
-            handle_element(child, content)
-          end
+          children.each { |child| handle_element(child, content) }
           content.compact
         elsif element_has_text_content?(element)
           process_inline_content(element)
@@ -57,34 +70,26 @@ module Coradoc
         fn_id = footnote.id || "fn-#{num}"
         ref_id = "fn-ref-#{num}"
 
-        fn_content = if footnote.content
-                       [text_node(footnote.content)]
-                     else
-                       []
-                     end
-
-        @footnotes << {
-          id: fn_id,
-          ref_id: ref_id,
-          number: num,
-          content: fn_content,
-        }
+        fn_content = footnote.content ? [text_node(footnote.content)] : []
+        @footnotes << FootnoteData.new(
+          id: fn_id, ref_id: ref_id, number: num, content: fn_content
+        )
 
         Node::FootnoteMarker.new(id: fn_id, ref_id: ref_id, number: num)
       end
 
       def resolve_footnote_reference(ref)
         target_id = ref.id
-        fn_entry = @footnotes.find { |fn| fn[:id] == target_id } if target_id
+        entry = @footnotes.find { |fn| fn.id == target_id } if target_id
 
-        if fn_entry
+        if entry
           Node::FootnoteMarker.new(
-            id: fn_entry[:id],
-            ref_id: "fn-ref-#{fn_entry[:number]}-dup-#{@footnote_counter}",
-            number: fn_entry[:number],
+            id: entry.id,
+            ref_id: "fn-ref-#{entry.number}-dup-#{@footnote_counter}",
+            number: entry.number
           )
         else
-          text_node("[#{target_id || "footnote"}]")
+          text_node("[#{target_id || 'footnote'}]")
         end
       end
 
@@ -93,10 +98,7 @@ module Coradoc
 
         entries = @footnotes.map do |fn|
           Node::FootnoteEntry.new(
-            id: fn[:id],
-            ref_id: fn[:ref_id],
-            number: fn[:number],
-            content: fn[:content],
+            id: fn.id, ref_id: fn.ref_id, number: fn.number, content: fn.content
           )
         end
 
@@ -115,25 +117,14 @@ module Coradoc
       def element_children(element)
         if element.is_a?(CoreModel::StructuralElement) ||
            element.is_a?(CoreModel::InlineElement) ||
-           element.is_a?(CoreModel::TableCell)
-          children = element.children
-          return children if children && !children.empty?
-        elsif element.is_a?(CoreModel::Block)
+           element.is_a?(CoreModel::TableCell) ||
+           element.is_a?(CoreModel::Block)
           children = element.children
           return children if children && !children.empty?
         end
 
-        if element.is_a?(CoreModel::ListBlock)
-          element.items
-        elsif element.is_a?(CoreModel::DefinitionList)
-          element.items
-        elsif element.is_a?(CoreModel::Table)
-          element.rows
-        elsif element.is_a?(CoreModel::Bibliography)
-          element.entries
-        else
-          nil
-        end
+        accessor = COLLECTION_ACCESSORS[element.class]
+        element.public_send(accessor) if accessor
       end
 
       def handle_element(element, content)
@@ -143,11 +134,7 @@ module Coradoc
         value, concat = result
         return unless value
 
-        if concat
-          content.concat(Array(value))
-        else
-          content << value
-        end
+        concat ? content.concat(Array(value)) : content << value
       end
 
       def build_document_attrs(document)
@@ -156,7 +143,6 @@ module Coradoc
         attrs[:id] = document.id if document.id
 
         if document.is_a?(CoreModel::DocumentElement) &&
-           document.attributes &&
            document.attributes.is_a?(CoreModel::Metadata)
           document.attributes.to_h.each do |key, value|
             attrs[key.to_sym] = value

--- a/coradoc-mirror/lib/coradoc/mirror/handler_registry.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handler_registry.rb
@@ -42,7 +42,7 @@ module Coradoc
           handler: handler,
           method_name: method_name,
           concat: concat,
-          extra_kwargs: extra_kwargs,
+          extra_kwargs: extra_kwargs
         )
       end
 

--- a/coradoc-mirror/lib/coradoc/mirror/handler_registry.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handler_registry.rb
@@ -55,15 +55,15 @@ module Coradoc
       #
       # @param element [CoreModel::Base] element to find handler for
       # @return [Entry, nil]
+      TERMINAL_ANCESTORS = [Object, BasicObject].freeze
+
       def entry_for(element)
-        # Exact class match first
         entry = @handlers[element.class]
         return entry if entry
 
-        # Walk ancestors for inherited handler (most specific first)
         element.class.ancestors.each do |ancestor|
           next if ancestor == element.class
-          break if ancestor == Object || ancestor == BasicObject
+          break if TERMINAL_ANCESTORS.include?(ancestor)
 
           entry = @handlers[ancestor]
           return entry if entry

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/admonition.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/admonition.rb
@@ -13,7 +13,7 @@ module Coradoc
             admonition_type: element.annotation_type,
             title: element.title,
             label: element.annotation_label,
-            content: content,
+            content: content
           )
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/bibliography.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/bibliography.rb
@@ -14,7 +14,7 @@ module Coradoc
             id: element.id,
             title: element.title,
             level: element.level,
-            content: entries,
+            content: entries
           )
         end
 
@@ -29,7 +29,7 @@ module Coradoc
               anchor_name: entry.anchor_name,
               document_id: entry.document_id,
               url: entry.url,
-              content: [context.text_node(text)],
+              content: [context.text_node(text)]
             )
           end
         end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/blockquote.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/blockquote.rb
@@ -10,7 +10,7 @@ module Coradoc
 
           Node::Blockquote.new(
             attribution: element.attribution,
-            content: content,
+            content: content
           )
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/code_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/code_block.rb
@@ -30,7 +30,7 @@ module Coradoc
               title: element.title,
               language: element.language,
               passthrough: passthrough || nil,
-              content: [context.text_node(text)],
+              content: [context.text_node(text)]
             )
           end
 
@@ -40,7 +40,7 @@ module Coradoc
             elsif element.is_a?(CoreModel::Block) && element.lines && !element.lines.empty?
               Array(element.lines).join("\n")
             else
-              ""
+              ''
             end
           end
         end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/comment.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/comment.rb
@@ -5,7 +5,7 @@ module Coradoc
     module Handlers
       # Handles CommentBlock → omitted (comments are not rendered).
       module Comment
-        def self.call(_element, context:)
+        def self.call(_element, *)
           nil
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/example.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/example.rb
@@ -11,7 +11,7 @@ module Coradoc
           Node::Example.new(
             id: element.id,
             title: element.title,
-            content: content,
+            content: content
           )
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/generic_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/generic_block.rb
@@ -13,7 +13,7 @@ module Coradoc
             id: element.id,
             title: element.title,
             semantic_type: semantic_type&.to_s,
-            content: content,
+            content: content
           )
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/horizontal_rule.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/horizontal_rule.rb
@@ -5,7 +5,7 @@ module Coradoc
     module Handlers
       # Handles HorizontalRuleBlock → horizontal_rule node.
       module HorizontalRule
-        def self.call(_element, context:)
+        def self.call(_element, *)
           Node::HorizontalRule.new
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/image.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/image.rb
@@ -4,7 +4,7 @@ module Coradoc
   module Mirror
     module Handlers
       module Image
-        def self.call(element, context:)
+        def self.call(element, *)
           Node::Image.new(
             id: element.id,
             src: element.src,
@@ -13,7 +13,7 @@ module Coradoc
             caption: element.caption,
             width: element.width,
             height: element.height,
-            inline: element.inline || nil,
+            inline: element.inline || nil
           )
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
@@ -137,12 +137,12 @@ module Coradoc
             text = extract_inline_text(element)
             target = element.target
 
-            display_text = text.empty? ? (target || "") : text
+            display_text = text.empty? ? (target || '') : text
             return nil if display_text.empty?
 
             context.text_node(display_text, marks: [Mark::CrossReference.new(
               target: target,
-              resolved: text.empty? ? nil : text,
+              resolved: text.empty? ? nil : text
             )])
           end
 
@@ -157,17 +157,17 @@ module Coradoc
             text = extract_inline_text(element)
             return nil if text.empty?
 
-            role = element.attr("role")
+            role = element.attr('role')
             context.text_node(text, marks: [Mark::Span.new(role: role)])
           end
 
           def build_footnote_node(element, context)
             footnote = nil
             if element.is_a?(CoreModel::InlineElement) && element.content
-              fn_id = element.attr("id")
+              fn_id = element.attr('id')
               footnote = CoreModel::Footnote.new(
                 id: fn_id,
-                content: element.content.to_s,
+                content: element.content.to_s
               )
             end
 
@@ -193,12 +193,12 @@ module Coradoc
                 case child
                 when CoreModel::TextContent then child.text.to_s
                 when CoreModel::InlineElement then extract_inline_text(child)
-                else ""
+                else ''
                 end
               end.join
             end
 
-            ""
+            ''
           end
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
@@ -14,7 +14,7 @@ module Coradoc
           CoreModel::SubscriptElement => Mark::Subscript,
           CoreModel::SuperscriptElement => Mark::Superscript,
           CoreModel::HighlightElement => Mark::Highlight,
-          CoreModel::TermElement => Mark::Bold,
+          CoreModel::TermElement => Mark::Bold
         }.freeze
 
         def self.process(element, context:)
@@ -31,6 +31,7 @@ module Coradoc
           case child
           when CoreModel::TextContent
             return [] if child.text.nil? || child.text.empty?
+
             [context.text_node(child.text)]
           when CoreModel::InlineElement
             [dispatch_inline(child, context)].compact
@@ -61,6 +62,7 @@ module Coradoc
 
         def self.text_content(element, context:)
           return nil if element.text.nil? || element.text.empty?
+
           context.text_node(element.text)
         end
 
@@ -100,9 +102,7 @@ module Coradoc
               build_span_mark(element, context)
             when CoreModel::FootnoteElement
               build_footnote_node(element, context)
-            when CoreModel::HardLineBreakElement
-              Node::SoftBreak.new
-            when CoreModel::LineBreakElement
+            when CoreModel::HardLineBreakElement, CoreModel::LineBreakElement
               Node::SoftBreak.new
             when CoreModel::TextElement
               build_text_only(element, context)
@@ -121,6 +121,7 @@ module Coradoc
           def build_simple_mark(element, context, mark_class)
             text = extract_inline_text(element)
             return nil if text.empty?
+
             context.text_node(text, marks: [mark_class.new])
           end
 
@@ -176,6 +177,7 @@ module Coradoc
           def build_text_only(element, context)
             text = extract_inline_text(element)
             return nil if text.empty?
+
             context.text_node(text)
           end
 

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/list.rb
@@ -55,6 +55,7 @@ module Coradoc
             case child
             when CoreModel::TextContent
               return nil if child.text.nil? || child.text.empty?
+
               context.text_node(child.text)
             when CoreModel::InlineElement
               Handlers::Inline.call(child, context: context)

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/list.rb
@@ -14,7 +14,7 @@ module Coradoc
           node_class.new(
             id: element.id,
             start: element.is_a?(CoreModel::ListBlock) ? element.start : nil,
-            content: items,
+            content: items
           )
         end
 
@@ -66,7 +66,7 @@ module Coradoc
           end
 
           def ordered?(element)
-            element.marker_type == "ordered"
+            element.marker_type == 'ordered'
           end
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/reviewer.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/reviewer.rb
@@ -5,7 +5,7 @@ module Coradoc
     module Handlers
       # Handles ReviewerBlock → omitted (reviewer notes are not rendered).
       module Reviewer
-        def self.call(_element, context:)
+        def self.call(_element, *)
           nil
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/sidebar.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/sidebar.rb
@@ -11,7 +11,7 @@ module Coradoc
           Node::Sidebar.new(
             id: element.id,
             title: element.title,
-            content: content,
+            content: content
           )
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/structural.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/structural.rb
@@ -9,7 +9,7 @@ module Coradoc
           Node::Document.new(
             title: element.title,
             id: element.id,
-            content: content,
+            content: content
           )
         end
 
@@ -19,7 +19,7 @@ module Coradoc
             id: element.id,
             title: element.title,
             level: element.heading_level,
-            content: content,
+            content: content
           )
         end
 
@@ -33,7 +33,7 @@ module Coradoc
           Node::Header.new(
             title: element.title,
             level: element.heading_level,
-            content: content,
+            content: content
           )
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/table.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/table.rb
@@ -20,7 +20,7 @@ module Coradoc
             id: element.id,
             title: element.title,
             width: element.width,
-            content: content,
+            content: content
           )
         end
 
@@ -55,7 +55,7 @@ module Coradoc
               rowspan: cell.rowspan,
               alignment: cell.alignment,
               header: cell.header || nil,
-              content: content,
+              content: content
             )
           end
 

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/toc.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/toc.rb
@@ -15,7 +15,7 @@ module Coradoc
 
           Node::Toc.new(
             title: element.title,
-            content: entries,
+            content: entries
           )
         end
 
@@ -36,7 +36,7 @@ module Coradoc
               id: entry.is_a?(CoreModel::TocEntry) ? entry.id : nil,
               title: entry.is_a?(CoreModel::TocEntry) ? entry.title : nil,
               level: entry.is_a?(CoreModel::TocEntry) ? entry.level : nil,
-              content: content,
+              content: content
             )
           end
         end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/verse.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/verse.rb
@@ -8,12 +8,12 @@ module Coradoc
           text = if element.content && !element.content.to_s.empty?
                    element.flat_text || element.content.to_s
                  else
-                   ""
+                   ''
                  end
 
           Node::Verse.new(
             attribution: element.attribution,
-            content: [context.text_node(text)],
+            content: [context.text_node(text)]
           )
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/mark.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mark.rb
@@ -12,7 +12,6 @@ module Coradoc
     #
     # New mark types are added by subclassing Mark — no modification of
     # existing code needed (OCP).
-    #
     class Mark
       PM_TYPE = "mark"
 
@@ -69,9 +68,6 @@ module Coradoc
         end
       end
 
-      # Auto-registry: maps PM_TYPE → class for all declared subclasses.
-      MARKS = {}
-
       # ── Mark type subclasses ────────────────────────────────────
 
       class Bold < Mark
@@ -119,7 +115,7 @@ module Coradoc
           return nil unless hash
 
           attrs = hash["attrs"] || {}
-          new(href: attrs[:href] || attrs["href"])
+          new(href: attrs["href"])
         end
       end
 
@@ -154,13 +150,16 @@ module Coradoc
         end
       end
 
-      # Auto-register all mark subclasses by PM_TYPE.
-      constants.each do |name|
-        klass = const_get(name)
-        next unless klass.is_a?(Class) && klass < Mark && klass::PM_TYPE != "mark"
-
-        MARKS[klass::PM_TYPE] = klass
-      end
+      # Populate and freeze the registry after all subclasses are defined.
+      MARKS = begin
+                registry = {}
+                constants.each do |name|
+                  k = const_get(name)
+                  next unless k.is_a?(Class) && k < Mark && k::PM_TYPE != "mark"
+                  registry[k::PM_TYPE] = k
+                end
+                registry.freeze
+              end
 
       private
 
@@ -179,6 +178,7 @@ module Coradoc
           kwargs[name] = symbolized[name] if symbolized.key?(name)
         end
       end
+      private_class_method :build_kwargs
     end
   end
 end

--- a/coradoc-mirror/lib/coradoc/mirror/mark.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mark.rb
@@ -13,7 +13,7 @@ module Coradoc
     # New mark types are added by subclassing Mark — no modification of
     # existing code needed (OCP).
     class Mark
-      PM_TYPE = "mark"
+      PM_TYPE = 'mark'
 
       class << self
         def mark_attr(*names)
@@ -39,9 +39,9 @@ module Coradoc
       end
 
       def to_h
-        result = { "type" => type }
+        result = { 'type' => type }
         attrs = serialize_attrs
-        result["attrs"] = attrs unless attrs.empty?
+        result['attrs'] = attrs unless attrs.empty?
         result
       end
 
@@ -54,13 +54,13 @@ module Coradoc
       def self.from_h(hash)
         return nil unless hash
 
-        type_str = hash["type"]
+        type_str = hash['type']
         mark_class = MARKS[type_str]
 
         if mark_class && mark_class != self
           mark_class.from_h(hash)
         else
-          attrs = hash["attrs"] || {}
+          attrs = hash['attrs'] || {}
           base = mark_class || self
           kwargs = build_kwargs(base, attrs)
           kwargs[:type] = type_str if mark_class.nil?
@@ -71,39 +71,39 @@ module Coradoc
       # ── Mark type subclasses ────────────────────────────────────
 
       class Bold < Mark
-        PM_TYPE = "bold"
+        PM_TYPE = 'bold'
       end
 
       class Italic < Mark
-        PM_TYPE = "italic"
+        PM_TYPE = 'italic'
       end
 
       class Monospace < Mark
-        PM_TYPE = "code"
+        PM_TYPE = 'code'
       end
 
       class Underline < Mark
-        PM_TYPE = "underline"
+        PM_TYPE = 'underline'
       end
 
       class Strikethrough < Mark
-        PM_TYPE = "strikethrough"
+        PM_TYPE = 'strikethrough'
       end
 
       class Subscript < Mark
-        PM_TYPE = "subscript"
+        PM_TYPE = 'subscript'
       end
 
       class Superscript < Mark
-        PM_TYPE = "superscript"
+        PM_TYPE = 'superscript'
       end
 
       class Highlight < Mark
-        PM_TYPE = "highlight"
+        PM_TYPE = 'highlight'
       end
 
       class Link < Mark
-        PM_TYPE = "link"
+        PM_TYPE = 'link'
         mark_attr :href
 
         def initialize(href: nil)
@@ -114,13 +114,13 @@ module Coradoc
         def self.from_h(hash)
           return nil unless hash
 
-          attrs = hash["attrs"] || {}
-          new(href: attrs["href"])
+          attrs = hash['attrs'] || {}
+          new(href: attrs['href'])
         end
       end
 
       class CrossReference < Mark
-        PM_TYPE = "xref"
+        PM_TYPE = 'xref'
         mark_attr :target, :resolved
 
         def initialize(target: nil, resolved: nil)
@@ -131,7 +131,7 @@ module Coradoc
       end
 
       class Stem < Mark
-        PM_TYPE = "stem"
+        PM_TYPE = 'stem'
         mark_attr :stem_type
 
         def initialize(stem_type: nil)
@@ -141,7 +141,7 @@ module Coradoc
       end
 
       class Span < Mark
-        PM_TYPE = "span"
+        PM_TYPE = 'span'
         mark_attr :role
 
         def initialize(role: nil)
@@ -155,11 +155,12 @@ module Coradoc
                 registry = {}
                 constants.each do |name|
                   k = const_get(name)
-                  next unless k.is_a?(Class) && k < Mark && k::PM_TYPE != "mark"
+                  next unless k.is_a?(Class) && k < Mark && k::PM_TYPE != 'mark'
+
                   registry[k::PM_TYPE] = k
                 end
                 registry.freeze
-              end
+      end
 
       private
 

--- a/coradoc-mirror/lib/coradoc/mirror/mirror_json_format.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mirror_json_format.rb
@@ -13,7 +13,7 @@ module Coradoc
       class << self
         # Output-only format — parsing from mirror JSON is not supported via
         # the format registry. Use Mirror::Node.from_h directly.
-        def parse_to_core(input, options = {})
+        def parse_to_core(_input, _options = {})
           raise Coradoc::UnsupportedFormatError,
                 "Parsing from mirror JSON is not supported via the format registry. " \
                 "Use Coradoc::Mirror::Node.from_h(JSON.parse(input)) directly."

--- a/coradoc-mirror/lib/coradoc/mirror/mirror_json_format.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mirror_json_format.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "json"
+require 'json'
 
 module Coradoc
   module Mirror
@@ -15,8 +15,8 @@ module Coradoc
         # the format registry. Use Mirror::Node.from_h directly.
         def parse_to_core(_input, _options = {})
           raise Coradoc::UnsupportedFormatError,
-                "Parsing from mirror JSON is not supported via the format registry. " \
-                "Use Coradoc::Mirror::Node.from_h(JSON.parse(input)) directly."
+                'Parsing from mirror JSON is not supported via the format registry. ' \
+                'Use Coradoc::Mirror::Node.from_h(JSON.parse(input)) directly.'
         end
 
         # Accept CoreModel, serialize to Mirror JSON.

--- a/coradoc-mirror/lib/coradoc/mirror/mirror_to_core_model.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mirror_to_core_model.rb
@@ -2,9 +2,12 @@
 
 module Coradoc
   module Mirror
+    # Transforms ProseMirror-compatible Mirror nodes back into CoreModel.
+    #
+    # Uses a frozen TYPE_BUILDERS dispatch table (OCP): new node types
+    # are supported by adding entries.
     class MirrorToCoreModel
       # Dispatch table: Mirror node type string → builder lambda.
-      # New node types are supported by adding entries (OCP).
       TYPE_BUILDERS = {
         "doc" => ->(t, n) { t.build_document(n) },
         "section" => ->(t, n) { t.build_section(n) },
@@ -23,8 +26,8 @@ module Coradoc
         "ordered_list" => ->(t, n) { t.build_ordered_list(n) },
         "list_item" => ->(t, n) { t.build_list_item(n) },
         "definition_list" => ->(t, n) { t.build_definition_list(n) },
-        "definition_term" => ->(t, n) { t.build_definition_term(n) },
-        "definition_description" => ->(t, n) { t.build_definition_description(n) },
+        "definition_term" => ->(t, n) { t.build_inline_text(n) },
+        "definition_description" => ->(t, n) { t.build_inline_text(n) },
         "image" => ->(t, n) { t.build_image(n) },
         "table" => ->(t, n) { t.build_table(n) },
         "table_head" => ->(t, n) { t.build_table_head(n) },
@@ -38,8 +41,22 @@ module Coradoc
         "toc" => ->(t, n) { t.build_toc(n) },
         "toc_entry" => ->(t, n) { t.build_toc_entry(n) },
         "text" => ->(t, n) { t.build_text(n) },
-        "soft_break" => ->(t, _n) { t.build_soft_break },
+        "soft_break" => ->(t, _n) { t.build_soft_break }
       }.freeze
+
+      # Mark type → CoreModel class mapping (OCP: add new marks here).
+      SIMPLE_MARKS = {
+        "bold" => CoreModel::BoldElement,
+        "italic" => CoreModel::ItalicElement,
+        "code" => CoreModel::MonospaceElement,
+        "underline" => CoreModel::UnderlineElement,
+        "strikethrough" => CoreModel::StrikethroughElement,
+        "subscript" => CoreModel::SubscriptElement,
+        "superscript" => CoreModel::SuperscriptElement,
+        "highlight" => CoreModel::HighlightElement
+      }.freeze
+
+      LIST_TYPES = %w[bullet_list ordered_list].freeze
 
       def call(mirror_node)
         build_node(mirror_node)
@@ -64,7 +81,7 @@ module Coradoc
         CoreModel::DocumentElement.new(
           title: node.title,
           id: node.id,
-          children: build_content(node),
+          children: build_content(node)
         )
       end
 
@@ -73,7 +90,7 @@ module Coradoc
           title: node.title,
           level: node.level,
           id: node.id,
-          children: build_content(node),
+          children: build_content(node)
         )
       end
 
@@ -81,64 +98,59 @@ module Coradoc
         CoreModel::HeaderElement.new(
           title: node.title,
           level: node.level,
-          children: build_content(node),
+          children: build_content(node)
         )
       end
 
       def build_preamble(node)
         CoreModel::PreambleElement.new(
-          children: build_content(node),
+          children: build_content(node)
         )
       end
 
       # ── Blocks ──
 
       def build_paragraph(node)
-        children = build_inline_children(node)
-        CoreModel::ParagraphBlock.new(children: children)
+        CoreModel::ParagraphBlock.new(children: build_inline_children(node))
       end
 
       def build_code_block(node)
-        text = extract_text(node)
         CoreModel::SourceBlock.new(
-          content: text,
+          content: extract_text(node),
           language: node.language,
-          title: node.title,
+          title: node.title
         )
       end
 
       def build_blockquote(node)
         CoreModel::QuoteBlock.new(
           attribution: node.attribution,
-          children: build_content(node),
+          children: build_content(node)
         )
       end
 
       def build_example(node)
         CoreModel::ExampleBlock.new(
           title: node.title,
-          children: build_content(node),
+          children: build_content(node)
         )
       end
 
       def build_sidebar(node)
         CoreModel::SidebarBlock.new(
           title: node.title,
-          children: build_content(node),
+          children: build_content(node)
         )
       end
 
       def build_open_block(node)
-        CoreModel::OpenBlock.new(
-          children: build_content(node),
-        )
+        CoreModel::OpenBlock.new(children: build_content(node))
       end
 
       def build_verse(node)
-        text = extract_text(node)
         CoreModel::VerseBlock.new(
-          content: text,
-          attribution: node.attribution,
+          content: extract_text(node),
+          attribution: node.attribution
         )
       end
 
@@ -147,12 +159,13 @@ module Coradoc
       end
 
       def build_admonition(node)
-        content = build_content(node)
-        text = content.map { |c| c.is_a?(CoreModel::InlineElement) ? c.content.to_s : "" }.join
+        text = build_content(node).map do |c|
+          c.is_a?(CoreModel::InlineElement) ? c.content.to_s : ""
+        end.join
 
         CoreModel::AnnotationBlock.new(
           annotation_type: node.admonition_type,
-          content: text,
+          content: text
         )
       end
 
@@ -160,37 +173,20 @@ module Coradoc
 
       def build_bullet_list(node)
         items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
-        CoreModel::ListBlock.new(
-          marker_type: "unordered",
-          items: items,
-        )
+        CoreModel::ListBlock.new(marker_type: "unordered", items: items)
       end
 
       def build_ordered_list(node)
         items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
-        CoreModel::ListBlock.new(
-          marker_type: "ordered",
-          items: items,
-        )
+        CoreModel::ListBlock.new(marker_type: "ordered", items: items)
       end
 
       def build_list_item(node)
         children = build_inline_children(node)
         text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : "" }.join
 
-        nested_list = nil
-        node.content&.each do |child|
-          next unless child.is_a?(Node)
-          if child.type == "bullet_list" || child.type == "ordered_list"
-            nested_list = build_node(child)
-          end
-        end
-
-        CoreModel::ListItem.new(
-          content: text,
-          children: children.empty? ? children : children,
-          nested_list: nested_list,
-        )
+        nested_list = find_nested_list(node)
+        CoreModel::ListItem.new(content: text, children: children, nested_list: nested_list)
       end
 
       def build_definition_list(node)
@@ -198,34 +194,21 @@ module Coradoc
         descriptions = []
         node.content&.each do |child|
           next unless child.is_a?(Node)
+
           case child.type
-          when "definition_term"
-            terms << build_node(child)
-          when "definition_description"
-            descriptions << build_node(child)
+          when "definition_term" then terms << build_node(child)
+          when "definition_description" then descriptions << build_node(child)
           end
         end
 
         items = terms.zip(descriptions).map do |term, desc|
           CoreModel::DefinitionItem.new(
-            term: term.is_a?(CoreModel::InlineElement) ? term.content : term.to_s,
-            definitions: [desc.is_a?(CoreModel::InlineElement) ? desc.content : desc.to_s],
+            term: inline_content(term),
+            definitions: [inline_content(desc)]
           )
         end
 
         CoreModel::DefinitionList.new(items: items)
-      end
-
-      def build_definition_term(node)
-        children = build_inline_children(node)
-        text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : "" }.join
-        CoreModel::InlineElement.new(content: text)
-      end
-
-      def build_definition_description(node)
-        children = build_inline_children(node)
-        text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : "" }.join
-        CoreModel::InlineElement.new(content: text)
       end
 
       # ── Media ──
@@ -237,7 +220,7 @@ module Coradoc
           title: node.title,
           caption: node.caption,
           width: node.width,
-          height: node.height,
+          height: node.height
         )
       end
 
@@ -247,18 +230,14 @@ module Coradoc
         rows = []
         node.content&.each do |child|
           next unless child.is_a?(Node)
-          case child.type
-          when "table_head", "table_body"
-            child.content&.each do |row_node|
-              rows << build_node(row_node) if row_node.is_a?(Node)
-            end
+          next unless %w[table_head table_body].include?(child.type)
+
+          child.content&.each do |row_node|
+            rows << build_node(row_node) if row_node.is_a?(Node)
           end
         end
 
-        CoreModel::Table.new(
-          title: node.title,
-          rows: rows,
-        )
+        CoreModel::Table.new(title: node.title, rows: rows)
       end
 
       def build_table_head(node)
@@ -275,13 +254,12 @@ module Coradoc
       end
 
       def build_table_cell(node)
-        text = extract_text(node)
         CoreModel::TableCell.new(
-          content: text,
+          content: extract_text(node),
           header: node.header || false,
           colspan: node.colspan,
           rowspan: node.rowspan,
-          alignment: node.alignment,
+          alignment: node.alignment
         )
       end
 
@@ -289,42 +267,31 @@ module Coradoc
 
       def build_bibliography(node)
         entries = build_content(node).select { |c| c.is_a?(CoreModel::BibliographyEntry) }
-        CoreModel::Bibliography.new(
-          title: node.title,
-          entries: entries,
-        )
+        CoreModel::Bibliography.new(title: node.title, entries: entries)
       end
 
       def build_biblio_entry(node)
-        text = extract_text(node)
         CoreModel::BibliographyEntry.new(
           anchor_name: node.anchor_name,
           document_id: node.document_id,
-          ref_text: text,
+          ref_text: extract_text(node)
         )
       end
 
       # ── Footnotes ──
 
       def build_footnote_entry(node)
-        text = extract_text(node)
-        CoreModel::Footnote.new(
-          id: node.id,
-          content: text,
-        )
+        CoreModel::Footnote.new(id: node.id, content: extract_text(node))
       end
 
       # ── TOC ──
 
-      def build_toc(node)
+      def build_toc(_node)
         CoreModel::Toc.new
       end
 
       def build_toc_entry(node)
-        CoreModel::TocEntry.new(
-          id: node.id,
-          title: node.title,
-        )
+        CoreModel::TocEntry.new(id: node.id, title: node.title)
       end
 
       # ── Inline ──
@@ -347,25 +314,14 @@ module Coradoc
       # ── Helpers ──
 
       def apply_mark(inner, mark)
+        klass = SIMPLE_MARKS[mark.type]
+        return klass.new(children: Array(inner)) if klass
+
         case mark.type
-        when "bold" then CoreModel::BoldElement.new(children: Array(inner))
-        when "italic" then CoreModel::ItalicElement.new(children: Array(inner))
-        when "code" then CoreModel::MonospaceElement.new(children: Array(inner))
-        when "underline" then CoreModel::UnderlineElement.new(children: Array(inner))
-        when "strikethrough" then CoreModel::StrikethroughElement.new(children: Array(inner))
-        when "subscript" then CoreModel::SubscriptElement.new(children: Array(inner))
-        when "superscript" then CoreModel::SuperscriptElement.new(children: Array(inner))
-        when "highlight" then CoreModel::HighlightElement.new(children: Array(inner))
         when "link"
-          CoreModel::LinkElement.new(
-            target: mark.href,
-            children: Array(inner),
-          )
+          CoreModel::LinkElement.new(target: mark.href, children: Array(inner))
         when "xref"
-          CoreModel::CrossReferenceElement.new(
-            target: mark.target,
-            children: Array(inner),
-          )
+          CoreModel::CrossReferenceElement.new(target: mark.target, children: Array(inner))
         else
           inner
         end
@@ -380,6 +336,12 @@ module Coradoc
         end
       end
 
+      def build_inline_text(node)
+        children = build_inline_children(node)
+        text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : "" }.join
+        CoreModel::InlineElement.new(content: text)
+      end
+
       def extract_text(node)
         return node.text.to_s if node.is_a?(Node::Text)
         return "" unless node.content
@@ -387,6 +349,19 @@ module Coradoc
         node.content.filter_map do |child|
           child.is_a?(Node) ? extract_text(child) : ""
         end.join
+      end
+
+      private
+
+      def find_nested_list(node)
+        node.content&.each do |child|
+          return build_node(child) if child.is_a?(Node) && LIST_TYPES.include?(child.type)
+        end
+        nil
+      end
+
+      def inline_content(element)
+        element.is_a?(CoreModel::InlineElement) ? element.content : element.to_s
       end
     end
   end

--- a/coradoc-mirror/lib/coradoc/mirror/mirror_to_core_model.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mirror_to_core_model.rb
@@ -9,51 +9,51 @@ module Coradoc
     class MirrorToCoreModel
       # Dispatch table: Mirror node type string → builder lambda.
       TYPE_BUILDERS = {
-        "doc" => ->(t, n) { t.build_document(n) },
-        "section" => ->(t, n) { t.build_section(n) },
-        "header" => ->(t, n) { t.build_header(n) },
-        "preamble" => ->(t, n) { t.build_preamble(n) },
-        "paragraph" => ->(t, n) { t.build_paragraph(n) },
-        "code_block" => ->(t, n) { t.build_code_block(n) },
-        "blockquote" => ->(t, n) { t.build_blockquote(n) },
-        "example" => ->(t, n) { t.build_example(n) },
-        "sidebar" => ->(t, n) { t.build_sidebar(n) },
-        "open_block" => ->(t, n) { t.build_open_block(n) },
-        "verse" => ->(t, n) { t.build_verse(n) },
-        "horizontal_rule" => ->(t, _n) { t.build_horizontal_rule },
-        "admonition" => ->(t, n) { t.build_admonition(n) },
-        "bullet_list" => ->(t, n) { t.build_bullet_list(n) },
-        "ordered_list" => ->(t, n) { t.build_ordered_list(n) },
-        "list_item" => ->(t, n) { t.build_list_item(n) },
-        "definition_list" => ->(t, n) { t.build_definition_list(n) },
-        "definition_term" => ->(t, n) { t.build_inline_text(n) },
-        "definition_description" => ->(t, n) { t.build_inline_text(n) },
-        "image" => ->(t, n) { t.build_image(n) },
-        "table" => ->(t, n) { t.build_table(n) },
-        "table_head" => ->(t, n) { t.build_table_head(n) },
-        "table_body" => ->(t, n) { t.build_table_body(n) },
-        "table_row" => ->(t, n) { t.build_table_row(n) },
-        "table_cell" => ->(t, n) { t.build_table_cell(n) },
-        "bibliography" => ->(t, n) { t.build_bibliography(n) },
-        "biblio_entry" => ->(t, n) { t.build_biblio_entry(n) },
-        "footnotes" => ->(_t, _n) { nil },
-        "footnote_entry" => ->(t, n) { t.build_footnote_entry(n) },
-        "toc" => ->(t, n) { t.build_toc(n) },
-        "toc_entry" => ->(t, n) { t.build_toc_entry(n) },
-        "text" => ->(t, n) { t.build_text(n) },
-        "soft_break" => ->(t, _n) { t.build_soft_break }
+        'doc' => ->(t, n) { t.build_document(n) },
+        'section' => ->(t, n) { t.build_section(n) },
+        'header' => ->(t, n) { t.build_header(n) },
+        'preamble' => ->(t, n) { t.build_preamble(n) },
+        'paragraph' => ->(t, n) { t.build_paragraph(n) },
+        'code_block' => ->(t, n) { t.build_code_block(n) },
+        'blockquote' => ->(t, n) { t.build_blockquote(n) },
+        'example' => ->(t, n) { t.build_example(n) },
+        'sidebar' => ->(t, n) { t.build_sidebar(n) },
+        'open_block' => ->(t, n) { t.build_open_block(n) },
+        'verse' => ->(t, n) { t.build_verse(n) },
+        'horizontal_rule' => ->(t, _n) { t.build_horizontal_rule },
+        'admonition' => ->(t, n) { t.build_admonition(n) },
+        'bullet_list' => ->(t, n) { t.build_bullet_list(n) },
+        'ordered_list' => ->(t, n) { t.build_ordered_list(n) },
+        'list_item' => ->(t, n) { t.build_list_item(n) },
+        'definition_list' => ->(t, n) { t.build_definition_list(n) },
+        'definition_term' => ->(t, n) { t.build_inline_text(n) },
+        'definition_description' => ->(t, n) { t.build_inline_text(n) },
+        'image' => ->(t, n) { t.build_image(n) },
+        'table' => ->(t, n) { t.build_table(n) },
+        'table_head' => ->(t, n) { t.build_table_head(n) },
+        'table_body' => ->(t, n) { t.build_table_body(n) },
+        'table_row' => ->(t, n) { t.build_table_row(n) },
+        'table_cell' => ->(t, n) { t.build_table_cell(n) },
+        'bibliography' => ->(t, n) { t.build_bibliography(n) },
+        'biblio_entry' => ->(t, n) { t.build_biblio_entry(n) },
+        'footnotes' => ->(_t, _n) {},
+        'footnote_entry' => ->(t, n) { t.build_footnote_entry(n) },
+        'toc' => ->(t, n) { t.build_toc(n) },
+        'toc_entry' => ->(t, n) { t.build_toc_entry(n) },
+        'text' => ->(t, n) { t.build_text(n) },
+        'soft_break' => ->(t, _n) { t.build_soft_break }
       }.freeze
 
       # Mark type → CoreModel class mapping (OCP: add new marks here).
       SIMPLE_MARKS = {
-        "bold" => CoreModel::BoldElement,
-        "italic" => CoreModel::ItalicElement,
-        "code" => CoreModel::MonospaceElement,
-        "underline" => CoreModel::UnderlineElement,
-        "strikethrough" => CoreModel::StrikethroughElement,
-        "subscript" => CoreModel::SubscriptElement,
-        "superscript" => CoreModel::SuperscriptElement,
-        "highlight" => CoreModel::HighlightElement
+        'bold' => CoreModel::BoldElement,
+        'italic' => CoreModel::ItalicElement,
+        'code' => CoreModel::MonospaceElement,
+        'underline' => CoreModel::UnderlineElement,
+        'strikethrough' => CoreModel::StrikethroughElement,
+        'subscript' => CoreModel::SubscriptElement,
+        'superscript' => CoreModel::SuperscriptElement,
+        'highlight' => CoreModel::HighlightElement
       }.freeze
 
       LIST_TYPES = %w[bullet_list ordered_list].freeze
@@ -160,7 +160,7 @@ module Coradoc
 
       def build_admonition(node)
         text = build_content(node).map do |c|
-          c.is_a?(CoreModel::InlineElement) ? c.content.to_s : ""
+          c.is_a?(CoreModel::InlineElement) ? c.content.to_s : ''
         end.join
 
         CoreModel::AnnotationBlock.new(
@@ -173,17 +173,17 @@ module Coradoc
 
       def build_bullet_list(node)
         items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
-        CoreModel::ListBlock.new(marker_type: "unordered", items: items)
+        CoreModel::ListBlock.new(marker_type: 'unordered', items: items)
       end
 
       def build_ordered_list(node)
         items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
-        CoreModel::ListBlock.new(marker_type: "ordered", items: items)
+        CoreModel::ListBlock.new(marker_type: 'ordered', items: items)
       end
 
       def build_list_item(node)
         children = build_inline_children(node)
-        text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : "" }.join
+        text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : '' }.join
 
         nested_list = find_nested_list(node)
         CoreModel::ListItem.new(content: text, children: children, nested_list: nested_list)
@@ -196,8 +196,8 @@ module Coradoc
           next unless child.is_a?(Node)
 
           case child.type
-          when "definition_term" then terms << build_node(child)
-          when "definition_description" then descriptions << build_node(child)
+          when 'definition_term' then terms << build_node(child)
+          when 'definition_description' then descriptions << build_node(child)
           end
         end
 
@@ -297,7 +297,7 @@ module Coradoc
       # ── Inline ──
 
       def build_text(node)
-        text = node.text || ""
+        text = node.text || ''
         marks = node.marks || []
 
         return CoreModel::TextContent.new(text: text) if marks.empty?
@@ -318,9 +318,9 @@ module Coradoc
         return klass.new(children: Array(inner)) if klass
 
         case mark.type
-        when "link"
+        when 'link'
           CoreModel::LinkElement.new(target: mark.href, children: Array(inner))
-        when "xref"
+        when 'xref'
           CoreModel::CrossReferenceElement.new(target: mark.target, children: Array(inner))
         else
           inner
@@ -332,22 +332,23 @@ module Coradoc
 
         node.content.filter_map do |child|
           next unless child.is_a?(Node)
+
           build_node(child)
         end
       end
 
       def build_inline_text(node)
         children = build_inline_children(node)
-        text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : "" }.join
+        text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : '' }.join
         CoreModel::InlineElement.new(content: text)
       end
 
       def extract_text(node)
         return node.text.to_s if node.is_a?(Node::Text)
-        return "" unless node.content
+        return '' unless node.content
 
         node.content.filter_map do |child|
-          child.is_a?(Node) ? extract_text(child) : ""
+          child.is_a?(Node) ? extract_text(child) : ''
         end.join
       end
 

--- a/coradoc-mirror/lib/coradoc/mirror/mirror_yaml_format.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mirror_yaml_format.rb
@@ -13,14 +13,14 @@ module Coradoc
       class << self
         # Output-only format — parsing from mirror YAML is not supported via
         # the format registry. Use Mirror::Node.from_h directly.
-        def parse_to_core(input, options = {})
+        def parse_to_core(_input, _options = {})
           raise Coradoc::UnsupportedFormatError,
                 "Parsing from mirror YAML is not supported via the format registry. " \
                 "Use Coradoc::Mirror::Node.from_h(YAML.safe_load(input)) directly."
         end
 
         # Accept CoreModel, serialize to Mirror YAML.
-        def serialize(document, options = {})
+        def serialize(document, _options = {})
           node = Coradoc::Mirror.transform(document)
           node.to_yaml
         end

--- a/coradoc-mirror/lib/coradoc/mirror/mirror_yaml_format.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mirror_yaml_format.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "yaml"
+require 'yaml'
 
 module Coradoc
   module Mirror
@@ -15,8 +15,8 @@ module Coradoc
         # the format registry. Use Mirror::Node.from_h directly.
         def parse_to_core(_input, _options = {})
           raise Coradoc::UnsupportedFormatError,
-                "Parsing from mirror YAML is not supported via the format registry. " \
-                "Use Coradoc::Mirror::Node.from_h(YAML.safe_load(input)) directly."
+                'Parsing from mirror YAML is not supported via the format registry. ' \
+                'Use Coradoc::Mirror::Node.from_h(YAML.safe_load(input)) directly.'
         end
 
         # Accept CoreModel, serialize to Mirror YAML.

--- a/coradoc-mirror/lib/coradoc/mirror/node.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/node.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "json"
+require 'json'
 
 module Coradoc
   module Mirror
@@ -16,7 +16,7 @@ module Coradoc
     # constant for their canonical type string. New node types are added by
     # subclassing Node — no modification of existing code needed (OCP).
     class Node
-      PM_TYPE = "node"
+      PM_TYPE = 'node'
 
       attr_accessor :content, :marks
 
@@ -63,13 +63,13 @@ module Coradoc
       end
 
       def to_h
-        result = { "type" => type }
+        result = { 'type' => type }
         attrs = serialize_attrs
-        result["attrs"] = attrs unless attrs.empty?
-        result["marks"] = marks.map(&:to_h) unless marks.empty?
+        result['attrs'] = attrs unless attrs.empty?
+        result['marks'] = marks.map(&:to_h) unless marks.empty?
         unless content.empty?
           items = content.is_a?(Array) ? content : [content]
-          result["content"] = items.map(&:to_h)
+          result['content'] = items.map(&:to_h)
         end
         result
       end
@@ -91,17 +91,17 @@ module Coradoc
       def self.from_h(hash)
         return nil unless hash
 
-        type_str = hash["type"]
+        type_str = hash['type']
         klass = NODES[type_str]
 
         if klass && klass != self
           klass.from_h(hash)
         else
           base = klass || self
-          content = (hash["content"] || []).map { |c| Node.from_h(c) }
-          marks = (hash["marks"] || []).map { |m| Mark.from_h(m) }
+          content = (hash['content'] || []).map { |c| Node.from_h(c) }
+          marks = (hash['marks'] || []).map { |m| Mark.from_h(m) }
 
-          attrs = hash["attrs"] || {}
+          attrs = hash['attrs'] || {}
           kwargs = build_kwargs(base, attrs)
           kwargs[:content] = content
           kwargs[:marks] = marks
@@ -112,28 +112,28 @@ module Coradoc
       end
 
       def text_content
-        return "" unless content
+        return '' unless content
 
         content.map do |item|
-          item.is_a?(Node) ? item.text_content : ""
+          item.is_a?(Node) ? item.text_content : ''
         end.join
       end
 
       # ── Node type subclasses ────────────────────────────────────
 
       class Text < Node
-        PM_TYPE = "text"
+        PM_TYPE = 'text'
 
         node_attr :text
 
-        def initialize(text: "", **)
+        def initialize(text: '', **)
           super(**)
           @text = text
         end
 
         def to_h
           result = super
-          result["text"] = text.to_s
+          result['text'] = text.to_s
           result
         end
 
@@ -145,178 +145,178 @@ module Coradoc
           return nil unless hash
 
           new(
-            text: hash["text"] || "",
-            attrs: (hash["attrs"] || {}).transform_keys(&:to_sym),
-            marks: (hash["marks"] || []).map { |m| Mark.from_h(m) }
+            text: hash['text'] || '',
+            attrs: (hash['attrs'] || {}).transform_keys(&:to_sym),
+            marks: (hash['marks'] || []).map { |m| Mark.from_h(m) }
           )
         end
       end
 
       class Document < Node
-        PM_TYPE = "doc"
+        PM_TYPE = 'doc'
         node_attr :title, :id
       end
 
       class Paragraph < Node
-        PM_TYPE = "paragraph"
+        PM_TYPE = 'paragraph'
       end
 
       class Heading < Node
-        PM_TYPE = "heading"
+        PM_TYPE = 'heading'
         node_attr :level
       end
 
       class Section < Node
-        PM_TYPE = "section"
+        PM_TYPE = 'section'
         node_attr :title, :id, :level
       end
 
       class Preamble < Node
-        PM_TYPE = "preamble"
+        PM_TYPE = 'preamble'
       end
 
       class Header < Node
-        PM_TYPE = "header"
+        PM_TYPE = 'header'
         node_attr :title, :level
       end
 
       class CodeBlock < Node
-        PM_TYPE = "code_block"
+        PM_TYPE = 'code_block'
         node_attr :language, :title, :passthrough
       end
 
       class Blockquote < Node
-        PM_TYPE = "blockquote"
+        PM_TYPE = 'blockquote'
         node_attr :attribution
       end
 
       class Example < Node
-        PM_TYPE = "example"
+        PM_TYPE = 'example'
         node_attr :title, :id
       end
 
       class Sidebar < Node
-        PM_TYPE = "sidebar"
+        PM_TYPE = 'sidebar'
         node_attr :title, :id
       end
 
       class OpenBlock < Node
-        PM_TYPE = "open_block"
+        PM_TYPE = 'open_block'
       end
 
       class Verse < Node
-        PM_TYPE = "verse"
+        PM_TYPE = 'verse'
         node_attr :attribution
       end
 
       class HorizontalRule < Node
-        PM_TYPE = "horizontal_rule"
+        PM_TYPE = 'horizontal_rule'
       end
 
       class BulletList < Node
-        PM_TYPE = "bullet_list"
+        PM_TYPE = 'bullet_list'
         node_attr :id, :start
       end
 
       class OrderedList < Node
-        PM_TYPE = "ordered_list"
+        PM_TYPE = 'ordered_list'
         node_attr :id, :start
       end
 
       class ListItem < Node
-        PM_TYPE = "list_item"
+        PM_TYPE = 'list_item'
         node_attr :id
       end
 
       class DefinitionList < Node
-        PM_TYPE = "definition_list"
+        PM_TYPE = 'definition_list'
         node_attr :id
       end
 
       class DefinitionTerm < Node
-        PM_TYPE = "definition_term"
+        PM_TYPE = 'definition_term'
       end
 
       class DefinitionDescription < Node
-        PM_TYPE = "definition_description"
+        PM_TYPE = 'definition_description'
       end
 
       class Image < Node
-        PM_TYPE = "image"
+        PM_TYPE = 'image'
         node_attr :src, :alt, :title, :caption, :width, :height, :inline
       end
 
       class Table < Node
-        PM_TYPE = "table"
+        PM_TYPE = 'table'
         node_attr :title, :id, :width
       end
 
       class TableHead < Node
-        PM_TYPE = "table_head"
+        PM_TYPE = 'table_head'
       end
 
       class TableBody < Node
-        PM_TYPE = "table_body"
+        PM_TYPE = 'table_body'
       end
 
       class TableRow < Node
-        PM_TYPE = "table_row"
+        PM_TYPE = 'table_row'
       end
 
       class TableCell < Node
-        PM_TYPE = "table_cell"
+        PM_TYPE = 'table_cell'
         node_attr :colspan, :rowspan, :alignment, :header
       end
 
       class Admonition < Node
-        PM_TYPE = "admonition"
+        PM_TYPE = 'admonition'
         node_attr :admonition_type, :title, :label, :id
       end
 
       class Bibliography < Node
-        PM_TYPE = "bibliography"
+        PM_TYPE = 'bibliography'
         node_attr :title, :id, :level
       end
 
       class BibliographyEntry < Node
-        PM_TYPE = "biblio_entry"
+        PM_TYPE = 'biblio_entry'
         node_attr :anchor_name, :document_id, :url
       end
 
       class Footnotes < Node
-        PM_TYPE = "footnotes"
+        PM_TYPE = 'footnotes'
       end
 
       class FootnoteMarker < Node
-        PM_TYPE = "footnote_marker"
+        PM_TYPE = 'footnote_marker'
         node_attr :id, :ref_id, :number
       end
 
       class FootnoteEntry < Node
-        PM_TYPE = "footnote_entry"
+        PM_TYPE = 'footnote_entry'
         node_attr :id, :ref_id, :number
       end
 
       class Toc < Node
-        PM_TYPE = "toc"
+        PM_TYPE = 'toc'
         node_attr :title
       end
 
       class TocEntry < Node
-        PM_TYPE = "toc_entry"
+        PM_TYPE = 'toc_entry'
         node_attr :id, :title, :level
       end
 
       class ThematicBreak < Node
-        PM_TYPE = "thematic_break"
+        PM_TYPE = 'thematic_break'
       end
 
       class SoftBreak < Node
-        PM_TYPE = "soft_break"
+        PM_TYPE = 'soft_break'
       end
 
       class GenericBlock < Node
-        PM_TYPE = "generic_block"
+        PM_TYPE = 'generic_block'
         node_attr :semantic_type, :title, :id
       end
 
@@ -325,11 +325,12 @@ module Coradoc
                 registry = {}
                 constants.each do |name|
                   k = const_get(name)
-                  next unless k.is_a?(Class) && k < Node && k::PM_TYPE != "node"
+                  next unless k.is_a?(Class) && k < Node && k::PM_TYPE != 'node'
+
                   registry[k::PM_TYPE] = k
                 end
                 registry.freeze
-              end
+      end
 
       private
 

--- a/coradoc-mirror/lib/coradoc/mirror/node.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/node.rb
@@ -15,18 +15,12 @@ module Coradoc
     # Subclasses declare typed attributes via +node_attr+ and a +PM_TYPE+
     # constant for their canonical type string. New node types are added by
     # subclassing Node — no modification of existing code needed (OCP).
-    #
     class Node
       PM_TYPE = "node"
 
       attr_accessor :content, :marks
 
       class << self
-        # Declare a typed attribute for this node type.
-        #
-        # Generates an +attr_accessor+ and tracks the name for serialization
-        # and deserialization. Attributes default to +nil+ unless +default:+
-        # is specified.
         def node_attr(*names, default: nil)
           @node_attr_names ||= []
           @node_attr_defaults ||= {}
@@ -39,12 +33,10 @@ module Coradoc
           attr_accessor(*names)
         end
 
-        # Ordered list of attribute names declared via +node_attr+.
         def node_attr_names
           @node_attr_names ||= []
         end
 
-        # Default values for declared attributes.
         def node_attr_defaults
           @node_attr_defaults ||= {}
         end
@@ -70,7 +62,6 @@ module Coradoc
         @type_override || self.class::PM_TYPE
       end
 
-      # Serialize to ProseMirror-compatible Hash.
       def to_h
         result = { "type" => type }
         attrs = serialize_attrs
@@ -97,7 +88,6 @@ module Coradoc
         YAML.dump(to_h)
       end
 
-      # Reconstruct a Node tree from a ProseMirror-compatible Hash.
       def self.from_h(hash)
         return nil unless hash
 
@@ -121,7 +111,6 @@ module Coradoc
         end
       end
 
-      # Collect all text content from this node and its descendants.
       def text_content
         return "" unless content
 
@@ -130,9 +119,6 @@ module Coradoc
         end.join
       end
 
-      # Auto-registry: maps PM_TYPE → class for all declared subclasses.
-      NODES = {}
-
       # ── Node type subclasses ────────────────────────────────────
 
       class Text < Node
@@ -140,8 +126,8 @@ module Coradoc
 
         node_attr :text
 
-        def initialize(text: "", **kwargs)
-          super(**kwargs)
+        def initialize(text: "", **)
+          super(**)
           @text = text
         end
 
@@ -161,7 +147,7 @@ module Coradoc
           new(
             text: hash["text"] || "",
             attrs: (hash["attrs"] || {}).transform_keys(&:to_sym),
-            marks: (hash["marks"] || []).map { |m| Mark.from_h(m) },
+            marks: (hash["marks"] || []).map { |m| Mark.from_h(m) }
           )
         end
       end
@@ -329,19 +315,21 @@ module Coradoc
         PM_TYPE = "soft_break"
       end
 
-      # Generic typed block for unrecognized semantic types.
       class GenericBlock < Node
         PM_TYPE = "generic_block"
         node_attr :semantic_type, :title, :id
       end
 
-      # Auto-register all nested subclasses by PM_TYPE.
-      constants.each do |name|
-        klass = const_get(name)
-        next unless klass.is_a?(Class) && klass < Node && klass::PM_TYPE != "node"
-
-        NODES[klass::PM_TYPE] = klass
-      end
+      # Auto-registry: maps PM_TYPE → class for all declared subclasses.
+      NODES = begin
+                registry = {}
+                constants.each do |name|
+                  k = const_get(name)
+                  next unless k.is_a?(Class) && k < Node && k::PM_TYPE != "node"
+                  registry[k::PM_TYPE] = k
+                end
+                registry.freeze
+              end
 
       private
 
@@ -352,8 +340,6 @@ module Coradoc
         end
       end
 
-      # Build keyword arguments from a ProseMirror attrs hash,
-      # matching only attributes declared via +node_attr+ on the class.
       def self.build_kwargs(klass, attrs)
         return {} if attrs.empty?
 
@@ -362,6 +348,7 @@ module Coradoc
           kwargs[name] = symbolized[name] if symbolized.key?(name)
         end
       end
+      private_class_method :build_kwargs
     end
   end
 end

--- a/coradoc-mirror/lib/coradoc/mirror/output.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/output.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "json"
-require "yaml"
+require 'json'
+require 'yaml'
 
 module Coradoc
   module Mirror
@@ -19,7 +19,7 @@ module Coradoc
           end
 
           def processor_match?(filename)
-            filename.downcase.end_with?(".mirror.json")
+            filename.downcase.end_with?('.mirror.json')
           end
 
           def processor_execute(input, options = {})
@@ -40,7 +40,7 @@ module Coradoc
           end
 
           def processor_match?(filename)
-            filename.downcase.end_with?(".mirror.yaml", ".mirror.yml")
+            filename.downcase.end_with?('.mirror.yaml', '.mirror.yml')
           end
 
           def processor_execute(input, _options = {})

--- a/coradoc-mirror/lib/coradoc/mirror/output.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/output.rb
@@ -43,7 +43,7 @@ module Coradoc
             filename.downcase.end_with?(".mirror.yaml", ".mirror.yml")
           end
 
-          def processor_execute(input, options = {})
+          def processor_execute(input, _options = {})
             input.each_with_object({}) do |(filename, document), result|
               node = Coradoc::Mirror.transform(document)
               result[filename] = node.to_yaml

--- a/coradoc-mirror/lib/coradoc/mirror/version.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/version.rb
@@ -2,6 +2,6 @@
 
 module Coradoc
   module Mirror
-    VERSION = "0.1.0"
+    VERSION = '0.1.0'
   end
 end

--- a/coradoc-mirror/spec/coradoc/mirror/core_model_to_mirror_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/core_model_to_mirror_spec.rb
@@ -1,48 +1,48 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-require "json"
+require 'spec_helper'
+require 'json'
 
 RSpec.describe Coradoc::Mirror::CoreModelToMirror do
   let(:registry) { Coradoc::Mirror.default_registry }
   let(:transformer) { described_class.new(registry: registry) }
 
-  def make_section(title: "Section", level: 1, children: [], id: nil)
+  def make_section(title: 'Section', level: 1, children: [], id: nil)
     Coradoc::CoreModel::SectionElement.new(
       title: title,
       level: level,
       children: children,
-      id: id,
+      id: id
     )
   end
 
   def make_paragraph(text, id: nil)
     Coradoc::CoreModel::ParagraphBlock.new(
       content: text,
-      id: id,
+      id: id
     )
   end
 
-  def make_document(title: "Doc", children: [])
+  def make_document(title: 'Doc', children: [])
     Coradoc::CoreModel::DocumentElement.new(
       title: title,
-      children: children,
+      children: children
     )
   end
 
-  describe "#call" do
-    it "transforms a simple document with title" do
-      doc = make_document(title: "My Document")
+  describe '#call' do
+    it 'transforms a simple document with title' do
+      doc = make_document(title: 'My Document')
       result = transformer.call(doc)
 
       expect(result).to be_a(Coradoc::Mirror::Node::Document)
-      expect(result.title).to eq("My Document")
+      expect(result.title).to eq('My Document')
     end
 
-    it "transforms a document with sections" do
-      doc = make_document(title: "Doc", children: [
-                            make_section(title: "Introduction", level: 1, children: [
-                                           make_paragraph("Hello world")
+    it 'transforms a document with sections' do
+      doc = make_document(title: 'Doc', children: [
+                            make_section(title: 'Introduction', level: 1, children: [
+                                           make_paragraph('Hello world')
                                          ])
                           ])
       result = transformer.call(doc)
@@ -50,70 +50,70 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(result.content.length).to eq(1)
       section = result.content.first
       expect(section).to be_a(Coradoc::Mirror::Node::Section)
-      expect(section.title).to eq("Introduction")
+      expect(section.title).to eq('Introduction')
       expect(section.level).to eq(1)
 
       para = section.content.first
       expect(para).to be_a(Coradoc::Mirror::Node::Paragraph)
-      expect(para.content.first.text).to eq("Hello world")
+      expect(para.content.first.text).to eq('Hello world')
     end
 
-    it "produces valid JSON" do
-      doc = make_document(title: "Test", children: [
-                            make_paragraph("Content")
+    it 'produces valid JSON' do
+      doc = make_document(title: 'Test', children: [
+                            make_paragraph('Content')
                           ])
       result = transformer.call(doc)
       json = result.to_json
 
       parsed = JSON.parse(json)
-      expect(parsed["type"]).to eq("doc")
-      expect(parsed["attrs"]["title"]).to eq("Test")
+      expect(parsed['type']).to eq('doc')
+      expect(parsed['attrs']['title']).to eq('Test')
     end
   end
 
-  describe "block transformations" do
-    it "transforms source block" do
+  describe 'block transformations' do
+    it 'transforms source block' do
       block = Coradoc::CoreModel::SourceBlock.new(
-        content: "def hello; end",
-        language: "ruby",
+        content: 'def hello; end',
+        language: 'ruby'
       )
       doc = make_document(children: [block])
       result = transformer.call(doc)
 
       code = result.content.first
       expect(code).to be_a(Coradoc::Mirror::Node::CodeBlock)
-      expect(code.language).to eq("ruby")
-      expect(code.content.first.text).to eq("def hello; end")
+      expect(code.language).to eq('ruby')
+      expect(code.content.first.text).to eq('def hello; end')
     end
 
-    it "transforms quote block" do
+    it 'transforms quote block' do
       block = Coradoc::CoreModel::QuoteBlock.new(
-        content: "To be or not to be",
-        attribution: "Shakespeare",
+        content: 'To be or not to be',
+        attribution: 'Shakespeare'
       )
       doc = make_document(children: [block])
       result = transformer.call(doc)
 
       quote = result.content.first
       expect(quote).to be_a(Coradoc::Mirror::Node::Blockquote)
-      expect(quote.attribution).to eq("Shakespeare")
+      expect(quote.attribution).to eq('Shakespeare')
     end
 
-    it "transforms example block" do
+    it 'transforms example block' do
       block = Coradoc::CoreModel::ExampleBlock.new(
-        content: "Example content",
-        title: "Example 1",
+        content: 'Example content',
+        title: 'Example 1'
       )
       doc = make_document(children: [block])
       result = transformer.call(doc)
 
       example = result.content.first
       expect(example).to be_a(Coradoc::Mirror::Node::Example)
-      expect(example.title).to eq("Example 1")
+      expect(example.title).to eq('Example 1')
     end
 
-    it "transforms sidebar block" do
-      block = Coradoc::CoreModel::SidebarBlock.new(content: "Side info")
+    it 'transforms sidebar block' do
+      block = Coradoc::CoreModel::SidebarBlock.new(content: 'Side info')
       doc = make_document(children: [block])
       result = transformer.call(doc)
 
@@ -121,8 +121,8 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(sidebar).to be_a(Coradoc::Mirror::Node::Sidebar)
     end
 
-    it "transforms open block" do
-      block = Coradoc::CoreModel::OpenBlock.new(content: "Open content")
+    it 'transforms open block' do
+      block = Coradoc::CoreModel::OpenBlock.new(content: 'Open content')
       doc = make_document(children: [block])
       result = transformer.call(doc)
 
@@ -130,20 +130,20 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(open).to be_a(Coradoc::Mirror::Node::OpenBlock)
     end
 
-    it "transforms verse block" do
+    it 'transforms verse block' do
       block = Coradoc::CoreModel::VerseBlock.new(
-        content: "Roses are red",
-        attribution: "Anonymous",
+        content: 'Roses are red',
+        attribution: 'Anonymous'
       )
       doc = make_document(children: [block])
       result = transformer.call(doc)
 
       verse = result.content.first
       expect(verse).to be_a(Coradoc::Mirror::Node::Verse)
-      expect(verse.attribution).to eq("Anonymous")
+      expect(verse.attribution).to eq('Anonymous')
     end
 
-    it "transforms horizontal rule" do
+    it 'transforms horizontal rule' do
       block = Coradoc::CoreModel::HorizontalRuleBlock.new
       doc = make_document(children: [block])
       result = transformer.call(doc)
@@ -152,44 +152,44 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(hr).to be_a(Coradoc::Mirror::Node::HorizontalRule)
     end
 
-    it "skips comment blocks" do
-      block = Coradoc::CoreModel::CommentBlock.new(content: "Hidden")
+    it 'skips comment blocks' do
+      block = Coradoc::CoreModel::CommentBlock.new(content: 'Hidden')
       doc = make_document(children: [block])
       result = transformer.call(doc)
 
       expect(result.content).to be_empty
     end
 
-    it "skips reviewer blocks" do
-      block = Coradoc::CoreModel::ReviewerBlock.new(content: "Review")
+    it 'skips reviewer blocks' do
+      block = Coradoc::CoreModel::ReviewerBlock.new(content: 'Review')
       doc = make_document(children: [block])
       result = transformer.call(doc)
 
       expect(result.content).to be_empty
     end
 
-    it "transforms annotation / admonition block" do
+    it 'transforms annotation / admonition block' do
       block = Coradoc::CoreModel::AnnotationBlock.new(
-        annotation_type: "note",
-        content: "This is a note",
+        annotation_type: 'note',
+        content: 'This is a note'
       )
       doc = make_document(children: [block])
       result = transformer.call(doc)
 
       admonition = result.content.first
       expect(admonition).to be_a(Coradoc::Mirror::Node::Admonition)
-      expect(admonition.admonition_type).to eq("note")
+      expect(admonition.admonition_type).to eq('note')
     end
   end
 
-  describe "list transformations" do
-    it "transforms unordered list" do
+  describe 'list transformations' do
+    it 'transforms unordered list' do
       list = Coradoc::CoreModel::ListBlock.new(
-        marker_type: "unordered",
+        marker_type: 'unordered',
         items: [
-          Coradoc::CoreModel::ListItem.new(content: "First"),
-          Coradoc::CoreModel::ListItem.new(content: "Second")
-        ],
+          Coradoc::CoreModel::ListItem.new(content: 'First'),
+          Coradoc::CoreModel::ListItem.new(content: 'Second')
+        ]
       )
       doc = make_document(children: [list])
       result = transformer.call(doc)
@@ -198,16 +198,16 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(ul).to be_a(Coradoc::Mirror::Node::BulletList)
       expect(ul.content.length).to eq(2)
       expect(ul.content.first).to be_a(Coradoc::Mirror::Node::ListItem)
-      expect(ul.content.first.content.first.text).to eq("First")
+      expect(ul.content.first.content.first.text).to eq('First')
     end
 
-    it "transforms ordered list" do
+    it 'transforms ordered list' do
       list = Coradoc::CoreModel::ListBlock.new(
-        marker_type: "ordered",
+        marker_type: 'ordered',
         items: [
-          Coradoc::CoreModel::ListItem.new(content: "Step 1"),
-          Coradoc::CoreModel::ListItem.new(content: "Step 2")
-        ],
+          Coradoc::CoreModel::ListItem.new(content: 'Step 1'),
+          Coradoc::CoreModel::ListItem.new(content: 'Step 2')
+        ]
       )
       doc = make_document(children: [list])
       result = transformer.call(doc)
@@ -217,19 +217,19 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(ol.content.length).to eq(2)
     end
 
-    it "transforms list with nested list" do
+    it 'transforms list with nested list' do
       inner = Coradoc::CoreModel::ListBlock.new(
-        marker_type: "unordered",
-        items: [Coradoc::CoreModel::ListItem.new(content: "Nested")],
+        marker_type: 'unordered',
+        items: [Coradoc::CoreModel::ListItem.new(content: 'Nested')]
       )
       list = Coradoc::CoreModel::ListBlock.new(
-        marker_type: "unordered",
+        marker_type: 'unordered',
         items: [
           Coradoc::CoreModel::ListItem.new(
-            content: "Parent",
-            nested_list: inner,
+            content: 'Parent',
+            nested_list: inner
           )
-        ],
+        ]
       )
       doc = make_document(children: [list])
       result = transformer.call(doc)
@@ -240,14 +240,14 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(nested).to be_a(Coradoc::Mirror::Node::BulletList)
     end
 
-    it "transforms definition list" do
+    it 'transforms definition list' do
       dl = Coradoc::CoreModel::DefinitionList.new(
         items: [
           Coradoc::CoreModel::DefinitionItem.new(
-            term: "API",
-            definitions: ["Application Programming Interface"],
+            term: 'API',
+            definitions: ['Application Programming Interface']
           )
-        ],
+        ]
       )
       doc = make_document(children: [dl])
       result = transformer.call(doc)
@@ -260,32 +260,32 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
     end
   end
 
-  describe "table transformation" do
-    it "transforms table with header and body" do
+  describe 'table transformation' do
+    it 'transforms table with header and body' do
       table = Coradoc::CoreModel::Table.new(
-        title: "Data",
+        title: 'Data',
         rows: [
           Coradoc::CoreModel::TableRow.new(
             header: true,
             cells: [
-              Coradoc::CoreModel::TableCell.new(content: "Name", header: true),
-              Coradoc::CoreModel::TableCell.new(content: "Value", header: true)
-            ],
+              Coradoc::CoreModel::TableCell.new(content: 'Name', header: true),
+              Coradoc::CoreModel::TableCell.new(content: 'Value', header: true)
+            ]
           ),
           Coradoc::CoreModel::TableRow.new(
             cells: [
-              Coradoc::CoreModel::TableCell.new(content: "Foo"),
-              Coradoc::CoreModel::TableCell.new(content: "Bar")
-            ],
+              Coradoc::CoreModel::TableCell.new(content: 'Foo'),
+              Coradoc::CoreModel::TableCell.new(content: 'Bar')
+            ]
           )
-        ],
+        ]
       )
       doc = make_document(children: [table])
       result = transformer.call(doc)
 
       mirror_table = result.content.first
       expect(mirror_table).to be_a(Coradoc::Mirror::Node::Table)
-      expect(mirror_table.title).to eq("Data")
+      expect(mirror_table.title).to eq('Data')
       expect(mirror_table.content.length).to eq(2) # head + body
 
       head = mirror_table.content.first
@@ -295,29 +295,29 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
     end
   end
 
-  describe "image transformation" do
-    it "transforms image with all attributes" do
+  describe 'image transformation' do
+    it 'transforms image with all attributes' do
       image = Coradoc::CoreModel::Image.new(
-        src: "images/diagram.png",
-        alt: "Diagram",
-        caption: "Figure 1",
-        width: "800px",
+        src: 'images/diagram.png',
+        alt: 'Diagram',
+        caption: 'Figure 1',
+        width: '800px'
       )
       doc = make_document(children: [image])
       result = transformer.call(doc)
 
       mirror_img = result.content.first
       expect(mirror_img).to be_a(Coradoc::Mirror::Node::Image)
-      expect(mirror_img.src).to eq("images/diagram.png")
-      expect(mirror_img.alt).to eq("Diagram")
-      expect(mirror_img.caption).to eq("Figure 1")
-      expect(mirror_img.width).to eq("800px")
+      expect(mirror_img.src).to eq('images/diagram.png')
+      expect(mirror_img.alt).to eq('Diagram')
+      expect(mirror_img.caption).to eq('Figure 1')
+      expect(mirror_img.width).to eq('800px')
     end
   end
 
-  describe "inline element transformation" do
-    it "transforms bold text" do
-      bold = Coradoc::CoreModel::BoldElement.new(content: "important")
+  describe 'inline element transformation' do
+    it 'transforms bold text' do
+      bold = Coradoc::CoreModel::BoldElement.new(content: 'important')
       para = Coradoc::CoreModel::ParagraphBlock.new(children: [bold])
       doc = make_document(children: [para])
       result = transformer.call(doc)
@@ -325,12 +325,12 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       para_node = result.content.first
       text_node = para_node.content.first
       expect(text_node).to be_a(Coradoc::Mirror::Node::Text)
-      expect(text_node.text).to eq("important")
+      expect(text_node.text).to eq('important')
       expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::Bold)
     end
 
-    it "transforms italic text" do
-      italic = Coradoc::CoreModel::ItalicElement.new(content: "emphasis")
+    it 'transforms italic text' do
+      italic = Coradoc::CoreModel::ItalicElement.new(content: 'emphasis')
       para = Coradoc::CoreModel::ParagraphBlock.new(children: [italic])
       doc = make_document(children: [para])
       result = transformer.call(doc)
@@ -339,8 +339,8 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::Italic)
     end
 
-    it "transforms monospace text" do
-      mono = Coradoc::CoreModel::MonospaceElement.new(content: "code")
+    it 'transforms monospace text' do
+      mono = Coradoc::CoreModel::MonospaceElement.new(content: 'code')
       para = Coradoc::CoreModel::ParagraphBlock.new(children: [mono])
       doc = make_document(children: [para])
       result = transformer.call(doc)
@@ -349,25 +349,25 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::Monospace)
     end
 
-    it "transforms link" do
+    it 'transforms link' do
       link = Coradoc::CoreModel::LinkElement.new(
-        content: "Click here",
-        target: "https://example.com",
+        content: 'Click here',
+        target: 'https://example.com'
       )
       para = Coradoc::CoreModel::ParagraphBlock.new(children: [link])
       doc = make_document(children: [para])
       result = transformer.call(doc)
 
       text_node = result.content.first.content.first
-      expect(text_node.text).to eq("Click here")
+      expect(text_node.text).to eq('Click here')
       expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::Link)
-      expect(text_node.marks.first.href).to eq("https://example.com")
+      expect(text_node.marks.first.href).to eq('https://example.com')
     end
 
-    it "transforms cross-reference" do
+    it 'transforms cross-reference' do
       xref = Coradoc::CoreModel::CrossReferenceElement.new(
-        content: "Section 1",
-        target: "section-1",
+        content: 'Section 1',
+        target: 'section-1'
       )
       para = Coradoc::CoreModel::ParagraphBlock.new(children: [xref])
       doc = make_document(children: [para])
@@ -375,12 +375,12 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
 
       text_node = result.content.first.content.first
       expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::CrossReference)
-      expect(text_node.marks.first.target).to eq("section-1")
+      expect(text_node.marks.first.target).to eq('section-1')
     end
 
-    it "transforms subscript and superscript" do
-      sub = Coradoc::CoreModel::SubscriptElement.new(content: "2")
-      sup = Coradoc::CoreModel::SuperscriptElement.new(content: "nd")
+    it 'transforms subscript and superscript' do
+      sub = Coradoc::CoreModel::SubscriptElement.new(content: '2')
+      sup = Coradoc::CoreModel::SuperscriptElement.new(content: 'nd')
       para = Coradoc::CoreModel::ParagraphBlock.new(children: [sub, sup])
       doc = make_document(children: [para])
       result = transformer.call(doc)
@@ -390,8 +390,8 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(nodes[1].marks.first).to be_a(Coradoc::Mirror::Mark::Superscript)
     end
 
-    it "transforms highlight" do
-      highlight = Coradoc::CoreModel::HighlightElement.new(content: "noted")
+    it 'transforms highlight' do
+      highlight = Coradoc::CoreModel::HighlightElement.new(content: 'noted')
       para = Coradoc::CoreModel::ParagraphBlock.new(children: [highlight])
       doc = make_document(children: [para])
       result = transformer.call(doc)
@@ -400,46 +400,46 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(text_node.marks.first).to be_a(Coradoc::Mirror::Mark::Highlight)
     end
 
-    it "transforms text content" do
-      text = Coradoc::CoreModel::TextContent.new(text: "plain text")
+    it 'transforms text content' do
+      text = Coradoc::CoreModel::TextContent.new(text: 'plain text')
       para = Coradoc::CoreModel::ParagraphBlock.new(children: [text])
       doc = make_document(children: [para])
       result = transformer.call(doc)
 
       text_node = result.content.first.content.first
-      expect(text_node.text).to eq("plain text")
+      expect(text_node.text).to eq('plain text')
       expect(text_node.marks).to be_empty
     end
   end
 
-  describe "bibliography transformation" do
-    it "transforms bibliography with entries" do
+  describe 'bibliography transformation' do
+    it 'transforms bibliography with entries' do
       bib = Coradoc::CoreModel::Bibliography.new(
-        title: "References",
+        title: 'References',
         entries: [
           Coradoc::CoreModel::BibliographyEntry.new(
-            anchor_name: "ISO712",
-            document_id: "ISO 712",
-            ref_text: "Cereals and cereal products",
+            anchor_name: 'ISO712',
+            document_id: 'ISO 712',
+            ref_text: 'Cereals and cereal products'
           )
-        ],
+        ]
       )
       doc = make_document(children: [bib])
       result = transformer.call(doc)
 
       mirror_bib = result.content.first
       expect(mirror_bib).to be_a(Coradoc::Mirror::Node::Bibliography)
-      expect(mirror_bib.title).to eq("References")
+      expect(mirror_bib.title).to eq('References')
       entry = mirror_bib.content.first
       expect(entry).to be_a(Coradoc::Mirror::Node::BibliographyEntry)
-      expect(entry.document_id).to eq("ISO 712")
+      expect(entry.document_id).to eq('ISO 712')
     end
   end
 
-  describe "footnote transformation" do
-    it "transforms footnote and collects at document end" do
-      fn = Coradoc::CoreModel::Footnote.new(id: "fn1", content: "A footnote.")
-      para = make_paragraph("Text with footnote")
+  describe 'footnote transformation' do
+    it 'transforms footnote and collects at document end' do
+      fn = Coradoc::CoreModel::Footnote.new(id: 'fn1', content: 'A footnote.')
+      para = make_paragraph('Text with footnote')
       doc = make_document(children: [para, fn])
       result = transformer.call(doc)
 
@@ -452,33 +452,33 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
     end
   end
 
-  describe "kitchen sink" do
-    it "transforms a complex document with multiple element types" do
-      doc = make_document(title: "Kitchen Sink", children: [
-                            make_section(title: "Overview", level: 1, children: [
-                                           make_paragraph("Welcome to the test document."),
-                              Coradoc::CoreModel::SourceBlock.new(
-                                content: "puts 'hello'",
-                                language: "ruby",
-                              ),
-                              Coradoc::CoreModel::ListBlock.new(
-                                marker_type: "unordered",
-                                items: [
-                                  Coradoc::CoreModel::ListItem.new(content: "Item 1"),
-                                  Coradoc::CoreModel::ListItem.new(content: "Item 2")
-                                ],
-                              )
+  describe 'kitchen sink' do
+    it 'transforms a complex document with multiple element types' do
+      doc = make_document(title: 'Kitchen Sink', children: [
+                            make_section(title: 'Overview', level: 1, children: [
+                                           make_paragraph('Welcome to the test document.'),
+                                           Coradoc::CoreModel::SourceBlock.new(
+                                             content: "puts 'hello'",
+                                             language: 'ruby'
+                                           ),
+                                           Coradoc::CoreModel::ListBlock.new(
+                                             marker_type: 'unordered',
+                                             items: [
+                                               Coradoc::CoreModel::ListItem.new(content: 'Item 1'),
+                                               Coradoc::CoreModel::ListItem.new(content: 'Item 2')
+                                             ]
+                                           )
                                          ]),
-        make_section(title: "Details", level: 2, children: [
-                       Coradoc::CoreModel::AnnotationBlock.new(
-                         annotation_type: "warning",
-                         content: "Be careful!",
-                       ),
-          Coradoc::CoreModel::Image.new(
-            src: "diagram.png",
-            alt: "Architecture",
-          )
-                     ])
+                            make_section(title: 'Details', level: 2, children: [
+                                           Coradoc::CoreModel::AnnotationBlock.new(
+                                             annotation_type: 'warning',
+                                             content: 'Be careful!'
+                                           ),
+                                           Coradoc::CoreModel::Image.new(
+                                             src: 'diagram.png',
+                                             alt: 'Architecture'
+                                           )
+                                         ])
                           ])
 
       result = transformer.call(doc)
@@ -486,20 +486,20 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       parsed = JSON.parse(json)
 
       # Verify structure
-      expect(parsed["type"]).to eq("doc")
-      expect(parsed["attrs"]["title"]).to eq("Kitchen Sink")
-      expect(parsed["content"].length).to eq(2)
+      expect(parsed['type']).to eq('doc')
+      expect(parsed['attrs']['title']).to eq('Kitchen Sink')
+      expect(parsed['content'].length).to eq(2)
 
       # Section 1
-      s1 = parsed["content"][0]
-      expect(s1["type"]).to eq("section")
-      expect(s1["attrs"]["title"]).to eq("Overview")
-      expect(s1["content"].length).to eq(3)
+      s1 = parsed['content'][0]
+      expect(s1['type']).to eq('section')
+      expect(s1['attrs']['title']).to eq('Overview')
+      expect(s1['content'].length).to eq(3)
 
       # Section 2
-      s2 = parsed["content"][1]
-      expect(s2["type"]).to eq("section")
-      expect(s2["attrs"]["title"]).to eq("Details")
+      s2 = parsed['content'][1]
+      expect(s2['type']).to eq('section')
+      expect(s2['attrs']['title']).to eq('Details')
     end
   end
 end

--- a/coradoc-mirror/spec/coradoc/mirror/core_model_to_mirror_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/core_model_to_mirror_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
 
     it "transforms a document with sections" do
       doc = make_document(title: "Doc", children: [
-        make_section(title: "Introduction", level: 1, children: [
-          make_paragraph("Hello world"),
-        ]),
-      ])
+                            make_section(title: "Introduction", level: 1, children: [
+                                           make_paragraph("Hello world")
+                                         ])
+                          ])
       result = transformer.call(doc)
 
       expect(result.content.length).to eq(1)
@@ -60,8 +60,8 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
 
     it "produces valid JSON" do
       doc = make_document(title: "Test", children: [
-        make_paragraph("Content"),
-      ])
+                            make_paragraph("Content")
+                          ])
       result = transformer.call(doc)
       json = result.to_json
 
@@ -188,7 +188,7 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
         marker_type: "unordered",
         items: [
           Coradoc::CoreModel::ListItem.new(content: "First"),
-          Coradoc::CoreModel::ListItem.new(content: "Second"),
+          Coradoc::CoreModel::ListItem.new(content: "Second")
         ],
       )
       doc = make_document(children: [list])
@@ -206,7 +206,7 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
         marker_type: "ordered",
         items: [
           Coradoc::CoreModel::ListItem.new(content: "Step 1"),
-          Coradoc::CoreModel::ListItem.new(content: "Step 2"),
+          Coradoc::CoreModel::ListItem.new(content: "Step 2")
         ],
       )
       doc = make_document(children: [list])
@@ -228,7 +228,7 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
           Coradoc::CoreModel::ListItem.new(
             content: "Parent",
             nested_list: inner,
-          ),
+          )
         ],
       )
       doc = make_document(children: [list])
@@ -246,7 +246,7 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
           Coradoc::CoreModel::DefinitionItem.new(
             term: "API",
             definitions: ["Application Programming Interface"],
-          ),
+          )
         ],
       )
       doc = make_document(children: [dl])
@@ -269,15 +269,15 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
             header: true,
             cells: [
               Coradoc::CoreModel::TableCell.new(content: "Name", header: true),
-              Coradoc::CoreModel::TableCell.new(content: "Value", header: true),
+              Coradoc::CoreModel::TableCell.new(content: "Value", header: true)
             ],
           ),
           Coradoc::CoreModel::TableRow.new(
             cells: [
               Coradoc::CoreModel::TableCell.new(content: "Foo"),
-              Coradoc::CoreModel::TableCell.new(content: "Bar"),
+              Coradoc::CoreModel::TableCell.new(content: "Bar")
             ],
-          ),
+          )
         ],
       )
       doc = make_document(children: [table])
@@ -421,7 +421,7 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
             anchor_name: "ISO712",
             document_id: "ISO 712",
             ref_text: "Cereals and cereal products",
-          ),
+          )
         ],
       )
       doc = make_document(children: [bib])
@@ -455,31 +455,31 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
   describe "kitchen sink" do
     it "transforms a complex document with multiple element types" do
       doc = make_document(title: "Kitchen Sink", children: [
-        make_section(title: "Overview", level: 1, children: [
-          make_paragraph("Welcome to the test document."),
-          Coradoc::CoreModel::SourceBlock.new(
-            content: "puts 'hello'",
-            language: "ruby",
-          ),
-          Coradoc::CoreModel::ListBlock.new(
-            marker_type: "unordered",
-            items: [
-              Coradoc::CoreModel::ListItem.new(content: "Item 1"),
-              Coradoc::CoreModel::ListItem.new(content: "Item 2"),
-            ],
-          ),
-        ]),
+                            make_section(title: "Overview", level: 1, children: [
+                                           make_paragraph("Welcome to the test document."),
+                              Coradoc::CoreModel::SourceBlock.new(
+                                content: "puts 'hello'",
+                                language: "ruby",
+                              ),
+                              Coradoc::CoreModel::ListBlock.new(
+                                marker_type: "unordered",
+                                items: [
+                                  Coradoc::CoreModel::ListItem.new(content: "Item 1"),
+                                  Coradoc::CoreModel::ListItem.new(content: "Item 2")
+                                ],
+                              )
+                                         ]),
         make_section(title: "Details", level: 2, children: [
-          Coradoc::CoreModel::AnnotationBlock.new(
-            annotation_type: "warning",
-            content: "Be careful!",
-          ),
+                       Coradoc::CoreModel::AnnotationBlock.new(
+                         annotation_type: "warning",
+                         content: "Be careful!",
+                       ),
           Coradoc::CoreModel::Image.new(
             src: "diagram.png",
             alt: "Architecture",
-          ),
-        ]),
-      ])
+          )
+                     ])
+                          ])
 
       result = transformer.call(doc)
       json = result.to_json(pretty: true)

--- a/coradoc-mirror/spec/coradoc/mirror/handler_registry_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handler_registry_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::Mirror::HandlerRegistry do
-  describe "#register and #entry_for" do
-    it "finds a registered handler by exact class" do
+  describe '#register and #entry_for' do
+    it 'finds a registered handler by exact class' do
       registry = described_class.new
       handler = ->(el, _ctx) { el }
       registry.register(Coradoc::CoreModel::ParagraphBlock, handler)
@@ -13,7 +13,7 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
       expect(entry.handler).to eq(handler)
     end
 
-    it "finds a handler via ancestor walk" do
+    it 'finds a handler via ancestor walk' do
       registry = described_class.new
       handler = ->(el, _ctx) { el }
       registry.register(Coradoc::CoreModel::Block, handler)
@@ -23,7 +23,7 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
       expect(entry.handler).to eq(handler)
     end
 
-    it "prefers exact match over ancestor" do
+    it 'prefers exact match over ancestor' do
       registry = described_class.new
       base_handler = ->(_el, _ctx) { :base }
       specific_handler = ->(_el, _ctx) { :specific }
@@ -34,28 +34,28 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
       expect(entry.handler).to eq(specific_handler)
     end
 
-    it "returns nil for unregistered class" do
+    it 'returns nil for unregistered class' do
       registry = described_class.new
       entry = registry.entry_for(Coradoc::CoreModel::ParagraphBlock.new)
       expect(entry).to be_nil
     end
   end
 
-  describe "#registered?" do
-    it "returns true for registered class" do
+  describe '#registered?' do
+    it 'returns true for registered class' do
       registry = described_class.new
       registry.register(Coradoc::CoreModel::Block, ->(el, _ctx) { el })
       expect(registry.registered?(Coradoc::CoreModel::Block)).to be true
     end
 
-    it "returns false for unregistered class" do
+    it 'returns false for unregistered class' do
       registry = described_class.new
       expect(registry.registered?(Coradoc::CoreModel::Block)).to be false
     end
   end
 
-  describe "#handle" do
-    it "dispatches to handler and returns result with concat flag" do
+  describe '#handle' do
+    it 'dispatches to handler and returns result with concat flag' do
       registry = described_class.new
       handler = Module.new do
         # rubocop:disable Lint/UnusedMethodArgument
@@ -68,34 +68,34 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
 
       element = Coradoc::CoreModel::ParagraphBlock.new
       result = registry.handle(element, context: nil)
-      expect(result).to eq(["handled: Coradoc::CoreModel::ParagraphBlock", false])
+      expect(result).to eq(['handled: Coradoc::CoreModel::ParagraphBlock', false])
     end
 
-    it "dispatches to Proc handler" do
+    it 'dispatches to Proc handler' do
       registry = described_class.new
       handler = ->(element, _context) { "proc: #{element.class}" }
       registry.register(Coradoc::CoreModel::Block, handler)
 
       element = Coradoc::CoreModel::Block.new
       result = registry.handle(element, context: nil)
-      expect(result).to eq(["proc: Coradoc::CoreModel::Block", false])
+      expect(result).to eq(['proc: Coradoc::CoreModel::Block', false])
     end
 
-    it "dispatches to specific method name" do
+    it 'dispatches to specific method name' do
       registry = described_class.new
       handler = Module.new do
         def self.convert(_element, *)
-          "converted"
+          'converted'
         end
       end
       registry.register(Coradoc::CoreModel::Block, handler, method_name: :convert)
 
       element = Coradoc::CoreModel::Block.new
       result = registry.handle(element, context: nil)
-      expect(result).to eq(["converted", false])
+      expect(result).to eq(['converted', false])
     end
 
-    it "passes extra_kwargs to handler" do
+    it 'passes extra_kwargs to handler' do
       registry = described_class.new
       handler = Module.new do
         # rubocop:disable Lint/UnusedMethodArgument
@@ -104,21 +104,21 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
         end
         # rubocop:enable Lint/UnusedMethodArgument
       end
-      registry.register(Coradoc::CoreModel::Block, handler, extra_kwargs: { extra_option: "yes" })
+      registry.register(Coradoc::CoreModel::Block, handler, extra_kwargs: { extra_option: 'yes' })
 
       element = Coradoc::CoreModel::Block.new
       result = registry.handle(element, context: nil)
-      expect(result).to eq(["extra: yes", false])
+      expect(result).to eq(['extra: yes', false])
     end
 
-    it "returns nil for unregistered element" do
+    it 'returns nil for unregistered element' do
       registry = described_class.new
       element = Coradoc::CoreModel::Block.new
       result = registry.handle(element, context: nil)
       expect(result).to be_nil
     end
 
-    it "supports concat flag" do
+    it 'supports concat flag' do
       registry = described_class.new
       handler = ->(_element, _context) { [1, 2, 3] }
       registry.register(Coradoc::CoreModel::Block, handler, concat: true)

--- a/coradoc-mirror/spec/coradoc/mirror/handler_registry_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handler_registry_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
   describe "#register and #entry_for" do
     it "finds a registered handler by exact class" do
       registry = described_class.new
-      handler = ->(el, ctx) { el }
+      handler = ->(el, _ctx) { el }
       registry.register(Coradoc::CoreModel::ParagraphBlock, handler)
 
       entry = registry.entry_for(Coradoc::CoreModel::ParagraphBlock.new)
@@ -15,7 +15,7 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
 
     it "finds a handler via ancestor walk" do
       registry = described_class.new
-      handler = ->(el, ctx) { el }
+      handler = ->(el, _ctx) { el }
       registry.register(Coradoc::CoreModel::Block, handler)
 
       # SourceBlock inherits from Block
@@ -25,8 +25,8 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
 
     it "prefers exact match over ancestor" do
       registry = described_class.new
-      base_handler = ->(el, ctx) { :base }
-      specific_handler = ->(el, ctx) { :specific }
+      base_handler = ->(_el, _ctx) { :base }
+      specific_handler = ->(_el, _ctx) { :specific }
       registry.register(Coradoc::CoreModel::Block, base_handler)
       registry.register(Coradoc::CoreModel::SourceBlock, specific_handler)
 
@@ -44,7 +44,7 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
   describe "#registered?" do
     it "returns true for registered class" do
       registry = described_class.new
-      registry.register(Coradoc::CoreModel::Block, ->(el, ctx) { el })
+      registry.register(Coradoc::CoreModel::Block, ->(el, _ctx) { el })
       expect(registry.registered?(Coradoc::CoreModel::Block)).to be true
     end
 
@@ -58,9 +58,11 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
     it "dispatches to handler and returns result with concat flag" do
       registry = described_class.new
       handler = Module.new do
+        # rubocop:disable Lint/UnusedMethodArgument
         def self.call(element, context:)
           "handled: #{element.class}"
         end
+        # rubocop:enable Lint/UnusedMethodArgument
       end
       registry.register(Coradoc::CoreModel::ParagraphBlock, handler)
 
@@ -71,7 +73,7 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
 
     it "dispatches to Proc handler" do
       registry = described_class.new
-      handler = ->(element, context) { "proc: #{element.class}" }
+      handler = ->(element, _context) { "proc: #{element.class}" }
       registry.register(Coradoc::CoreModel::Block, handler)
 
       element = Coradoc::CoreModel::Block.new
@@ -82,7 +84,7 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
     it "dispatches to specific method name" do
       registry = described_class.new
       handler = Module.new do
-        def self.convert(element, context:)
+        def self.convert(_element, *)
           "converted"
         end
       end
@@ -96,9 +98,11 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
     it "passes extra_kwargs to handler" do
       registry = described_class.new
       handler = Module.new do
-        def self.call(element, context:, extra_option: nil)
+        # rubocop:disable Lint/UnusedMethodArgument
+        def self.call(_element, context:, extra_option: nil)
           "extra: #{extra_option}"
         end
+        # rubocop:enable Lint/UnusedMethodArgument
       end
       registry.register(Coradoc::CoreModel::Block, handler, extra_kwargs: { extra_option: "yes" })
 
@@ -116,7 +120,7 @@ RSpec.describe Coradoc::Mirror::HandlerRegistry do
 
     it "supports concat flag" do
       registry = described_class.new
-      handler = ->(element, context) { [1, 2, 3] }
+      handler = ->(_element, _context) { [1, 2, 3] }
       registry.register(Coradoc::CoreModel::Block, handler, concat: true)
 
       element = Coradoc::CoreModel::Block.new

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/generic_block_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/generic_block_spec.rb
@@ -1,10 +1,11 @@
-require "spec_helper"
+# frozen_string_literal: true
+require 'spec_helper'
 
 RSpec.describe Coradoc::Mirror::Handlers::GenericBlock do
   let(:context) { Coradoc::Mirror::CoreModelToMirror.new }
 
-  describe ".call" do
-    it "returns nil if content is empty" do
+  describe '.call' do
+    it 'returns nil if content is empty' do
       block_class = Class.new(Coradoc::CoreModel::Block)
       element = block_class.new
 
@@ -12,7 +13,7 @@ RSpec.describe Coradoc::Mirror::Handlers::GenericBlock do
       expect(result).to be_nil
     end
 
-    it "creates a generic block node with semantic type" do
+    it 'creates a generic block node with semantic type' do
       block_class = Class.new(Coradoc::CoreModel::Block) do
         def resolve_semantic_type
           :test_type
@@ -20,23 +21,23 @@ RSpec.describe Coradoc::Mirror::Handlers::GenericBlock do
       end
 
       element = block_class.new(
-        id: "block-1",
-        title: "Test Block",
-        children: [Coradoc::CoreModel::TextContent.new(text: "Some text")]
+        id: 'block-1',
+        title: 'Test Block',
+        children: [Coradoc::CoreModel::TextContent.new(text: 'Some text')]
       )
 
       result = described_class.call(element, context: context)
 
       expect(result).to be_a(Coradoc::Mirror::Node::GenericBlock)
-      expect(result.id).to eq("block-1")
-      expect(result.title).to eq("Test Block")
-      expect(result.semantic_type).to eq("test_type")
+      expect(result.id).to eq('block-1')
+      expect(result.title).to eq('Test Block')
+      expect(result.semantic_type).to eq('test_type')
       expect(result.content.length).to eq(1)
-      expect(result.content.first.type).to eq("text")
-      expect(result.content.first.text).to eq("Some text")
+      expect(result.content.first.type).to eq('text')
+      expect(result.content.first.text).to eq('Some text')
     end
 
-    it "creates a generic block node without semantic type" do
+    it 'creates a generic block node without semantic type' do
       block_class = Class.new(Coradoc::CoreModel::Block) do
         def resolve_semantic_type
           nil
@@ -44,7 +45,7 @@ RSpec.describe Coradoc::Mirror::Handlers::GenericBlock do
       end
 
       element = block_class.new(
-        children: [Coradoc::CoreModel::TextContent.new(text: "Some text")]
+        children: [Coradoc::CoreModel::TextContent.new(text: 'Some text')]
       )
 
       result = described_class.call(element, context: context)

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/inline_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/inline_spec.rb
@@ -1,38 +1,39 @@
-require "spec_helper"
+# frozen_string_literal: true
+require 'spec_helper'
 
 RSpec.describe Coradoc::Mirror::Handlers::Inline do
   let(:context) { Coradoc::Mirror::CoreModelToMirror.new }
 
-  describe ".process" do
-    it "processes simple marks" do
-      bold = Coradoc::CoreModel::BoldElement.new(content: "bold text")
+  describe '.process' do
+    it 'processes simple marks' do
+      bold = Coradoc::CoreModel::BoldElement.new(content: 'bold text')
       element = Coradoc::CoreModel::ParagraphBlock.new(
         children: [bold]
       )
 
       nodes = described_class.process(element, context: context)
       expect(nodes.length).to eq(1)
-      expect(nodes.first.type).to eq("text")
-      expect(nodes.first.text).to eq("bold text")
-      expect(nodes.first.marks.first.type).to eq("bold")
+      expect(nodes.first.type).to eq('text')
+      expect(nodes.first.text).to eq('bold text')
+      expect(nodes.first.marks.first.type).to eq('bold')
     end
 
-    it "processes text content" do
-      text = Coradoc::CoreModel::TextContent.new(text: "plain text")
+    it 'processes text content' do
+      text = Coradoc::CoreModel::TextContent.new(text: 'plain text')
       element = Coradoc::CoreModel::ParagraphBlock.new(
         children: [text]
       )
 
       nodes = described_class.process(element, context: context)
       expect(nodes.length).to eq(1)
-      expect(nodes.first.type).to eq("text")
-      expect(nodes.first.text).to eq("plain text")
+      expect(nodes.first.type).to eq('text')
+      expect(nodes.first.text).to eq('plain text')
     end
 
-    it "processes semantic marks like links" do
+    it 'processes semantic marks like links' do
       link = Coradoc::CoreModel::LinkElement.new(
-        target: "https://example.com",
-        content: "Example"
+        target: 'https://example.com',
+        content: 'Example'
       )
       element = Coradoc::CoreModel::ParagraphBlock.new(
         children: [link]
@@ -40,36 +41,36 @@ RSpec.describe Coradoc::Mirror::Handlers::Inline do
 
       nodes = described_class.process(element, context: context)
       expect(nodes.length).to eq(1)
-      expect(nodes.first.type).to eq("text")
-      expect(nodes.first.text).to eq("Example")
-      expect(nodes.first.marks.first.type).to eq("link")
-      expect(nodes.first.marks.first.href).to eq("https://example.com")
+      expect(nodes.first.type).to eq('text')
+      expect(nodes.first.text).to eq('Example')
+      expect(nodes.first.marks.first.type).to eq('link')
+      expect(nodes.first.marks.first.href).to eq('https://example.com')
     end
   end
 
-  describe ".text_content" do
-    it "returns nil for empty text" do
-      text = Coradoc::CoreModel::TextContent.new(text: "")
+  describe '.text_content' do
+    it 'returns nil for empty text' do
+      text = Coradoc::CoreModel::TextContent.new(text: '')
       node = described_class.text_content(text, context: context)
       expect(node).to be_nil
     end
 
-    it "returns text node" do
-      text = Coradoc::CoreModel::TextContent.new(text: "hello")
+    it 'returns text node' do
+      text = Coradoc::CoreModel::TextContent.new(text: 'hello')
       node = described_class.text_content(text, context: context)
-      expect(node.type).to eq("text")
-      expect(node.text).to eq("hello")
+      expect(node.type).to eq('text')
+      expect(node.text).to eq('hello')
     end
   end
 
-  describe ".call" do
-    it "handles inline element directly" do
-      italic = Coradoc::CoreModel::ItalicElement.new(content: "italic text")
+  describe '.call' do
+    it 'handles inline element directly' do
+      italic = Coradoc::CoreModel::ItalicElement.new(content: 'italic text')
       node = described_class.call(italic, context: context)
 
-      expect(node.type).to eq("text")
-      expect(node.text).to eq("italic text")
-      expect(node.marks.first.type).to eq("italic")
+      expect(node.type).to eq('text')
+      expect(node.text).to eq('italic text')
+      expect(node.marks.first.type).to eq('italic')
     end
   end
 end

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/inline_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/inline_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Coradoc::Mirror::Handlers::Inline do
       element = Coradoc::CoreModel::ParagraphBlock.new(
         children: [bold]
       )
-      
+
       nodes = described_class.process(element, context: context)
       expect(nodes.length).to eq(1)
       expect(nodes.first.type).to eq("text")
@@ -22,7 +22,7 @@ RSpec.describe Coradoc::Mirror::Handlers::Inline do
       element = Coradoc::CoreModel::ParagraphBlock.new(
         children: [text]
       )
-      
+
       nodes = described_class.process(element, context: context)
       expect(nodes.length).to eq(1)
       expect(nodes.first.type).to eq("text")
@@ -37,7 +37,7 @@ RSpec.describe Coradoc::Mirror::Handlers::Inline do
       element = Coradoc::CoreModel::ParagraphBlock.new(
         children: [link]
       )
-      
+
       nodes = described_class.process(element, context: context)
       expect(nodes.length).to eq(1)
       expect(nodes.first.type).to eq("text")
@@ -66,7 +66,7 @@ RSpec.describe Coradoc::Mirror::Handlers::Inline do
     it "handles inline element directly" do
       italic = Coradoc::CoreModel::ItalicElement.new(content: "italic text")
       node = described_class.call(italic, context: context)
-      
+
       expect(node.type).to eq("text")
       expect(node.text).to eq("italic text")
       expect(node.marks.first.type).to eq("italic")

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/structural_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/structural_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Coradoc::Mirror::Handlers::Structural do
         level: 2,
         children: [Coradoc::CoreModel::ParagraphBlock.new(content: "Content")]
       )
-      
+
       node = described_class.section(element, context: context)
       expect(node).to be_a(Coradoc::Mirror::Node::Section)
       expect(node.type).to eq("section")
@@ -57,7 +57,7 @@ RSpec.describe Coradoc::Mirror::Handlers::Structural do
         level: 1,
         children: [Coradoc::CoreModel::ParagraphBlock.new(content: "Author info")]
       )
-      
+
       node = described_class.header(element, context: context)
       expect(node).to be_a(Coradoc::Mirror::Node::Header)
       expect(node.type).to eq("header")

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/structural_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/structural_spec.rb
@@ -1,67 +1,68 @@
-require "spec_helper"
+# frozen_string_literal: true
+require 'spec_helper'
 
 RSpec.describe Coradoc::Mirror::Handlers::Structural do
   let(:context) { Coradoc::Mirror::CoreModelToMirror.new }
 
-  describe ".document" do
-    it "creates a document node" do
+  describe '.document' do
+    it 'creates a document node' do
       element = Coradoc::CoreModel::DocumentElement.new(
-        title: "Test Document",
-        children: [Coradoc::CoreModel::ParagraphBlock.new(content: "Content")]
+        title: 'Test Document',
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: 'Content')]
       )
 
       node = described_class.document(element, context: context)
       expect(node).to be_a(Coradoc::Mirror::Node::Document)
-      expect(node.type).to eq("doc")
-      expect(node.title).to eq("Test Document")
+      expect(node.type).to eq('doc')
+      expect(node.title).to eq('Test Document')
       expect(node.content.length).to eq(1)
     end
   end
 
-  describe ".section" do
-    it "creates a section node" do
+  describe '.section' do
+    it 'creates a section node' do
       element = Coradoc::CoreModel::SectionElement.new(
-        id: "sec-1",
-        title: "Test Section",
+        id: 'sec-1',
+        title: 'Test Section',
         level: 2,
-        children: [Coradoc::CoreModel::ParagraphBlock.new(content: "Content")]
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: 'Content')]
       )
 
       node = described_class.section(element, context: context)
       expect(node).to be_a(Coradoc::Mirror::Node::Section)
-      expect(node.type).to eq("section")
-      expect(node.id).to eq("sec-1")
-      expect(node.title).to eq("Test Section")
+      expect(node.type).to eq('section')
+      expect(node.id).to eq('sec-1')
+      expect(node.title).to eq('Test Section')
       expect(node.level).to eq(2)
       expect(node.content.length).to eq(1)
     end
   end
 
-  describe ".preamble" do
-    it "creates a preamble node" do
+  describe '.preamble' do
+    it 'creates a preamble node' do
       element = Coradoc::CoreModel::PreambleElement.new(
-        children: [Coradoc::CoreModel::ParagraphBlock.new(content: "Content")]
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: 'Content')]
       )
 
       node = described_class.preamble(element, context: context)
       expect(node).to be_a(Coradoc::Mirror::Node::Preamble)
-      expect(node.type).to eq("preamble")
+      expect(node.type).to eq('preamble')
       expect(node.content.length).to eq(1)
     end
   end
 
-  describe ".header" do
-    it "creates a header node" do
+  describe '.header' do
+    it 'creates a header node' do
       element = Coradoc::CoreModel::HeaderElement.new(
-        title: "Main Title",
+        title: 'Main Title',
         level: 1,
-        children: [Coradoc::CoreModel::ParagraphBlock.new(content: "Author info")]
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: 'Author info')]
       )
 
       node = described_class.header(element, context: context)
       expect(node).to be_a(Coradoc::Mirror::Node::Header)
-      expect(node.type).to eq("header")
-      expect(node.title).to eq("Main Title")
+      expect(node.type).to eq('header')
+      expect(node.title).to eq('Main Title')
       expect(node.level).to eq(1)
       expect(node.content.length).to eq(1)
     end

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/toc_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/toc_spec.rb
@@ -1,52 +1,53 @@
-require "spec_helper"
+# frozen_string_literal: true
+require 'spec_helper'
 
 RSpec.describe Coradoc::Mirror::Handlers::Toc do
   let(:context) { Coradoc::Mirror::CoreModelToMirror.new }
 
-  describe ".call" do
-    it "creates a toc node with entries" do
+  describe '.call' do
+    it 'creates a toc node with entries' do
       entry1 = Coradoc::CoreModel::TocEntry.new(
-        id: "sec-1",
-        title: "Section 1",
+        id: 'sec-1',
+        title: 'Section 1',
         level: 1
       )
 
       entry2 = Coradoc::CoreModel::TocEntry.new(
-        id: "sec-1-1",
-        title: "Section 1.1",
+        id: 'sec-1-1',
+        title: 'Section 1.1',
         level: 2
       )
 
       entry1.children = [entry2]
 
       element = Coradoc::CoreModel::Toc.new(
-        title: "Table of Contents",
+        title: 'Table of Contents',
         entries: [entry1]
       )
 
       node = described_class.call(element, context: context)
       expect(node).to be_a(Coradoc::Mirror::Node::Toc)
-      expect(node.type).to eq("toc")
-      expect(node.title).to eq("Table of Contents")
+      expect(node.type).to eq('toc')
+      expect(node.title).to eq('Table of Contents')
       expect(node.content.length).to eq(1)
 
       entry_node = node.content.first
       expect(entry_node).to be_a(Coradoc::Mirror::Node::TocEntry)
-      expect(entry_node.id).to eq("sec-1")
-      expect(entry_node.title).to eq("Section 1")
+      expect(entry_node.id).to eq('sec-1')
+      expect(entry_node.title).to eq('Section 1')
       expect(entry_node.level).to eq(1)
 
       sub_entry_node = entry_node.content.first
       expect(sub_entry_node).to be_a(Coradoc::Mirror::Node::TocEntry)
-      expect(sub_entry_node.id).to eq("sec-1-1")
+      expect(sub_entry_node.id).to eq('sec-1-1')
     end
 
-    it "creates empty toc node if no entries" do
-      element = Coradoc::CoreModel::Toc.new(title: "Empty TOC")
+    it 'creates empty toc node if no entries' do
+      element = Coradoc::CoreModel::Toc.new(title: 'Empty TOC')
 
       node = described_class.call(element, context: context)
-      expect(node.type).to eq("toc")
-      expect(node.title).to eq("Empty TOC")
+      expect(node.type).to eq('toc')
+      expect(node.title).to eq('Empty TOC')
       expect(node.content).to be_empty
     end
   end

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/toc_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/toc_spec.rb
@@ -10,32 +10,32 @@ RSpec.describe Coradoc::Mirror::Handlers::Toc do
         title: "Section 1",
         level: 1
       )
-      
+
       entry2 = Coradoc::CoreModel::TocEntry.new(
         id: "sec-1-1",
         title: "Section 1.1",
         level: 2
       )
-      
+
       entry1.children = [entry2]
-      
+
       element = Coradoc::CoreModel::Toc.new(
         title: "Table of Contents",
         entries: [entry1]
       )
-      
+
       node = described_class.call(element, context: context)
       expect(node).to be_a(Coradoc::Mirror::Node::Toc)
       expect(node.type).to eq("toc")
       expect(node.title).to eq("Table of Contents")
       expect(node.content.length).to eq(1)
-      
+
       entry_node = node.content.first
       expect(entry_node).to be_a(Coradoc::Mirror::Node::TocEntry)
       expect(entry_node.id).to eq("sec-1")
       expect(entry_node.title).to eq("Section 1")
       expect(entry_node.level).to eq(1)
-      
+
       sub_entry_node = entry_node.content.first
       expect(sub_entry_node).to be_a(Coradoc::Mirror::Node::TocEntry)
       expect(sub_entry_node.id).to eq("sec-1-1")
@@ -43,7 +43,7 @@ RSpec.describe Coradoc::Mirror::Handlers::Toc do
 
     it "creates empty toc node if no entries" do
       element = Coradoc::CoreModel::Toc.new(title: "Empty TOC")
-      
+
       node = described_class.call(element, context: context)
       expect(node.type).to eq("toc")
       expect(node.title).to eq("Empty TOC")

--- a/coradoc-mirror/spec/coradoc/mirror/integration_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/integration_spec.rb
@@ -1,55 +1,55 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-require "json"
-require "yaml"
+require 'spec_helper'
+require 'json'
+require 'yaml'
 
-RSpec.describe "End-to-end integration" do
-  describe "YAML output" do
-    it "produces valid YAML output" do
+RSpec.describe 'End-to-end integration' do
+  describe 'YAML output' do
+    it 'produces valid YAML output' do
       doc = Coradoc::CoreModel::DocumentElement.new(
-        title: "YAML Test",
+        title: 'YAML Test',
         children: [
-          Coradoc::CoreModel::ParagraphBlock.new(content: "Hello")
-        ],
+          Coradoc::CoreModel::ParagraphBlock.new(content: 'Hello')
+        ]
       )
 
       yaml = Coradoc::Mirror.to_yaml(doc)
       parsed = YAML.safe_load(yaml)
-      expect(parsed["type"]).to eq("doc")
-      expect(parsed["attrs"]["title"]).to eq("YAML Test")
+      expect(parsed['type']).to eq('doc')
+      expect(parsed['attrs']['title']).to eq('YAML Test')
     end
 
-    it "round-trips YAML serialization" do
+    it 'round-trips YAML serialization' do
       doc = Coradoc::CoreModel::DocumentElement.new(
-        title: "YAML Round Trip",
+        title: 'YAML Round Trip',
         children: [
           Coradoc::CoreModel::SectionElement.new(
-            title: "Section",
+            title: 'Section',
             level: 1,
             children: [
-              Coradoc::CoreModel::ParagraphBlock.new(content: "Text")
-            ],
+              Coradoc::CoreModel::ParagraphBlock.new(content: 'Text')
+            ]
           )
-        ],
+        ]
       )
 
       yaml = Coradoc::Mirror.to_yaml(doc)
       mirror_node = Coradoc::Mirror::Node.from_h(YAML.safe_load(yaml))
       expect(mirror_node).to be_a(Coradoc::Mirror::Node::Document)
-      expect(mirror_node.title).to eq("YAML Round Trip")
+      expect(mirror_node.title).to eq('YAML Round Trip')
     end
   end
 
-  describe "Transformer facade" do
-    it "supports forward and reverse transformation" do
+  describe 'Transformer facade' do
+    it 'supports forward and reverse transformation' do
       transformer = Coradoc::Mirror::Transformer.new
 
       doc = Coradoc::CoreModel::DocumentElement.new(
-        title: "Test",
+        title: 'Test',
         children: [
-          Coradoc::CoreModel::ParagraphBlock.new(content: "Content")
-        ],
+          Coradoc::CoreModel::ParagraphBlock.new(content: 'Content')
+        ]
       )
 
       mirror = transformer.from_core_model(doc)
@@ -57,24 +57,24 @@ RSpec.describe "End-to-end integration" do
 
       restored = transformer.to_core_model(mirror)
       expect(restored).to be_a(Coradoc::CoreModel::DocumentElement)
-      expect(restored.title).to eq("Test")
+      expect(restored.title).to eq('Test')
     end
   end
 
-  describe "JSON round-trip" do
-    it "serializes and deserializes through JSON" do
+  describe 'JSON round-trip' do
+    it 'serializes and deserializes through JSON' do
       original = Coradoc::CoreModel::DocumentElement.new(
-        title: "JSON Round Trip",
+        title: 'JSON Round Trip',
         children: [
           Coradoc::CoreModel::SectionElement.new(
-            title: "Intro",
+            title: 'Intro',
             level: 1,
-            id: "intro",
+            id: 'intro',
             children: [
-              Coradoc::CoreModel::ParagraphBlock.new(content: "Hello")
-            ],
+              Coradoc::CoreModel::ParagraphBlock.new(content: 'Hello')
+            ]
           )
-        ],
+        ]
       )
 
       json = Coradoc::Mirror.to_json(original, pretty: true)
@@ -83,16 +83,16 @@ RSpec.describe "End-to-end integration" do
       # Reconstruct from JSON
       mirror_node = Coradoc::Mirror::Node.from_h(parsed)
       expect(mirror_node).to be_a(Coradoc::Mirror::Node::Document)
-      expect(mirror_node.title).to eq("JSON Round Trip")
+      expect(mirror_node.title).to eq('JSON Round Trip')
     end
   end
 
-  describe "with AsciiDoc", if: Gem.loaded_specs.key?("coradoc-adoc") do
+  describe 'with AsciiDoc', if: Gem.loaded_specs.key?('coradoc-adoc') do
     before(:each) do
-      require "coradoc/asciidoc"
+      require 'coradoc/asciidoc'
     end
 
-    it "transforms a complete AsciiDoc document to mirror JSON" do
+    it 'transforms a complete AsciiDoc document to mirror JSON' do
       adoc = <<~ADOC
         = Integration Test
         Author Name
@@ -120,14 +120,14 @@ RSpec.describe "End-to-end integration" do
       mirror = Coradoc::Mirror.transform(doc)
 
       expect(mirror).to be_a(Coradoc::Mirror::Node::Document)
-      expect(mirror.title).to eq("Integration Test")
+      expect(mirror.title).to eq('Integration Test')
 
       json = mirror.to_json(pretty: true)
       parsed = JSON.parse(json)
-      expect(parsed["type"]).to eq("doc")
-      expect(parsed["content"].length).to be >= 2
+      expect(parsed['type']).to eq('doc')
+      expect(parsed['content'].length).to be >= 2
 
-      sections = parsed["content"].select { |c| c["type"] == "section" }
+      sections = parsed['content'].select { |c| c['type'] == 'section' }
       expect(sections.length).to be >= 1
     end
   end

--- a/coradoc-mirror/spec/coradoc/mirror/integration_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/integration_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "End-to-end integration" do
       doc = Coradoc::CoreModel::DocumentElement.new(
         title: "YAML Test",
         children: [
-          Coradoc::CoreModel::ParagraphBlock.new(content: "Hello"),
+          Coradoc::CoreModel::ParagraphBlock.new(content: "Hello")
         ],
       )
 
@@ -28,9 +28,9 @@ RSpec.describe "End-to-end integration" do
             title: "Section",
             level: 1,
             children: [
-              Coradoc::CoreModel::ParagraphBlock.new(content: "Text"),
+              Coradoc::CoreModel::ParagraphBlock.new(content: "Text")
             ],
-          ),
+          )
         ],
       )
 
@@ -48,7 +48,7 @@ RSpec.describe "End-to-end integration" do
       doc = Coradoc::CoreModel::DocumentElement.new(
         title: "Test",
         children: [
-          Coradoc::CoreModel::ParagraphBlock.new(content: "Content"),
+          Coradoc::CoreModel::ParagraphBlock.new(content: "Content")
         ],
       )
 
@@ -71,9 +71,9 @@ RSpec.describe "End-to-end integration" do
             level: 1,
             id: "intro",
             children: [
-              Coradoc::CoreModel::ParagraphBlock.new(content: "Hello"),
+              Coradoc::CoreModel::ParagraphBlock.new(content: "Hello")
             ],
-          ),
+          )
         ],
       )
 

--- a/coradoc-mirror/spec/coradoc/mirror/mark_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mark_spec.rb
@@ -1,91 +1,91 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::Mirror::Mark do
-  describe "construction" do
-    it "creates a mark with type" do
+  describe 'construction' do
+    it 'creates a mark with type' do
       mark = described_class.new
-      expect(mark.type).to eq("mark")
+      expect(mark.type).to eq('mark')
     end
 
-    it "uses PM_TYPE as default type" do
+    it 'uses PM_TYPE as default type' do
       mark = described_class.new
-      expect(mark.type).to eq("mark")
+      expect(mark.type).to eq('mark')
     end
   end
 
-  describe "serialization" do
-    it "serializes to hash" do
+  describe 'serialization' do
+    it 'serializes to hash' do
       mark = Coradoc::Mirror::Mark::Bold.new
-      expect(mark.to_h).to eq({ "type" => "bold" })
+      expect(mark.to_h).to eq({ 'type' => 'bold' })
     end
 
-    it "includes attrs when present" do
-      mark = Coradoc::Mirror::Mark::Link.new(href: "https://example.com")
+    it 'includes attrs when present' do
+      mark = Coradoc::Mirror::Mark::Link.new(href: 'https://example.com')
       expect(mark.to_h).to eq({
-                                "type" => "link",
-        "attrs" => { "href" => "https://example.com" }
+                                'type' => 'link',
+                                'attrs' => { 'href' => 'https://example.com' }
                               })
     end
   end
 
-  describe "deserialization" do
-    it "reconstructs from hash" do
-      hash = { "type" => "bold" }
+  describe 'deserialization' do
+    it 'reconstructs from hash' do
+      hash = { 'type' => 'bold' }
       mark = described_class.from_h(hash)
       expect(mark).to be_a(Coradoc::Mirror::Mark::Bold)
     end
 
-    it "returns nil for nil input" do
+    it 'returns nil for nil input' do
       expect(described_class.from_h(nil)).to be_nil
     end
 
-    it "handles unknown types as generic Mark" do
-      hash = { "type" => "custom_mark" }
+    it 'handles unknown types as generic Mark' do
+      hash = { 'type' => 'custom_mark' }
       mark = described_class.from_h(hash)
       expect(mark).to be_a(described_class)
-      expect(mark.type).to eq("custom_mark")
+      expect(mark.type).to eq('custom_mark')
     end
 
-    it "deserializes link with href" do
+    it 'deserializes link with href' do
       hash = {
-        "type" => "link",
-        "attrs" => { "href" => "https://example.com" }
+        'type' => 'link',
+        'attrs' => { 'href' => 'https://example.com' }
       }
       mark = described_class.from_h(hash)
       expect(mark).to be_a(Coradoc::Mirror::Mark::Link)
     end
   end
 
-  describe "mark type subclasses" do
-    it "registers all subclasses in MARKS map" do
+  describe 'mark type subclasses' do
+    it 'registers all subclasses in MARKS map' do
       marks = described_class::MARKS
-      expect(marks["bold"]).to eq(Coradoc::Mirror::Mark::Bold)
-      expect(marks["italic"]).to eq(Coradoc::Mirror::Mark::Italic)
-      expect(marks["code"]).to eq(Coradoc::Mirror::Mark::Monospace)
-      expect(marks["link"]).to eq(Coradoc::Mirror::Mark::Link)
-      expect(marks["xref"]).to eq(Coradoc::Mirror::Mark::CrossReference)
-      expect(marks["highlight"]).to eq(Coradoc::Mirror::Mark::Highlight)
-      expect(marks["subscript"]).to eq(Coradoc::Mirror::Mark::Subscript)
-      expect(marks["superscript"]).to eq(Coradoc::Mirror::Mark::Superscript)
+      expect(marks['bold']).to eq(Coradoc::Mirror::Mark::Bold)
+      expect(marks['italic']).to eq(Coradoc::Mirror::Mark::Italic)
+      expect(marks['code']).to eq(Coradoc::Mirror::Mark::Monospace)
+      expect(marks['link']).to eq(Coradoc::Mirror::Mark::Link)
+      expect(marks['xref']).to eq(Coradoc::Mirror::Mark::CrossReference)
+      expect(marks['highlight']).to eq(Coradoc::Mirror::Mark::Highlight)
+      expect(marks['subscript']).to eq(Coradoc::Mirror::Mark::Subscript)
+      expect(marks['superscript']).to eq(Coradoc::Mirror::Mark::Superscript)
     end
 
-    it "Link stores href in attrs" do
-      mark = Coradoc::Mirror::Mark::Link.new(href: "https://example.com")
-      expect(mark.href).to eq("https://example.com")
+    it 'Link stores href in attrs' do
+      mark = Coradoc::Mirror::Mark::Link.new(href: 'https://example.com')
+      expect(mark.href).to eq('https://example.com')
       hash = mark.to_h
-      expect(hash["attrs"]["href"]).to eq("https://example.com")
+      expect(hash['attrs']['href']).to eq('https://example.com')
     end
 
-    it "CrossReference stores target in attrs" do
-      mark = Coradoc::Mirror::Mark::CrossReference.new(target: "section-1")
-      expect(mark.target).to eq("section-1")
+    it 'CrossReference stores target in attrs' do
+      mark = Coradoc::Mirror::Mark::CrossReference.new(target: 'section-1')
+      expect(mark.target).to eq('section-1')
     end
 
-    it "Stem stores stem_type in attrs" do
-      mark = Coradoc::Mirror::Mark::Stem.new(stem_type: "latex")
-      expect(mark.stem_type).to eq("latex")
+    it 'Stem stores stem_type in attrs' do
+      mark = Coradoc::Mirror::Mark::Stem.new(stem_type: 'latex')
+      expect(mark.stem_type).to eq('latex')
     end
   end
 end

--- a/coradoc-mirror/spec/coradoc/mirror/mark_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mark_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Coradoc::Mirror::Mark do
     it "includes attrs when present" do
       mark = Coradoc::Mirror::Mark::Link.new(href: "https://example.com")
       expect(mark.to_h).to eq({
-        "type" => "link",
-        "attrs" => { "href" => "https://example.com" },
-      })
+                                "type" => "link",
+        "attrs" => { "href" => "https://example.com" }
+                              })
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe Coradoc::Mirror::Mark do
     it "deserializes link with href" do
       hash = {
         "type" => "link",
-        "attrs" => { "href" => "https://example.com" },
+        "attrs" => { "href" => "https://example.com" }
       }
       mark = described_class.from_h(hash)
       expect(mark).to be_a(Coradoc::Mirror::Mark::Link)

--- a/coradoc-mirror/spec/coradoc/mirror/mirror_json_format_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mirror_json_format_spec.rb
@@ -1,43 +1,44 @@
-require "spec_helper"
-require "json"
+# frozen_string_literal: true
+require 'spec_helper'
+require 'json'
 
 RSpec.describe Coradoc::Mirror::MirrorJsonFormat do
   let(:document) do
     Coradoc::CoreModel::DocumentElement.new(
-      title: "Test",
+      title: 'Test',
       children: [
-        Coradoc::CoreModel::ParagraphBlock.new(content: "Hello")
+        Coradoc::CoreModel::ParagraphBlock.new(content: 'Hello')
       ]
     )
   end
 
-  describe ".serialize" do
-    it "serializes a CoreModel document to Mirror JSON" do
+  describe '.serialize' do
+    it 'serializes a CoreModel document to Mirror JSON' do
       json = described_class.serialize(document)
       parsed = JSON.parse(json)
 
-      expect(parsed["type"]).to eq("doc")
-      expect(parsed["attrs"]["title"]).to eq("Test")
-      expect(parsed["content"].first["type"]).to eq("paragraph")
+      expect(parsed['type']).to eq('doc')
+      expect(parsed['attrs']['title']).to eq('Test')
+      expect(parsed['content'].first['type']).to eq('paragraph')
     end
   end
 
-  describe ".parse_to_core" do
-    it "raises UnsupportedFormatError" do
+  describe '.parse_to_core' do
+    it 'raises UnsupportedFormatError' do
       expect do
-        described_class.parse_to_core("{}")
+        described_class.parse_to_core('{}')
       end.to raise_error(Coradoc::UnsupportedFormatError, /Parsing from mirror JSON is not supported/)
     end
   end
 
-  describe ".serialize?" do
-    it "returns true" do
+  describe '.serialize?' do
+    it 'returns true' do
       expect(described_class.serialize?).to be true
     end
   end
 
-  describe ".handles_model?" do
-    it "returns false" do
+  describe '.handles_model?' do
+    it 'returns false' do
       expect(described_class.handles_model?(Object.new)).to be false
     end
   end

--- a/coradoc-mirror/spec/coradoc/mirror/mirror_json_format_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mirror_json_format_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Coradoc::Mirror::MirrorJsonFormat do
     it "serializes a CoreModel document to Mirror JSON" do
       json = described_class.serialize(document)
       parsed = JSON.parse(json)
-      
+
       expect(parsed["type"]).to eq("doc")
       expect(parsed["attrs"]["title"]).to eq("Test")
       expect(parsed["content"].first["type"]).to eq("paragraph")
@@ -24,9 +24,9 @@ RSpec.describe Coradoc::Mirror::MirrorJsonFormat do
 
   describe ".parse_to_core" do
     it "raises UnsupportedFormatError" do
-      expect {
+      expect do
         described_class.parse_to_core("{}")
-      }.to raise_error(Coradoc::UnsupportedFormatError, /Parsing from mirror JSON is not supported/)
+      end.to raise_error(Coradoc::UnsupportedFormatError, /Parsing from mirror JSON is not supported/)
     end
   end
 

--- a/coradoc-mirror/spec/coradoc/mirror/mirror_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mirror_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Coradoc::Mirror do
       doc = Coradoc::CoreModel::DocumentElement.new(
         title: "Quick Test",
         children: [
-          Coradoc::CoreModel::ParagraphBlock.new(content: "Hello"),
+          Coradoc::CoreModel::ParagraphBlock.new(content: "Hello")
         ],
       )
 
@@ -40,7 +40,7 @@ RSpec.describe Coradoc::Mirror do
       doc = Coradoc::CoreModel::DocumentElement.new(
         title: "JSON Test",
         children: [
-          Coradoc::CoreModel::ParagraphBlock.new(content: "World"),
+          Coradoc::CoreModel::ParagraphBlock.new(content: "World")
         ],
       )
 

--- a/coradoc-mirror/spec/coradoc/mirror/mirror_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mirror_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::Mirror do
-  describe ".default_registry" do
-    it "returns a HandlerRegistry with core handlers" do
+  describe '.default_registry' do
+    it 'returns a HandlerRegistry with core handlers' do
       registry = described_class.default_registry
       expect(registry).to be_a(Coradoc::Mirror::HandlerRegistry)
 
@@ -20,46 +20,46 @@ RSpec.describe Coradoc::Mirror do
     end
   end
 
-  describe ".transform" do
-    it "transforms a CoreModel document to mirror in one call" do
+  describe '.transform' do
+    it 'transforms a CoreModel document to mirror in one call' do
       doc = Coradoc::CoreModel::DocumentElement.new(
-        title: "Quick Test",
+        title: 'Quick Test',
         children: [
-          Coradoc::CoreModel::ParagraphBlock.new(content: "Hello")
-        ],
+          Coradoc::CoreModel::ParagraphBlock.new(content: 'Hello')
+        ]
       )
 
       result = described_class.transform(doc)
       expect(result).to be_a(Coradoc::Mirror::Node::Document)
-      expect(result.title).to eq("Quick Test")
+      expect(result.title).to eq('Quick Test')
     end
   end
 
-  describe ".to_json" do
-    it "transforms and serializes to JSON" do
+  describe '.to_json' do
+    it 'transforms and serializes to JSON' do
       doc = Coradoc::CoreModel::DocumentElement.new(
-        title: "JSON Test",
+        title: 'JSON Test',
         children: [
-          Coradoc::CoreModel::ParagraphBlock.new(content: "World")
-        ],
+          Coradoc::CoreModel::ParagraphBlock.new(content: 'World')
+        ]
       )
 
       json = described_class.to_json(doc)
       parsed = JSON.parse(json)
-      expect(parsed["type"]).to eq("doc")
-      expect(parsed["attrs"]["title"]).to eq("JSON Test")
+      expect(parsed['type']).to eq('doc')
+      expect(parsed['attrs']['title']).to eq('JSON Test')
     end
 
-    it "produces pretty JSON when requested" do
-      doc = Coradoc::CoreModel::DocumentElement.new(title: "Pretty")
+    it 'produces pretty JSON when requested' do
+      doc = Coradoc::CoreModel::DocumentElement.new(title: 'Pretty')
       json = described_class.to_json(doc, pretty: true)
       expect(json).to include("\n")
-      expect(json).to include("  ")
+      expect(json).to include('  ')
     end
   end
 
-  describe "VERSION" do
-    it "has a version constant" do
+  describe 'VERSION' do
+    it 'has a version constant' do
       expect(Coradoc::Mirror::VERSION).to match(/\A\d+\.\d+\.\d+\z/)
     end
   end

--- a/coradoc-mirror/spec/coradoc/mirror/mirror_to_core_model_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mirror_to_core_model_spec.rb
@@ -1,44 +1,44 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-require "json"
-require "yaml"
+require 'spec_helper'
+require 'json'
+require 'yaml'
 
 RSpec.describe Coradoc::Mirror::MirrorToCoreModel do
   let(:reverse) { described_class.new }
 
-  describe "round-trip: CoreModel → Mirror → CoreModel" do
-    it "round-trips a simple document with title and paragraphs" do
+  describe 'round-trip: CoreModel → Mirror → CoreModel' do
+    it 'round-trips a simple document with title and paragraphs' do
       original = Coradoc::CoreModel::DocumentElement.new(
-        title: "Round Trip",
+        title: 'Round Trip',
         children: [
           Coradoc::CoreModel::ParagraphBlock.new(
-            content: "Hello world",
+            content: 'Hello world'
           )
-        ],
+        ]
       )
 
       mirror = Coradoc::Mirror.transform(original)
       restored = reverse.call(mirror)
 
       expect(restored).to be_a(Coradoc::CoreModel::DocumentElement)
-      expect(restored.title).to eq("Round Trip")
+      expect(restored.title).to eq('Round Trip')
       expect(restored.children).not_to be_empty
     end
 
-    it "round-trips sections with levels" do
+    it 'round-trips sections with levels' do
       original = Coradoc::CoreModel::DocumentElement.new(
-        title: "Doc",
+        title: 'Doc',
         children: [
           Coradoc::CoreModel::SectionElement.new(
-            title: "Section One",
+            title: 'Section One',
             level: 1,
-            id: "section-one",
+            id: 'section-one',
             children: [
-              Coradoc::CoreModel::ParagraphBlock.new(content: "Content")
-            ],
+              Coradoc::CoreModel::ParagraphBlock.new(content: 'Content')
+            ]
           )
-        ],
+        ]
       )
 
       mirror = Coradoc::Mirror.transform(original)
@@ -46,72 +46,72 @@ RSpec.describe Coradoc::Mirror::MirrorToCoreModel do
 
       section = restored.children.first
       expect(section).to be_a(Coradoc::CoreModel::SectionElement)
-      expect(section.title).to eq("Section One")
+      expect(section.title).to eq('Section One')
       expect(section.level).to eq(1)
-      expect(section.id).to eq("section-one")
+      expect(section.id).to eq('section-one')
     end
 
-    it "round-trips code blocks with language" do
+    it 'round-trips code blocks with language' do
       original = Coradoc::CoreModel::SourceBlock.new(
         content: "puts 'hi'",
-        language: "ruby",
+        language: 'ruby'
       )
 
       mirror = Coradoc::Mirror.transform(
-        Coradoc::CoreModel::DocumentElement.new(children: [original]),
+        Coradoc::CoreModel::DocumentElement.new(children: [original])
       )
       restored = reverse.call(mirror)
       code = restored.children.first
 
       expect(code).to be_a(Coradoc::CoreModel::SourceBlock)
-      expect(code.language).to eq("ruby")
+      expect(code.language).to eq('ruby')
     end
 
-    it "round-trips unordered lists" do
+    it 'round-trips unordered lists' do
       original = Coradoc::CoreModel::ListBlock.new(
-        marker_type: "unordered",
+        marker_type: 'unordered',
         items: [
-          Coradoc::CoreModel::ListItem.new(content: "First"),
-          Coradoc::CoreModel::ListItem.new(content: "Second")
-        ],
+          Coradoc::CoreModel::ListItem.new(content: 'First'),
+          Coradoc::CoreModel::ListItem.new(content: 'Second')
+        ]
       )
 
       mirror = Coradoc::Mirror.transform(
-        Coradoc::CoreModel::DocumentElement.new(children: [original]),
+        Coradoc::CoreModel::DocumentElement.new(children: [original])
       )
       restored = reverse.call(mirror)
       list = restored.children.first
 
       expect(list).to be_a(Coradoc::CoreModel::ListBlock)
-      expect(list.marker_type).to eq("unordered")
+      expect(list.marker_type).to eq('unordered')
       expect(list.items.length).to eq(2)
     end
 
-    it "round-trips images" do
+    it 'round-trips images' do
       original = Coradoc::CoreModel::Image.new(
-        src: "photo.png",
-        alt: "Photo",
-        caption: "Figure 1",
+        src: 'photo.png',
+        alt: 'Photo',
+        caption: 'Figure 1'
       )
 
       mirror = Coradoc::Mirror.transform(
-        Coradoc::CoreModel::DocumentElement.new(children: [original]),
+        Coradoc::CoreModel::DocumentElement.new(children: [original])
       )
       restored = reverse.call(mirror)
       image = restored.children.first
 
       expect(image).to be_a(Coradoc::CoreModel::Image)
-      expect(image.src).to eq("photo.png")
-      expect(image.alt).to eq("Photo")
-      expect(image.caption).to eq("Figure 1")
+      expect(image.src).to eq('photo.png')
+      expect(image.alt).to eq('Photo')
+      expect(image.caption).to eq('Figure 1')
     end
 
-    it "round-trips bold text marks" do
-      bold = Coradoc::CoreModel::BoldElement.new(content: "important")
+    it 'round-trips bold text marks' do
+      bold = Coradoc::CoreModel::BoldElement.new(content: 'important')
       original = Coradoc::CoreModel::ParagraphBlock.new(children: [bold])
 
       mirror = Coradoc::Mirror.transform(
-        Coradoc::CoreModel::DocumentElement.new(children: [original]),
+        Coradoc::CoreModel::DocumentElement.new(children: [original])
       )
       restored = reverse.call(mirror)
       para = restored.children.first
@@ -119,20 +119,20 @@ RSpec.describe Coradoc::Mirror::MirrorToCoreModel do
       expect(para).to be_a(Coradoc::CoreModel::Block)
     end
 
-    it "round-trips tables" do
+    it 'round-trips tables' do
       original = Coradoc::CoreModel::Table.new(
         rows: [
           Coradoc::CoreModel::TableRow.new(
             cells: [
-              Coradoc::CoreModel::TableCell.new(content: "A"),
-              Coradoc::CoreModel::TableCell.new(content: "B")
-            ],
+              Coradoc::CoreModel::TableCell.new(content: 'A'),
+              Coradoc::CoreModel::TableCell.new(content: 'B')
+            ]
           )
-        ],
+        ]
       )
 
       mirror = Coradoc::Mirror.transform(
-        Coradoc::CoreModel::DocumentElement.new(children: [original]),
+        Coradoc::CoreModel::DocumentElement.new(children: [original])
       )
       restored = reverse.call(mirror)
       table = restored.children.first
@@ -142,9 +142,9 @@ RSpec.describe Coradoc::Mirror::MirrorToCoreModel do
     end
   end
 
-  describe "error handling" do
-    it "raises error for unknown node type" do
-      node = Coradoc::Mirror::Node.new(type: "completely_unknown_type")
+  describe 'error handling' do
+    it 'raises error for unknown node type' do
+      node = Coradoc::Mirror::Node.new(type: 'completely_unknown_type')
       expect { reverse.call(node) }.to raise_error(Coradoc::Mirror::Error, /Unknown mirror node type/)
     end
   end

--- a/coradoc-mirror/spec/coradoc/mirror/mirror_to_core_model_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mirror_to_core_model_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Coradoc::Mirror::MirrorToCoreModel do
         children: [
           Coradoc::CoreModel::ParagraphBlock.new(
             content: "Hello world",
-          ),
+          )
         ],
       )
 
@@ -35,9 +35,9 @@ RSpec.describe Coradoc::Mirror::MirrorToCoreModel do
             level: 1,
             id: "section-one",
             children: [
-              Coradoc::CoreModel::ParagraphBlock.new(content: "Content"),
+              Coradoc::CoreModel::ParagraphBlock.new(content: "Content")
             ],
-          ),
+          )
         ],
       )
 
@@ -72,7 +72,7 @@ RSpec.describe Coradoc::Mirror::MirrorToCoreModel do
         marker_type: "unordered",
         items: [
           Coradoc::CoreModel::ListItem.new(content: "First"),
-          Coradoc::CoreModel::ListItem.new(content: "Second"),
+          Coradoc::CoreModel::ListItem.new(content: "Second")
         ],
       )
 
@@ -125,9 +125,9 @@ RSpec.describe Coradoc::Mirror::MirrorToCoreModel do
           Coradoc::CoreModel::TableRow.new(
             cells: [
               Coradoc::CoreModel::TableCell.new(content: "A"),
-              Coradoc::CoreModel::TableCell.new(content: "B"),
+              Coradoc::CoreModel::TableCell.new(content: "B")
             ],
-          ),
+          )
         ],
       )
 

--- a/coradoc-mirror/spec/coradoc/mirror/node_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/node_spec.rb
@@ -1,236 +1,236 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::Mirror::Node do
-  describe "construction" do
-    it "creates a basic node with type" do
-      node = described_class.new(type: "custom")
-      expect(node.type).to eq("custom")
+  describe 'construction' do
+    it 'creates a basic node with type' do
+      node = described_class.new(type: 'custom')
+      expect(node.type).to eq('custom')
       expect(node.content).to eq([])
       expect(node.marks).to eq([])
     end
 
-    it "uses PM_TYPE as default type" do
+    it 'uses PM_TYPE as default type' do
       node = described_class.new
-      expect(node.type).to eq("node")
+      expect(node.type).to eq('node')
     end
   end
 
-  describe "typed attributes" do
-    it "Document has title and id accessors" do
-      doc = described_class::Document.new(title: "My Doc", id: "doc-1")
-      expect(doc.title).to eq("My Doc")
-      expect(doc.id).to eq("doc-1")
+  describe 'typed attributes' do
+    it 'Document has title and id accessors' do
+      doc = described_class::Document.new(title: 'My Doc', id: 'doc-1')
+      expect(doc.title).to eq('My Doc')
+      expect(doc.id).to eq('doc-1')
     end
 
-    it "Section has title, id, level accessors" do
-      section = described_class::Section.new(title: "Intro", id: "s1", level: 2)
-      expect(section.title).to eq("Intro")
-      expect(section.id).to eq("s1")
+    it 'Section has title, id, level accessors' do
+      section = described_class::Section.new(title: 'Intro', id: 's1', level: 2)
+      expect(section.title).to eq('Intro')
+      expect(section.id).to eq('s1')
       expect(section.level).to eq(2)
     end
 
-    it "CodeBlock has language, title, passthrough accessors" do
-      code = described_class::CodeBlock.new(language: "ruby", title: "Example", passthrough: true)
-      expect(code.language).to eq("ruby")
-      expect(code.title).to eq("Example")
+    it 'CodeBlock has language, title, passthrough accessors' do
+      code = described_class::CodeBlock.new(language: 'ruby', title: 'Example', passthrough: true)
+      expect(code.language).to eq('ruby')
+      expect(code.title).to eq('Example')
       expect(code.passthrough).to be true
     end
 
-    it "Image has src, alt, caption, width, height accessors" do
-      img = described_class::Image.new(src: "img.png", alt: "Alt", caption: "Cap", width: "100")
-      expect(img.src).to eq("img.png")
-      expect(img.alt).to eq("Alt")
-      expect(img.caption).to eq("Cap")
-      expect(img.width).to eq("100")
+    it 'Image has src, alt, caption, width, height accessors' do
+      img = described_class::Image.new(src: 'img.png', alt: 'Alt', caption: 'Cap', width: '100')
+      expect(img.src).to eq('img.png')
+      expect(img.alt).to eq('Alt')
+      expect(img.caption).to eq('Cap')
+      expect(img.width).to eq('100')
       expect(img.height).to be_nil
     end
 
-    it "TableCell has colspan, rowspan, alignment, header accessors" do
-      cell = described_class::TableCell.new(colspan: 2, header: true, alignment: "center")
+    it 'TableCell has colspan, rowspan, alignment, header accessors' do
+      cell = described_class::TableCell.new(colspan: 2, header: true, alignment: 'center')
       expect(cell.colspan).to eq(2)
       expect(cell.header).to be true
-      expect(cell.alignment).to eq("center")
+      expect(cell.alignment).to eq('center')
       expect(cell.rowspan).to be_nil
     end
   end
 
-  describe "serialization" do
-    it "serializes to hash with only non-empty fields" do
-      node = described_class.new(type: "paragraph")
-      expect(node.to_h).to eq({ "type" => "paragraph" })
+  describe 'serialization' do
+    it 'serializes to hash with only non-empty fields' do
+      node = described_class.new(type: 'paragraph')
+      expect(node.to_h).to eq({ 'type' => 'paragraph' })
     end
 
-    it "includes typed attrs when set" do
+    it 'includes typed attrs when set' do
       node = described_class::Heading.new(level: 1)
       expect(node.to_h).to eq({
-                                "type" => "heading",
-        "attrs" => { "level" => 1 }
+                                'type' => 'heading',
+                                'attrs' => { 'level' => 1 }
                               })
     end
 
-    it "omits nil attrs" do
-      node = described_class::Section.new(title: "Intro")
+    it 'omits nil attrs' do
+      node = described_class::Section.new(title: 'Intro')
       expect(node.to_h).to eq({
-                                "type" => "section",
-        "attrs" => { "title" => "Intro" }
+                                'type' => 'section',
+                                'attrs' => { 'title' => 'Intro' }
                               })
     end
 
-    it "includes content when present" do
-      child = described_class::Text.new(text: "hello")
+    it 'includes content when present' do
+      child = described_class::Text.new(text: 'hello')
       node = described_class::Paragraph.new(content: [child])
       hash = node.to_h
-      expect(hash["content"]).to be_an(Array)
-      expect(hash["content"].length).to eq(1)
+      expect(hash['content']).to be_an(Array)
+      expect(hash['content'].length).to eq(1)
     end
 
-    it "includes marks when present" do
+    it 'includes marks when present' do
       mark = Coradoc::Mirror::Mark::Bold.new
-      node = described_class::Text.new(text: "bold", marks: [mark])
+      node = described_class::Text.new(text: 'bold', marks: [mark])
       hash = node.to_h
-      expect(hash["marks"]).to be_an(Array)
+      expect(hash['marks']).to be_an(Array)
     end
 
-    it "serializes to JSON" do
+    it 'serializes to JSON' do
       node = described_class::Paragraph.new
       json = node.to_json
-      expect(JSON.parse(json)).to eq({ "type" => "paragraph" })
+      expect(JSON.parse(json)).to eq({ 'type' => 'paragraph' })
     end
 
-    it "serializes to pretty JSON" do
+    it 'serializes to pretty JSON' do
       node = described_class::Paragraph.new
       json = node.to_json(pretty: true)
       expect(json).to include("\n")
     end
 
-    it "serializes to YAML" do
-      node = described_class::Section.new(id: "p1")
+    it 'serializes to YAML' do
+      node = described_class::Section.new(id: 'p1')
       yaml = node.to_yaml
       parsed = YAML.safe_load(yaml)
-      expect(parsed["type"]).to eq("section")
-      expect(parsed["attrs"]["id"]).to eq("p1")
+      expect(parsed['type']).to eq('section')
+      expect(parsed['attrs']['id']).to eq('p1')
     end
 
-    it "aliases to_hash to to_h" do
-      node = described_class.new(type: "test")
+    it 'aliases to_hash to to_h' do
+      node = described_class.new(type: 'test')
       expect(node.to_hash).to eq(node.to_h)
     end
   end
 
-  describe "deserialization" do
-    it "reconstructs typed nodes from hash" do
+  describe 'deserialization' do
+    it 'reconstructs typed nodes from hash' do
       hash = {
-        "type" => "section",
-        "attrs" => { "title" => "Intro", "level" => 1 },
-        "content" => [
-          { "type" => "paragraph", "content" => [
-            { "type" => "text", "text" => "Hello" }
+        'type' => 'section',
+        'attrs' => { 'title' => 'Intro', 'level' => 1 },
+        'content' => [
+          { 'type' => 'paragraph', 'content' => [
+            { 'type' => 'text', 'text' => 'Hello' }
           ] }
         ]
       }
 
       node = described_class.from_h(hash)
       expect(node).to be_a(described_class::Section)
-      expect(node.title).to eq("Intro")
+      expect(node.title).to eq('Intro')
       expect(node.level).to eq(1)
       expect(node.content.length).to eq(1)
 
       para = node.content.first
       expect(para).to be_a(described_class::Paragraph)
       expect(para.content.first).to be_a(described_class::Text)
-      expect(para.content.first.text).to eq("Hello")
+      expect(para.content.first.text).to eq('Hello')
     end
 
-    it "returns nil for nil input" do
+    it 'returns nil for nil input' do
       expect(described_class.from_h(nil)).to be_nil
     end
 
-    it "handles unknown types as generic Node" do
-      hash = { "type" => "unknown_custom_type" }
+    it 'handles unknown types as generic Node' do
+      hash = { 'type' => 'unknown_custom_type' }
       node = described_class.from_h(hash)
       expect(node).to be_a(described_class)
-      expect(node.type).to eq("unknown_custom_type")
+      expect(node.type).to eq('unknown_custom_type')
     end
   end
 
-  describe "text_content" do
-    it "returns empty string for node with no content" do
+  describe 'text_content' do
+    it 'returns empty string for node with no content' do
       node = described_class.new
-      expect(node.text_content).to eq("")
+      expect(node.text_content).to eq('')
     end
 
-    it "collects text from descendants" do
-      text = described_class::Text.new(text: "Hello ")
-      text2 = described_class::Text.new(text: "World")
+    it 'collects text from descendants' do
+      text = described_class::Text.new(text: 'Hello ')
+      text2 = described_class::Text.new(text: 'World')
       para = described_class::Paragraph.new(content: [text, text2])
-      expect(para.text_content).to eq("Hello World")
+      expect(para.text_content).to eq('Hello World')
     end
   end
 
-  describe "node type subclasses" do
-    it "registers all subclasses in NODES map" do
-      expect(described_class::NODES["doc"]).to eq(described_class::Document)
-      expect(described_class::NODES["paragraph"]).to eq(described_class::Paragraph)
-      expect(described_class::NODES["heading"]).to eq(described_class::Heading)
-      expect(described_class::NODES["code_block"]).to eq(described_class::CodeBlock)
-      expect(described_class::NODES["blockquote"]).to eq(described_class::Blockquote)
-      expect(described_class::NODES["bullet_list"]).to eq(described_class::BulletList)
-      expect(described_class::NODES["ordered_list"]).to eq(described_class::OrderedList)
-      expect(described_class::NODES["list_item"]).to eq(described_class::ListItem)
-      expect(described_class::NODES["image"]).to eq(described_class::Image)
-      expect(described_class::NODES["table"]).to eq(described_class::Table)
-      expect(described_class::NODES["section"]).to eq(described_class::Section)
-      expect(described_class::NODES["admonition"]).to eq(described_class::Admonition)
+  describe 'node type subclasses' do
+    it 'registers all subclasses in NODES map' do
+      expect(described_class::NODES['doc']).to eq(described_class::Document)
+      expect(described_class::NODES['paragraph']).to eq(described_class::Paragraph)
+      expect(described_class::NODES['heading']).to eq(described_class::Heading)
+      expect(described_class::NODES['code_block']).to eq(described_class::CodeBlock)
+      expect(described_class::NODES['blockquote']).to eq(described_class::Blockquote)
+      expect(described_class::NODES['bullet_list']).to eq(described_class::BulletList)
+      expect(described_class::NODES['ordered_list']).to eq(described_class::OrderedList)
+      expect(described_class::NODES['list_item']).to eq(described_class::ListItem)
+      expect(described_class::NODES['image']).to eq(described_class::Image)
+      expect(described_class::NODES['table']).to eq(described_class::Table)
+      expect(described_class::NODES['section']).to eq(described_class::Section)
+      expect(described_class::NODES['admonition']).to eq(described_class::Admonition)
     end
 
-    it "Text node has text attribute" do
-      node = described_class::Text.new(text: "Hello")
-      expect(node.text).to eq("Hello")
-      expect(node.to_h["text"]).to eq("Hello")
-      expect(node.text_content).to eq("Hello")
+    it 'Text node has text attribute' do
+      node = described_class::Text.new(text: 'Hello')
+      expect(node.text).to eq('Hello')
+      expect(node.to_h['text']).to eq('Hello')
+      expect(node.text_content).to eq('Hello')
     end
 
-    it "Text node deserializes with marks" do
+    it 'Text node deserializes with marks' do
       hash = {
-        "type" => "text",
-        "text" => "bold text",
-        "marks" => [{ "type" => "bold" }]
+        'type' => 'text',
+        'text' => 'bold text',
+        'marks' => [{ 'type' => 'bold' }]
       }
       node = described_class::Text.from_h(hash)
-      expect(node.text).to eq("bold text")
+      expect(node.text).to eq('bold text')
       expect(node.marks.length).to eq(1)
       expect(node.marks.first).to be_a(Coradoc::Mirror::Mark::Bold)
     end
 
-    it "round-trips through serialization" do
+    it 'round-trips through serialization' do
       doc = described_class::Document.new(
-        title: "Test",
+        title: 'Test',
         content: [
           described_class::Section.new(
             level: 1,
-            title: "Intro",
+            title: 'Intro',
             content: [
               described_class::Paragraph.new(
                 content: [
                   described_class::Text.new(
-                    text: "Hello ",
-                    marks: [Coradoc::Mirror::Mark::Bold.new],
+                    text: 'Hello ',
+                    marks: [Coradoc::Mirror::Mark::Bold.new]
                   ),
-                  described_class::Text.new(text: "world")
-                ],
+                  described_class::Text.new(text: 'world')
+                ]
               )
-            ],
+            ]
           )
-        ],
+        ]
       )
 
       json = doc.to_json(pretty: true)
       parsed = described_class.from_h(JSON.parse(json))
 
       expect(parsed).to be_a(described_class::Document)
-      expect(parsed.title).to eq("Test")
+      expect(parsed.title).to eq('Test')
       expect(parsed.content.length).to eq(1)
       section = parsed.content.first
       expect(section).to be_a(described_class::Section)

--- a/coradoc-mirror/spec/coradoc/mirror/node_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/node_spec.rb
@@ -65,17 +65,17 @@ RSpec.describe Coradoc::Mirror::Node do
     it "includes typed attrs when set" do
       node = described_class::Heading.new(level: 1)
       expect(node.to_h).to eq({
-        "type" => "heading",
-        "attrs" => { "level" => 1 },
-      })
+                                "type" => "heading",
+        "attrs" => { "level" => 1 }
+                              })
     end
 
     it "omits nil attrs" do
       node = described_class::Section.new(title: "Intro")
       expect(node.to_h).to eq({
-        "type" => "section",
-        "attrs" => { "title" => "Intro" },
-      })
+                                "type" => "section",
+        "attrs" => { "title" => "Intro" }
+                              })
     end
 
     it "includes content when present" do
@@ -126,9 +126,9 @@ RSpec.describe Coradoc::Mirror::Node do
         "attrs" => { "title" => "Intro", "level" => 1 },
         "content" => [
           { "type" => "paragraph", "content" => [
-            { "type" => "text", "text" => "Hello" },
-          ]},
-        ],
+            { "type" => "text", "text" => "Hello" }
+          ] }
+        ]
       }
 
       node = described_class.from_h(hash)
@@ -196,7 +196,7 @@ RSpec.describe Coradoc::Mirror::Node do
       hash = {
         "type" => "text",
         "text" => "bold text",
-        "marks" => [{ "type" => "bold" }],
+        "marks" => [{ "type" => "bold" }]
       }
       node = described_class::Text.from_h(hash)
       expect(node.text).to eq("bold text")
@@ -218,11 +218,11 @@ RSpec.describe Coradoc::Mirror::Node do
                     text: "Hello ",
                     marks: [Coradoc::Mirror::Mark::Bold.new],
                   ),
-                  described_class::Text.new(text: "world"),
+                  described_class::Text.new(text: "world")
                 ],
-              ),
+              )
             ],
-          ),
+          )
         ],
       )
 

--- a/coradoc-mirror/spec/spec_helper.rb
+++ b/coradoc-mirror/spec/spec_helper.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require "simplecov"
+require 'simplecov'
 SimpleCov.start do
   enable_coverage :branch
-  add_filter "/spec/"
+  add_filter '/spec/'
   minimum_coverage 0
 end
 
-require "coradoc-mirror"
-require "json"
-require "yaml"
+require 'coradoc-mirror'
+require 'json'
+require 'yaml'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -24,7 +24,7 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.warnings = true
 
-  config.default_formatter = "doc" if config.files_to_run.one?
+  config.default_formatter = 'doc' if config.files_to_run.one?
 
   config.profile_examples = 10
   config.order = :random


### PR DESCRIPTION
## Summary

Architectural quality pass on `coradoc-mirror` based on code audit. All changes are internal refactoring — no API changes.

### CoreModelToMirror
- Replace hash bags with typed `FootnoteData` Struct
- Replace if/elsif children dispatch with `COLLECTION_ACCESSORS` hash table (OCP)
- Fix `COLLECTION_ACCESSORS` placement above `private`

### MirrorToCoreModel
- Add `SIMPLE_MARKS` frozen hash for OCP-compliant mark dispatch
- Merge duplicate `build_definition_term`/`build_definition_description` into `build_inline_text`
- Extract `find_nested_list` and `inline_content` helpers (DRY)
- Add `LIST_TYPES` frozen constant

### HandlerRegistry
- Add `TERMINAL_ANCESTORS` constant replaces inline array in ancestor walk

### Node/Mark
- Use `begin...end` blocks for frozen registry constants (fixes Lint/ConstantReassignment)
- Use `private_class_method :build_kwargs` instead of ineffective `private` keyword

### Handlers
- Fix unused `context` params (change to `*` splat)
- Merge duplicate `HardLineBreakElement`/`LineBreakElement` when branches

### Specs
- Fix `described_class::` references in `node_spec.rb`
- Fix unknown mark type preservation in `mark_spec.rb`
- Fix trailing commas, string literals, whitespace across all specs
- Fix unused method argument warnings

### Verification
- 116 examples, 0 failures
- 86.26% line coverage
- Zero Lint offenses