### PR TITLE
fix(adoc): preserve attribute list on definition lists

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/model/list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/list.rb
@@ -6,16 +6,18 @@ module Coradoc
       # Namespace for all AsciiDoc list types and their items.
       #
       # List Architecture:
-      #   - List::Core - Common list functionality (base class)
+      #   - List::Base - Universal list attributes (id, attrs)
+      #   - List::Nestable - Marker class for lists nestable inside Item
+      #   - List::Core - Ordered/unordered list base (marker, prefix, ol_count)
       #   - List::Ordered - Numbered lists (1., 2., 3., etc.)
       #   - List::Unordered - Bulleted lists (*, **, etc.)
       #   - List::Definition - Labeled/definition lists (term:: definition)
       #   - List::Item - Item for ordered/unordered lists
       #   - List::DefinitionItem - Item for definition lists
-      #   - List::Nestable - Mixin for nesting support
       #
       module List
         # Autoload list types lazily
+        autoload :Base, 'coradoc/asciidoc/model/list/base'
         autoload :Core, 'coradoc/asciidoc/model/list/core'
         autoload :Nestable, 'coradoc/asciidoc/model/list/nestable'
         autoload :Ordered, 'coradoc/asciidoc/model/list/ordered'

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/list/base.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/list/base.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module AsciiDoc
+    module Model
+      module List
+        # Shared base class for all list container types.
+        #
+        # Every list flavor (Core, Definition, and any future ones) inherits
+        # the universal list-level attributes from this class:
+        #
+        #   - +id+    optional anchor identifier (inherited from Model::Base)
+        #   - +attrs+ block attribute list, e.g. +[%hardbreaks]+ or +[#my-id]+
+        #
+        # Subclasses declare their own +items+ with the appropriate item type
+        # (List::Item for ordered/unordered, List::DefinitionItem for definition)
+        # plus any flavor-specific attributes (marker, prefix, delimiter, ...).
+        #
+        # @!attribute [r] attrs
+        #   @return [Coradoc::AsciiDoc::Model::AttributeList] Additional list
+        #     attributes parsed from the +[...]+ block header preceding the list
+        class Base < Coradoc::AsciiDoc::Model::Base
+          include Coradoc::AsciiDoc::Model::Anchorable
+
+          attribute :attrs,
+                    Coradoc::AsciiDoc::Model::AttributeList,
+                    default: -> { Coradoc::AsciiDoc::Model::AttributeList.new }
+
+          asciidoc do
+            map_attribute 'id', to: :id
+            map_attribute 'attrs', to: :attrs
+          end
+
+          def block_level?
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/list/core.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/list/core.rb
@@ -4,21 +4,17 @@ module Coradoc
   module AsciiDoc
     module Model
       module List
-        # Base class for list elements in AsciiDoc documents.
+        # Base class for ordered/unordered lists.
         #
-        # Lists are container elements that hold list items and provide
-        # functionality for different list types (ordered, unordered, definition).
+        # Inherits universal list attributes (id, attrs) from List::Base and
+        # adds the marker-related attributes specific to bulleted/numbered lists.
         #
-        # @!attribute [r] id
-        #   @return [String, nil] Optional identifier for the list
         # @!attribute [r] prefix
-        #   @return [String, nil] List marker prefix (e.g., "*", "*", "**", etc.)
+        #   @return [String, nil] List marker prefix (e.g., "*", "**", etc.)
         # @!attribute [r] items
         #   @return [Array<ListItem>] List items in this list
         # @!attribute [r] ol_count
         # @return [Integer] Ordered list nesting level
-        # @!attribute [r] attrs
-        #   @return [AttributeList] Additional list attributes
         # @!attribute [r] marker
         #   @return [String, nil] The marker character used for this list
         #
@@ -27,31 +23,15 @@ module Coradoc
         #   list.items << Coradoc::AsciiDoc::Model::List::Item.new("Item 1")
         #
         class Core < Nestable
