### PR TITLE
fix(release): set gated=false; resolve gem_name from client_payload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,12 @@ jobs:
   release:
     uses: metanorma/ci/.github/workflows/monorepo-rubygems-release.yml@main
     with:
-      gem_name: ${{ github.event.inputs.gem_name || 'coradoc' }}
+      # gated=false: coradoc has no test→do-release relay wired up, and
+      # metanorma/ci's do-release payload doesn't carry gem-name, so gated
+      # mode can never publish the right gem. Publish immediately on
+      # workflow_dispatch; the idempotency guard handles any duplicates.
+      gated: false
+      gem_name: ${{ github.event.client_payload.gem-name || github.event.inputs.gem_name || 'coradoc' }}
       gem_directory: '.'
       next_version: ${{ github.event.inputs.next_version || 'skip' }}
       version_file: >-


### PR DESCRIPTION
## Problem

The coradoc-adoc 2.0.10 release dispatch (run 27868283347) bumped and tagged correctly but never published — RubyGems still shows 2.0.9.

Root cause: `METANORMA_CI_PAT_TOKEN` was added to the repo recently. With PAT + default `gated=true`, the reusable workflow switches to the gated relay chain: bump → tag push → tests → `do-release` repository_dispatch → publish. But this chain is broken for coradoc:

1. **coradoc's rake.yml doesn't dispatch `do-release`** — it just runs tests on tag pushes, no relay bridge.
2. **metanorma/ci's do-release payload doesn't carry gem-name** — even if fired, `release.yml` would fall back to `gem_name=coradoc` and publish the wrong gem.

Result: tags get pushed, nothing publishes them. The 2.0.10 tag is sitting on the repo with no gem.

## Fix

Two surgical changes:

- **`gated: false`** — Publish immediately on `workflow_dispatch`. The idempotency guard in metanorma/ci handles duplicate publishes if a stray `do-release` ever arrives. This restores the pre-PAT behavior that successfully shipped coradoc 2.0.19.
- **Read `gem_name` from `client_payload.gem-name` first** — Future-proofs the `repository_dispatch` path so a later wired-up relay can target the correct gem.

This is the correct permanent setting for coradoc's monorepo setup until metanorma/ci's relay carries per-gem identity.

## Verification

After merge, will re-dispatch with `gem_name=coradoc-adoc next_version=skip` to publish the already-tagged 2.0.10.
