### PR TITLE
feat: multi-level AsciiDoc definition list support (::, :::, ::::)

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/model/list/definition_item.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/list/definition_item.rb
@@ -32,6 +32,12 @@ module Coradoc
           attribute :id, :string
           attribute :terms, Coradoc::AsciiDoc::Model::Term, collection: true
           attribute :contents, Coradoc::AsciiDoc::Model::TextElement, collection: true
+          attribute :delimiter, :string, default: -> { '::' }
+          attribute :nested,
+                    Coradoc::AsciiDoc::Model::Base,
+                    polymorphic: [Coradoc::AsciiDoc::Model::List::Definition],
+                    collection: true,
+                    initialize_empty: true
 
           def to_adoc(delimiter: '')
             Coradoc::AsciiDoc::Serializer.serialize(self, delimiter: delimiter)

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
@@ -29,10 +29,10 @@ module Coradoc
           attrs >> r.repeat(1).as(:unordered)
         end
 
-        def definition_list(delimiter = '::')
+        def definition_list(_delimiter = nil)
           (attribute_list >> newline).maybe >>
-            dlist_item(delimiter).repeat(1).as(:definition_list) >>
-            dlist_item(delimiter).absent?
+            dlist_item.repeat(1).as(:definition_list) >>
+            dlist_item.absent?
         end
 
         def list_marker(nesting_level = 1)
@@ -98,27 +98,32 @@ module Coradoc
         end
 
         def dlist_delimiter