-          include Coradoc::AsciiDoc::Model::Anchorable
-
-          def block_level?
-            true
-          end
-
-          attribute :id, :string
           attribute :prefix, :string
-          # attribute :anchor, Inline::Anchor, default: -> {
-          #   id.nil? ? nil : Inline::Anchor.new(id)
-          # }
           attribute :items, Coradoc::AsciiDoc::Model::List::Item, collection: true, initialize_empty: true
           attribute :ol_count, :integer, default: -> { 1 }
-          attribute :attrs, Coradoc::AsciiDoc::Model::AttributeList, default: lambda {
-            Coradoc::AsciiDoc::Model::AttributeList.new
-          }
           attribute :marker, :string
 
           asciidoc do
-            map_attribute 'id', to: :id
-            map_attribute 'anchor', to: :anchor
             map_attribute 'prefix', to: :prefix
             map_attribute 'items', to: :items
             map_attribute 'ol_count', to: :ol_count
-            map_attribute 'attrs', to: :attrs
             map_attribute 'marker', to: :marker
           end
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/list/definition.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/list/definition.rb
@@ -4,6 +4,13 @@ module Coradoc
   module AsciiDoc
     module Model
       module List
+        # Definition list container. Inherits universal list attributes
+        # (id, attrs) from List::Base.
+        #
+        # @!attribute [r] items
+        #   @return [Array<DefinitionItem>] Definition items in this list
+        # @!attribute [r] delimiter
+        #   @return [String] Delimiter indicating nesting depth ('::', ':::', ...)
         class Definition < Base
           attribute :items,
                     Coradoc::AsciiDoc::Model::Base,

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/list/definition_item.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/list/definition_item.rb
@@ -26,7 +26,7 @@ module Coradoc
         #   item.terms << Coradoc::AsciiDoc::Model::Term.new(term: "API")
         #   item.contents << Coradoc::AsciiDoc::Model::TextElement.new("Application Programming Interface")
         #
-        class DefinitionItem < Base
+        class DefinitionItem < Coradoc::AsciiDoc::Model::Base
           include Coradoc::AsciiDoc::Model::Anchorable
 
           attribute :id, :string

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/list/item.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/list/item.rb
@@ -40,7 +40,7 @@ module Coradoc
         #   item.nested = Coradoc::AsciiDoc::Model::List::Unordered.new
         #   item.nested.items << Coradoc::AsciiDoc::Model::List::Item.new
         #
-        class Item < Base
+        class Item < Coradoc::AsciiDoc::Model::Base
           include Coradoc::AsciiDoc::Model::Anchorable
 
           attribute :id, :string

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/list/nestable.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/list/nestable.rb
@@ -4,9 +4,13 @@ module Coradoc
   module AsciiDoc
     module Model
       module List
-        # Mixin module for nestable list functionality.
-        # Provides common functionality for lists that can contain nested lists.
-        class Nestable < Coradoc::AsciiDoc::Model::Base
+        # Marker class for lists that can be nested inside a List::Item
+        # via its +nested+ attribute. Inherits universal list attributes
+        # (id, attrs) from List::Base.
+        #
+        # List::Definition does not extend Nestable because it has its own
+        # nesting model via List::DefinitionItem#nested.
+        class Nestable < Base
         end
       end
     end

--- a/coradoc-adoc/lib/coradoc/asciidoc/serializer/serializers/list/definition.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/serializer/serializers/list/definition.rb
@@ -8,7 +8,9 @@ module Coradoc
           class Definition < Base
             def to_adoc(model, _options = {})
               @model = model
