### PR TITLE
fix(release): pass per-gem version_file for non-standard version paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,14 @@ jobs:
       gem_name: ${{ github.event.inputs.gem_name || 'coradoc' }}
       gem_directory: '.'
       next_version: ${{ github.event.inputs.next_version || 'skip' }}
+      version_file: >-
+        ${{
+          (github.event.inputs.gem_name == 'coradoc-adoc' && 'lib/coradoc/asciidoc/version.rb') ||
+          (github.event.inputs.gem_name == 'coradoc-html' && 'lib/coradoc/html/version.rb') ||
+          (github.event.inputs.gem_name == 'coradoc-markdown' && 'lib/coradoc/markdown/version.rb') ||
+          (github.event.inputs.gem_name == 'coradoc-docx' && 'lib/coradoc/docx/version.rb') ||
+          ''
+        }}
     secrets:
       rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}


### PR DESCRIPTION
## Problem

coradoc-adoc/html/markdown/docx all have version files at non-standard paths that gem-release cannot auto-detect:

| gem | version file | gem-release expects |
|-----|--------------|---------------------|
| coradoc-adoc | lib/coradoc/asciidoc/version.rb | lib/coradoc_adoc/version.rb |
| coradoc-html | lib/coradoc/html/version.rb | lib/coradoc_html/version.rb |
| coradoc-markdown | lib/coradoc/markdown/version.rb | lib/coradoc_markdown/version.rb |
| coradoc-docx | lib/coradoc/docx/version.rb | lib/coradoc_docx/version.rb |

This blocked the coradoc-adoc 2.0.10 patch release: workflow run 27867283902 failed at "Bump version" with `Ignoring coradoc-adoc. Version file ? not found. Aborting.`

## Fix

Pass `version_file` per gem to `metanorma/ci/.github/workflows/monorepo-rubygems-release.yml@main`. That workflow (after metanorma/ci#298) forwards it to `gem bump --file`, which lets gem-release locate the non-standard version path.

coradoc root gem has the standard layout (`lib/coradoc/version.rb`) and needs no override.

Depends on: metanorma/ci#298 (merged).