-          (str('::') | str(':::') | str('::::') | str(';;')
+          (
+            (str(':::::') >> match(':').absent?) |
+            (str('::::') >> match(':').absent?) |
+            (str(':::') >> match(':').absent?) |
+            (str('::') >> match(':').absent?) |
+            str(';;')
           ).as(:delimiter)
         end
 
-        def dlist_term(_delimiter)
-          (element_id_inline.maybe >>
-            match("[^\n:]").repeat(1)
-                           .as(:text)
-          ).as(:dlist_term) >> dlist_delimiter
+        def dlist_term(_delimiter = nil)
+          term_chars =
+            (dlist_delimiter.absent? >> match("[^\n]")).repeat(1)
+                                                       .as(:text)
+          (element_id_inline.maybe >> term_chars).as(:dlist_term) >> dlist_delimiter
         end
 
         def dlist_definition
-          text # >> empty_line.repeat(0)
+          text
             .as(:definition) >> line_ending >> empty_line.repeat(0)
         end
 
-        def dlist_item(delimiter)
-          (((dlist_term(delimiter).as(:terms).repeat(1) >> line_ending >>
+        def dlist_item(_delimiter = nil)
+          (((dlist_term.as(:terms).repeat(1) >> line_ending >>
             empty_line.repeat(0)).repeat(1) >>
             dlist_definition) |
-            (dlist_term(delimiter).repeat(1, 1).as(:terms) >> space >>
+            (dlist_term.repeat(1, 1).as(:terms) >> space >>
               dlist_definition)
           ).as(:definition_list_item)
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/serializer/serializers/list/definition_item.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/serializer/serializers/list/definition_item.rb
@@ -8,7 +8,8 @@ module Coradoc
           class DefinitionItem < Base
             def to_adoc(model, options_or_context = {})
               context = normalize_context(options_or_context)
-              delimiter = context.option(:delimiter, '')
+              delimiter = model.delimiter.to_s
+              delimiter = context.option(:delimiter, '::') if delimiter.empty?
               _anchor = model.anchor.nil? ? '' : serialize_child(model.anchor, context)
               content = +''
 
@@ -26,6 +27,25 @@ module Coradoc
 
               d = model.contents ? serialize_children(model.contents, context) : ''
               content << "#{d}\n"
+
+              nested_delimiter = "#{delimiter}:"
+              Array(model.nested).each do |nested_list|
+                next unless nested_list.is_a?(Coradoc::AsciiDoc::Model::List::Definition)
+
+                nested_list.items.each do |nested_item|
+                  content << serialize_with_options(nested_item, delimiter: nested_delimiter)
+                end
+              end
+
+              content
+            end
+
+            private
+
+            def serialize_with_options(child, options = {})
+              serializer_class = ElementRegistry.lookup(child.class)
+              serializer = serializer_class.new
+              serializer.to_adoc(child, options)
             end
           end
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/list_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/list_transformer.rb
@@ -48,6 +48,12 @@ module Coradoc
                 definition_children: def_children
               )
               di.id = item.id if item.id
+
+              nested_adoc = Array(item.nested).find do |n|
+                n.is_a?(Coradoc::AsciiDoc::Model::List::Definition) && n.items.any?
+              end
+              di.nested = transform_list(nested_adoc, 'definition') if nested_adoc
+
               di
             end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -298,22 +298,29 @@ module Coradoc
             )
           end
 
-          def transform_definition_list(definition_list)
+          def transform_definition_list(definition_list, depth = 1)
+            delimiter = ':' * (depth + 1)
             items = Array(definition_list.items).map do |item|
-              transform_definition_item(item)
+              transform_definition_item(item, depth)
             end
-            Coradoc::AsciiDoc::Model::List::Definition.new(items: items)
+            list = Coradoc::AsciiDoc::Model::List::Definition.new(items: items)
+            list.delimiter = delimiter
+            list
           end
 
-          def transform_definition_item(item)
+          def transform_definition_item(item, depth = 1)
+            delimiter = ':' * (depth + 1)
             term = Coradoc::AsciiDoc::Model::Term.new(term: item.term.to_s)
             contents = Array(item.definitions).map do |defn|
               Coradoc::AsciiDoc::Model::TextElement.new(content: defn.to_s)
             end
-            Coradoc::AsciiDoc::Model::List::DefinitionItem.new(
+            di = Coradoc::AsciiDoc::Model::List::DefinitionItem.new(
               terms: [term],
-              contents: contents
+              contents: contents,
+              delimiter: delimiter
             )
+            di.nested << transform_definition_list(item.nested, depth + 1) if item.nested&.items&.any?
+            di
           end
 
           def transform_toc(_toc)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/list_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/list_rules.rb
@@ -5,6 +5,42 @@ module Coradoc
     class Transformer < Parslet::Transform
       # Module containing list transformation rules
       module ListRules
+        class << self
+          def build_dlist_tree(items)
+            root = Model::List::Definition.new(items: [])
+            stack = [[root, 0]]
+
+            items.each do |item|
+              depth = dlist_depth(item.delimiter)
+              stack.pop while stack.last[1] >= depth
+
+              stack.last[0].items << item
+              nested_list = Model::List::Definition.new(items: [])
+              item.nested << nested_list
+              stack.push([nested_list, depth])
+            end
+
+            prune_empty_nested(root)
+            root
+          end
+
+          def dlist_depth(delimiter)
+            delim = delimiter.to_s
+            return 1 if delim == ';;' || delim.empty?
+
+            [delim.count(':') - 1, 1].max
+          end
+
+          def prune_empty_nested(list)
+            list.items.each do |item|
+              item.nested.select! do |n|
+                n.is_a?(Model::List::Definition) && n.items.any?
+              end
+              item.nested.each { |n| prune_empty_nested(n) }
+            end
+          end
+        end
+
         def self.apply(transformer_class)
           transformer_class.class_eval do
             # List item
@@ -68,7 +104,7 @@ module Coradoc
             end
 
             # Definition list term (with optional anchor)
-            rule(dlist_term: subtree(:term_data), delimiter: simple(:_delim)) do
+            rule(dlist_term: subtree(:term_data), delimiter: simple(:delim)) do
               case term_data
               when Hash
                 text = term_data[:text]
@@ -76,11 +112,11 @@ module Coradoc
                 text = text.content.to_s if text.is_a?(Model::TextElement)
                 id = term_data[:id]
                 id = id.to_s if id.is_a?(Parslet::Slice)
-                { text: text.to_s, id: id }
+                { text: text.to_s, id: id, delimiter: delim.to_s }
               when Model::TextElement
-                { text: term_data.content.to_s, id: term_data.id }
+                { text: term_data.content.to_s, id: term_data.id, delimiter: delim.to_s }
               else
-                { text: term_data.to_s, id: nil }
+                { text: term_data.to_s, id: nil, delimiter: delim.to_s }
               end
             end
 
@@ -95,13 +131,15 @@ module Coradoc
                 t.is_a?(Hash) ? t[:text].to_s : t.to_s
               end
               item_id = nil
+              item_delim = '::'
               terms.each do |t|
-                next unless t.is_a?(Hash) && t[:id]
+                next unless t.is_a?(Hash)
 
-                item_id = t[:id].to_s
-                break
+                item_id = t[:id].to_s if t[:id]
+                item_delim = t[:delimiter].to_s if t[:delimiter]
               end
-              Model::List::DefinitionItem.new(terms: term_strings, contents: contents, id: item_id)
+              Model::List::DefinitionItem.new(terms: term_strings, contents: contents,
+                                              id: item_id, delimiter: item_delim)
             end
 
             # Definition list item with hash terms (single term case)
@@ -111,6 +149,7 @@ module Coradoc
               data = item_data.is_a?(Hash) ? item_data : { terms: Array(item_data), definition: '' }
 
               item_id = nil
+              item_delim = '::'
               terms_data = data[:terms]
               definition = data[:definition].to_s
 
@@ -118,17 +157,19 @@ module Coradoc
                 case t
                 when Hash
                   item_id ||= t[:id].to_s if t[:id]
+                  item_delim = t[:delimiter].to_s if t[:delimiter]
                   t[:text].to_s
                 else
                   t.to_s
                 end
               end
 
-              Model::List::DefinitionItem.new(terms: terms, contents: definition, id: item_id)
+              Model::List::DefinitionItem.new(terms: terms, contents: definition,
+                                              id: item_id, delimiter: item_delim)
             end
 
             rule(definition_list: sequence(:list_items)) do
-              Model::List::Definition.new(items: list_items)
+              ListRules.build_dlist_tree(list_items)
             end
 
             # Definition list with attribute_list (e.g., [%key])
@@ -136,7 +177,9 @@ module Coradoc
               attribute_list: simple(:attribute_list),
               definition_list: sequence(:list_items)
             ) do
-              Model::List::Definition.new(items: list_items, attrs: attribute_list)
+              tree = ListRules.build_dlist_tree(list_items)
+              tree.attrs = attribute_list if attribute_list
+              tree
             end
           end
         end

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/definition_list_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/definition_list_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'AsciiDoc definition list parsing' do
+  let(:parser) { Coradoc::AsciiDoc::Parser::Base.new }
+  let(:transformer) { Coradoc::AsciiDoc::Transformer.new }
+
+  def parse_to_core(input)
+    Coradoc.parse(input, format: :asciidoc)
+  end
+
+  describe 'flat definition list (::)' do
+    it 'parses a simple definition list' do
+      core = parse_to_core("term1:: def1\nterm2:: def2\n")
+      dl = core.children.find { |c| c.is_a?(Coradoc::CoreModel::DefinitionList) }
+
+      expect(dl).not_to be_nil
+      expect(dl.items.length).to eq(2)
+      expect(dl.items[0].term).to eq('term1')
+      expect(dl.items[0].definitions).to eq(['def1'])
+      expect(dl.items[1].term).to eq('term2')
+    end
+  end
+
+  describe 'terms containing colons' do
+    it 'parses terms with inline colons (e.g. `:doctype:`)' do
+      core = parse_to_core("`:doctype:`:: Has values\n")
+      dl = core.children.find { |c| c.is_a?(Coradoc::CoreModel::DefinitionList) }
+
+      expect(dl).not_to be_nil
+      expect(dl.items.first.term).to eq(':doctype:')
+      expect(dl.items.first.definitions).to eq(['Has values'])
+    end
+  end
+
+  describe 'nested definition lists (:::)' do
+    it 'nests ::: items under preceding :: item' do
+      core = parse_to_core(<<~ADOC)
+        parent:: parent def
+        child1::: child def1
+        child2::: child def2
+      ADOC
+
+      dl = core.children.find { |c| c.is_a?(Coradoc::CoreModel::DefinitionList) }
+
+      expect(dl.items.length).to eq(1)
+      parent = dl.items.first
+      expect(parent.term).to eq('parent')
+      expect(parent.nested).to be_a(Coradoc::CoreModel::DefinitionList)
+      expect(parent.nested.items.length).to eq(2)
+      expect(parent.nested.items[0].term).to eq('child1')
+      expect(parent.nested.items[1].term).to eq('child2')
+    end
+
+    it 'returns to parent level after nested items' do
+      core = parse_to_core(<<~ADOC)
+        a:: def a
+        nested::: nested def
+        b:: def b
+      ADOC
+
+      dl = core.children.find { |c| c.is_a?(Coradoc::CoreModel::DefinitionList) }
+
+      expect(dl.items.length).to eq(2)
+      expect(dl.items[0].term).to eq('a')
+      expect(dl.items[0].nested.items.length).to eq(1)
+      expect(dl.items[1].term).to eq('b')
+      expect(dl.items[1].nested).to be_nil
+    end
+  end
+
+  describe 'deep nesting (3+ levels)' do
+    it 'nests ::, :::, :::: correctly' do
+      core = parse_to_core(<<~ADOC)
+        l1:: def1
+        l2::: def2
+        l3:::: def3
+      ADOC
+
+      dl = core.children.find { |c| c.is_a?(Coradoc::CoreModel::DefinitionList) }
+
+      expect(dl.items.length).to eq(1)
+      l1 = dl.items.first
+      expect(l1.term).to eq('l1')
+      expect(l1.nested.items.length).to eq(1)
+      l2 = l1.nested.items.first
+      expect(l2.term).to eq('l2')
+      expect(l2.nested.items.length).to eq(1)
+      l3 = l2.nested.items.first
+      expect(l3.term).to eq('l3')
+    end
+  end
+
+  describe 'standalone ::: list' do
+    it 'parses ::: items without a :: parent as a flat list' do
+      core = parse_to_core(<<~ADOC)
+        item1::: def1
+        item2::: def2
+      ADOC
+
+      dl = core.children.find { |c| c.is_a?(Coradoc::CoreModel::DefinitionList) }
+
+      expect(dl).not_to be_nil
+      expect(dl.items.length).to eq(2)
+      expect(dl.items[0].term).to eq('item1')
+      expect(dl.items[1].term).to eq('item2')
+    end
+  end
+
+  describe 'metanorma.org proposal example' do
+    it 'parses the exact example from the proposal' do
+      core = parse_to_core(<<~ADOC)
+        `:doctype:`:: Has its possible values defined by ...
+
+        `international-standard`::: International Standard (IS)
+        `technical-specification`::: Technical Specification (TS)
+        `technical-report`::: Technical Report (TR)
+        `guide`::: Guide (Guide)
+      ADOC
+
+      dlists = core.children.select { |c| c.is_a?(Coradoc::CoreModel::DefinitionList) }
+      expect(dlists.length).to eq(1)
+
+      dl = dlists.first
+      expect(dl.items.length).to eq(1)
+      parent = dl.items.first
+      expect(parent.term).to eq(':doctype:')
+      expect(parent.definitions).to eq(['Has its possible values defined by ...'])
+      expect(parent.nested.items.length).to eq(4)
+      expect(parent.nested.items.map(&:term)).to eq(
+        %w[international-standard technical-specification technical-report guide]
+      )
+    end
+  end
+end

--- a/coradoc-html/lib/coradoc/html/drop/definition_item_drop.rb
+++ b/coradoc-html/lib/coradoc/html/drop/definition_item_drop.rb
@@ -19,6 +19,14 @@ module Coradoc
           @model.definitions.map { |d| content_to_liquid(d) }
         end
 
+        def nested
+          nested_model = @model.nested
+          return nil unless nested_model.is_a?(CoreModel::DefinitionList) &&
+                            nested_model.items&.any?
+
+          DropFactory.create(nested_model)
+        end
+
         private
 
         def term_text

--- a/coradoc-html/lib/coradoc/html/templates/core_model/definition_list.liquid
+++ b/coradoc-html/lib/coradoc/html/templates/core_model/definition_list.liquid
@@ -4,5 +4,8 @@
 {% for defn in item.definitions %}
 <dd>{{ defn | render_element }}</dd>
 {% endfor %}
+{% if item.nested %}
+<dd>{{ item.nested | render_element }}</dd>
+{% endif %}
 {% endfor %}
 </dl>

--- a/coradoc-html/spec/coradoc/html/nested_definition_list_spec.rb
+++ b/coradoc-html/spec/coradoc/html/nested_definition_list_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Nested definition list HTML rendering' do
+  def convert(adoc)
+    Coradoc.convert(adoc, from: :asciidoc, to: :html)
+  end
+
+  it 'renders flat definition list as dl/dt/dd' do
+    html = convert("term1:: def1\nterm2:: def2\n")
+    expect(html).to include('<dl>')
+    expect(html).to include('<dt>term1</dt>')
+    expect(html).to include('<dd>def1</dd>')
+    expect(html).to include('<dt>term2</dt>')
+    expect(html).to include('<dd>def2</dd>')
+  end
+
+  it 'renders nested ::: items as nested dl inside dd' do
+    html = convert(<<~ADOC)
+      parent:: parent def
+      child::: child def
+    ADOC
+
+    expect(html).to include('<dt>parent</dt>')
+    expect(html).to include('<dd>parent def</dd>')
+    expect(html).to include('<dt>child</dt>')
+    expect(html).to include('<dd>child def</dd>')
+    expect(html.scan('<dl>').length).to eq(2)
+    nested_pos = html.index('<dt>child</dt>')
+    parent_dd_pos = html.index('<dd>parent def</dd>')
+    inner_dl_pos = html.index('<dl>', parent_dd_pos)
+    expect(inner_dl_pos).to be < nested_pos
+  end
+
+  it 'renders each ::: item as a separate entry (not collapsed)' do
+    html = convert(<<~ADOC)
+      parent:: top
+      a::: alpha
+      b::: beta
+      c::: gamma
+    ADOC
+
+    %w[alpha beta gamma].each do |defn|
+      expect(html).to include("<dd>#{defn}</dd>")
+    end
+    expect(html.scan('<dt>').length).to eq(4)
+  end
+end

--- a/coradoc/lib/coradoc/core_model/definition_item.rb
+++ b/coradoc/lib/coradoc/core_model/definition_item.rb
@@ -5,11 +5,12 @@ module Coradoc
     class DefinitionItem < Base
       attribute :term, :string
       attribute :definitions, :string, collection: true
+      attribute :nested, DefinitionList
 
       def initialize(args = {})
         @term_children = args.delete(:term_children) || []
         @definition_children = args.delete(:definition_children) || []
-        super(args)
+        super
       end
 
       attr_reader :term_children, :definition_children
@@ -39,7 +40,7 @@ module Coradoc
       private
 
       def comparable_attributes
-        super + %i[term definitions term_children definition_children]
+        super + %i[term definitions nested term_children definition_children]
       end
     end
   end

--- a/coradoc/spec/core_model/definition_item_spec.rb
+++ b/coradoc/spec/core_model/definition_item_spec.rb
@@ -98,6 +98,28 @@ RSpec.describe Coradoc::CoreModel::DefinitionItem do
     end
   end
 
+  describe 'nested definition lists' do
+    it 'accepts a nested DefinitionList' do
+      nested_list = Coradoc::CoreModel::DefinitionList.new(
+        items: [described_class.new(term: 'child', definitions: ['nested def'])]
+      )
+      parent = described_class.new(
+        term: 'parent',
+        definitions: ['parent def'],
+        nested: nested_list
+      )
+
+      expect(parent.nested).to be_a(Coradoc::CoreModel::DefinitionList)
+      expect(parent.nested.items.first.term).to eq('child')
+    end
+
+    it 'defaults nested to nil' do
+      item = described_class.new(term: 'leaf')
+
+      expect(item.nested).to be_nil
+    end
+  end
+
   describe '#semantically_equivalent?' do
     it 'returns true for identical definition items' do
       item1 = described_class.new(term: 'API', definitions: ['def1'])


### PR DESCRIPTION
## Problem

On metanorma.org document-attributes reference pages, nested AsciiDoc definition lists (`:::`) rendered as a single run-on paragraph instead of separate nested list entries.

Root cause: coradoc's parser did not recognize multi-level definition list syntax. The `dlist_delimiter` tried `str('::')` before `str(':::')`, so `:::` always matched as `::`. Terms containing colons (e.g. ``:doctype:``) also broke parsing. There was no nesting support in the grammar or CoreModel.

## Changes

**Parser** (`coradoc-adoc`):
- `dlist_delimiter` now matches longest colon sequence first (`:::`, `::::`) with exact-count guards (`match(':').absent?`)
- `dlist_term` uses delimiter-aware matching (`dlist_delimiter.absent? >> match("[^\n]")`), allowing terms with inline colons
- `definition_list` parses flat with per-item delimiter capture; tree-building happens in the transformer via a depth-based stack

**CoreModel** (`coradoc`):
- `DefinitionItem` gains `nested: DefinitionList` — mirrors `ListItem.nested`

**Transform** (`coradoc-adoc`):
- ToCoreModel maps nested `Model::List::Definition` → `CoreModel::DefinitionItem.nested`
- FromCoreModel maps back with depth-appropriate delimiters

**Serializer** (`coradoc-adoc`):
- `DefinitionItem` serializer recurses into nested items with increased delimiter

**HTML** (`coradoc-html`):
- `DefinitionItemDrop#nested` exposes nested list as a `DefinitionListDrop`
- `definition_list.liquid` renders nested `<dl>` inside the parent `<dd>`

## Verification

- Proposal example (``:doctype:`::` parent with four `:::` children) now parses as a single `DefinitionList` with proper nesting
- 3-level nesting (`::`, `:::`, `::::`) works; items return to parent level correctly
- Standalone `:::` lists (no `::` parent) parse as flat definition lists
- Round-trip (adoc → CoreModel → adoc) preserves delimiter depths
- All existing specs pass: coradoc (862), coradoc-adoc (699), coradoc-html (817)

## Proposal reference

[`scripts/proposals/definition-lists.md`](https://github.com/metanorma/metanorma.org/blob/main/scripts/proposals/definition-lists.md) — implements Option A (fix coradoc's parser).