-              content = +"\n"
+              _attrs = @model.attrs.to_adoc(show_empty: false).to_s
+              prefix = _attrs.empty? ? '' : "#{_attrs}\n"
+              content = "\n#{prefix}"
               @model.items.each do |item|
                 # Pass delimiter to item serialization
                 serialized = serialize_child_with_options(item, delimiter: @model.delimiter)

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/list/base_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/list/base_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Coradoc::AsciiDoc::Model::List::Base do
+  describe 'inheritance hierarchy' do
+    it 'Core inherits universal attrs from List::Base' do
+      expect(described_class).to be > Coradoc::AsciiDoc::Model::List::Core
+    end
+
+    it 'Definition inherits universal attrs from List::Base' do
+      expect(described_class).to be > Coradoc::AsciiDoc::Model::List::Definition
+    end
+
+    it 'Ordered inherits attrs transitively through Core/Nestable' do
+      expect(described_class).to be > Coradoc::AsciiDoc::Model::List::Ordered
+    end
+
+    it 'Unordered inherits attrs transitively through Core/Nestable' do
+      expect(described_class).to be > Coradoc::AsciiDoc::Model::List::Unordered
+    end
+
+    it 'List::Item is NOT under List::Base (items are not containers)' do
+      expect(described_class).not_to be > Coradoc::AsciiDoc::Model::List::Item
+    end
+
+    it 'DefinitionItem is NOT under List::Base' do
+      expect(described_class).not_to be > Coradoc::AsciiDoc::Model::List::DefinitionItem
+    end
+  end
+
+  describe 'shared attrs attribute' do
+    it 'Definition has attrs (regression for NoMethodError)' do
+      dlist = Coradoc::AsciiDoc::Model::List::Definition.new
+      expect(dlist.attrs).to be_a(Coradoc::AsciiDoc::Model::AttributeList)
+    end
+
+    it 'Ordered has attrs inherited from List::Base via Core/Nestable' do
+      list = Coradoc::AsciiDoc::Model::List::Ordered.new
+      expect(list.attrs).to be_a(Coradoc::AsciiDoc::Model::AttributeList)
+    end
+
+    it 'Definition is block-level' do
+      expect(Coradoc::AsciiDoc::Model::List::Definition.new.block_level?).to be(true)
+    end
+
+    it 'Core is block-level' do
+      expect(Coradoc::AsciiDoc::Model::List::Core.new.block_level?).to be(true)
+    end
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/definition_list_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/definition_list_spec.rb
@@ -133,4 +133,53 @@ RSpec.describe 'AsciiDoc definition list parsing' do
       )
     end
   end
+
+  describe 'attribute list on definition list' do
+    def find_adoc_dlist(node)
+      return node if node.is_a?(Coradoc::AsciiDoc::Model::List::Definition)
+
+      children = node.respond_to?(:sections) ? node.sections : Array(node.blocks)
+      children.flat_map { |c| [find_adoc_dlist(c)].compact }.first
+    end
+
+    it 'parses [%hardbreaks] prefix without raising (regression)' do
+      expect { parse_to_core("[%hardbreaks]\nterm:: def\n") }.not_to raise_error
+    end
+
+    it 'parses [%metadata] and preserves the attribute on the AsciiDoc model' do
+      doc = Coradoc::AsciiDoc.parse("[%metadata]\nidentifier:: abc\n")
+      dlist = find_adoc_dlist(doc)
+
+      expect(dlist).to be_a(Coradoc::AsciiDoc::Model::List::Definition)
+    end
+
+    it 'preserves [%metadata] attribute value through attrs.to_adoc' do
+      doc = Coradoc::AsciiDoc.parse("[%metadata]\nidentifier:: abc\n")
+      dlist = find_adoc_dlist(doc)
+
+      expect(dlist.attrs.to_adoc(show_empty: false)).to eq('[%metadata]')
+    end
+
+    it 'parses [.glossary] and preserves it on the AsciiDoc model' do
+      doc = Coradoc::AsciiDoc.parse("[.glossary]\nterm:: def\n")
+      dlist = find_adoc_dlist(doc)
+
+      expect(dlist.attrs.to_adoc(show_empty: false)).to eq('[.glossary]')
+    end
+
+    it 'serializes the attribute list back before the items' do
+      original = "[%metadata]\nidentifier:: abc\nsubject:: s\n"
+      serialized = Coradoc::AsciiDoc.serialize(Coradoc::AsciiDoc.parse(original))
+
+      expect(serialized).to include("[%metadata]\nidentifier:: abc")
+    end
+
+    it 'round-trips the attribute list through serialize/parse' do
+      original = "[%metadata]\nidentifier:: abc\nsubject:: s\n"
+      serialized = Coradoc::AsciiDoc.serialize(Coradoc::AsciiDoc.parse(original))
+      reparsed = find_adoc_dlist(Coradoc::AsciiDoc.parse(serialized))
+
+      expect(reparsed.attrs.to_adoc(show_empty: false)).to eq('[%metadata]')
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`Coradoc.parse` raised `NoMethodError: undefined method 'attrs=' for Coradoc::AsciiDoc::Model::List::Definition` whenever an AsciiDoc definition list was preceded by a block attribute header (e.g. `[%metadata]`, `[%hardbreaks]`, `[.glossary]`, `[#my-id]`).

This blocked **7 files** in `metanorma.org/author/topics/` (per metanorma.org team report) and **12 more** elsewhere in the repo (full scan: 59 occurrences across 14 files of `[xxx]\nterm:: def\n`).

## Root cause

`84d4daa` (multi-level dlist refactor) changed `list_rules.rb:181` from

```ruby
Model::List::Definition.new(items: list_items, attrs: attribute_list)   # silently dropped
```

to

```ruby
tree = ListRules.build_dlist_tree(list_items)
tree.attrs = attribute_list if attribute_list                            # raises NoMethodError
```

`Model::List::Definition` never declared an `attrs` attribute (unlike its sibling `Model::List::Core`), so the refactor surfaced a latent bug as a hard error. The pre-refactor code was *also* broken — lutaml-model silently dropped the unknown kwarg, so attribute metadata was being lost even before the user-visible failure.

## Fix

**Extract `Model::List::Base`** as a shared parent for list containers, owning the universal list attributes:

```
Model::Base
└── List::Base (NEW — id, attrs, block_level?, Anchorable)
    ├── List::Nestable
    │   └── List::Core (prefix, marker, ol_count)
    │       ├── List::Ordered
    │       └── List::Unordered
    └── List::Definition (items, delimiter)  ← now inherits attrs
```

- **`model/list/base.rb`** (new): declares `attrs` + asciidoc mapping + `block_level?`
- **`model/list/nestable.rb`**: inherits from `List::Base` (was `Model::Base`)
- **`model/list/core.rb`**: drops the now-duplicated `attrs`/`id` declarations
- **`model/list/definition.rb`**: automatically gains `attrs` via inheritance
- **`model/list/item.rb`** and **`definition_item.rb`**: explicitly extend `Model::Base` — items are not list containers, `attrs` does not apply to them. (This was necessary because unqualified `Base` now resolves to `List::Base` in their scope.)
- **`serializer/serializers/list/definition.rb`**: emits `[attrs]\n` before the items, mirroring `serializers/list/core.rb`

## Verification

- New specs: `spec/coradoc/asciidoc/parser/definition_list_spec.rb` (regression + 4 attrs cases) and `spec/coradoc/asciidoc/model/list/base_spec.rb` (inheritance hierarchy + shared attrs).
- Full suite:
  - coradoc: 944 examples, 0 failures
  - coradoc-adoc: 927 examples, 0 failures (5 pre-existing pending)
  - coradoc-markdown, coradoc-html: pass
  - coradoc-docx: 10 pre-existing failures (unrelated — same count on `main`)
- Rubocop: no new offenses beyond the project-wide baseline.

## Out of scope

- CoreModel does not gain an `attrs` field. `attrs` is a format-local concern (consistent with how `List::Core` already treats it — CoreModel has no attrs field for any list type).
- The `id` from `[#my-id]` is currently extracted into the DefinitionItem, not the Definition container. That's an existing parser design choice, untouched here.
- The orphan `Bump coradoc to 2.0.19` commit (`4af911b`) on `origin/main` from the failed release workflow is unrelated and will be addressed separately.