### PR TITLE
fix(adoc,callouts): verbatim block handling — callout annotations + nested delimiters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,10 @@ PROPOSAL-*
 **/PROPOSAL*
 **/PROPOSAL-*
 
+# BUG reports are personal issue tracking — NEVER commit
+BUG-*.md
+**/BUG-*.md
+
 # Scratch files
 sample.oscal.*
 /x

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/block.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/block.rb
@@ -104,11 +104,22 @@ module Coradoc
             delim_str = c.captures[capture_key].to_s.strip
             closing_pattern = str(delim_str) >> newline
 
-            content = block_image
-            content |= block(n_deep - 1) if n_deep.positive?
-            content |= list
-            content |= text_line(false, unguarded: true, verbatim: verbatim)
-            content |= empty_line.as(:line_break)
+            # Verbatim blocks (source/listing) treat their body as literal
+            # text per the AsciiDoc spec — no substitutions, no nested
+            # blocks. Allowing nested block parsing here would consume
+            # shorter inner delimiters (e.g. `----` inside `------`) and
+            # strip the original structure when serializing back.
+            content = if verbatim
+                        text_line(false, unguarded: true, verbatim: true) |
+                          empty_line.as(:line_break)
+                      else
+                        c = block_image
+                        c |= block(n_deep - 1) if n_deep.positive?
+                        c |= list
+                        c |= text_line(false, unguarded: true)
+                        c |= empty_line.as(:line_break)
+                        c
+                      end
 
             (closing_pattern.absent? >> content).repeat(1)
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/content.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/content.rb
@@ -24,7 +24,7 @@ module Coradoc
         # :zero :one :many
         def text_line(many_breaks = false, unguarded: false, verbatim: false)
           tl = if verbatim
-                 text_any.as(:text)
+                 raw_verbatim_line.as(:text)
                elsif unguarded
                  literal_space? >> text_any.as(:text)
                else
@@ -36,6 +36,15 @@ module Coradoc
           else
             tl >> (line_ending.as(:line_break) | eof?)
           end
+        end
+
+        # A verbatim source/listing line: capture every character up to the
+        # next newline without applying any inline substitutions. Source and
+        # listing blocks must round-trip their text untouched — otherwise
+        # sequences like Liquid `{{ var }}` collide with AsciiDoc attribute
+        # references and get rewritten.
+        def raw_verbatim_line
+          (line_ending.absent? >> any).repeat(1)
         end
 
         def asciidoc_char

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform.rb
@@ -13,6 +13,7 @@ module Coradoc
       autoload :InlineTransformVisitor, "#{__dir__}/transform/inline_transform_visitor"
       autoload :ElementTransformers, "#{__dir__}/transform/element_transformers"
       autoload :FrontmatterAttributeMap, "#{__dir__}/transform/frontmatter_attribute_map"
+      autoload :CalloutMerger, "#{__dir__}/transform/callout_merger"
     end
   end
 end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/callout_merger.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/callout_merger.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module AsciiDoc
+    module Transform
+      # Post-processing pass that merges AsciiDoc callout annotation
+      # paragraphs into the verbatim block they annotate.
+      #
+      # AsciiDoc callouts look like:
+      #
+      #   [source,ruby]
+      #   ----
+      #   get '/hi' do <1>
+      #   ----
+      #   <1> Returns hello world
+      #
+      # The parser emits the source block and the annotation as two
+      # independent children. The CoreModel representation should attach
+      # the annotation to the block as a typed Callout, so downstream
+      # serializers can render them appropriately for each format.
+      #
+      # Single responsibility: take a flat list of transformed CoreModel
+      # children, return a flat list with `<N>` paragraphs adjacent to a
+      # SourceBlock / ListingBlock folded into that block's `callouts`.
+      # Anything else is passed through untouched.
+      class CalloutMerger
+        ANNOTATION_LINE = /<(\d+)>\s*(.*?)\s*\z/
+        ANNOTATION_SPLIT = /(?=<\d+>)/
+
+        class << self
+          def call(children)
+            new.merge(Array(children))
+          end
+        end
+
+        # Walks the input children left-to-right. When a paragraph whose
+        # content is composed entirely of `<N> text` lines follows a
+        # verbatim block (SourceBlock or ListingBlock), each `<N>` line
+        # becomes a Callout attached to that block instead of a separate
+        # paragraph.
+        #
+        # Annotations that do not follow a verbatim block are preserved
+        # verbatim — they may be legitimate prose.
+        def merge(children)
+          children.each.with_object([]) do |child, result|
+            annotations = extract_annotations(child)
+            target = annotations && preceding_verbatim_block(result)
+            if target
+              target.callouts.concat(annotations)
+            else
+              result << child
+            end
+          end
+        end
+
+        private
+
+        # Returns an Array of Callout if the paragraph is entirely
+        # callout annotations, otherwise nil.
+        def extract_annotations(child)
+          return nil unless child.is_a?(Coradoc::CoreModel::ParagraphBlock)
+
+          lines = split_annotation_lines(child.flat_text)
+          return nil if lines.empty?
+
+          callouts = lines.map do |line|
+            match = line.match(ANNOTATION_LINE)
+            match ? Coradoc::CoreModel::Callout.new(index: match[1].to_i, content: match[2]) : nil
+          end
+          return nil if callouts.any?(&:nil?)
+
+          callouts
+        end
+
+        # Splits a paragraph into candidate annotation lines. Returns []
+        # if any non-blank segment fails to look like an annotation.
+        def split_annotation_lines(text)
+          return [] if text.nil? || text.strip.empty?
+
+          chunks = text.strip.split(ANNOTATION_SPLIT)
+          chunks.map(&:strip).reject(&:empty?)
+        end
+
+        def preceding_verbatim_block(result)
+          last = result.last
+          return nil unless last.is_a?(Coradoc::CoreModel::SourceBlock) ||
+                            last.is_a?(Coradoc::CoreModel::ListingBlock)
+
+          last
+        end
+      end
+    end
+  end
+end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/document_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/document_transformer.rb
@@ -10,6 +10,7 @@ module Coradoc
               title_text = ToCoreModel.extract_title_text(doc.header&.title)
               attributes = ToCoreModel.extract_document_attributes(doc)
               children = ToCoreModel.transform(doc.sections || doc.contents || [])
+              children = CalloutMerger.call(children)
               children = prepend_frontmatter(children, doc.frontmatter)
 
               Coradoc::CoreModel::DocumentElement.new(
@@ -38,6 +39,7 @@ module Coradoc
               )
 
               content_children = ToCoreModel.transform(section.contents || [])
+              content_children = CalloutMerger.call(content_children)
               nested_sections = (section.sections || []).map do |child|
                 transform_section(child, parent_id: section_id)
               end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -45,7 +45,7 @@ module Coradoc
               Coradoc::AsciiDoc::Model::Document.new(
                 id: element.id,
                 header: header,
-                sections: transform(sections),
+                sections: flatten_children(sections),
                 frontmatter: frontmatter
               )
             when CoreModel::SectionElement
@@ -53,15 +53,27 @@ module Coradoc
                 id: element.id,
                 level: element.level,
                 title: create_title(element.title, element.level),
-                contents: transform(element.children)
+                contents: flatten_children(element.children)
               )
             else
               Coradoc::AsciiDoc::Model::Section.new(
                 id: element.id,
                 title: create_title(element.title, 1),
-                contents: transform(element.children)
+                contents: flatten_children(element.children)
               )
             end
+          end
+
+          # Transforms each CoreModel child and flattens one level so a
+          # transform that returns multiple siblings (e.g. a source block
+          # followed by its re-expanded callout paragraphs) stays in
+          # document order.
+          def flatten_children(children)
+            Array(children).flat_map { |child| flatten_one(transform(child)) }
+          end
+
+          def flatten_one(result)
+            result.is_a?(Array) ? result : [result]
           end
 
           def transform_block(block)
@@ -82,7 +94,13 @@ module Coradoc
             end
 
             content_text = safe_content_to_string(content)
+            result = build_verbatim_block(semantic, block, content_text)
+            return result unless verbatim_with_callouts?(semantic, block)
 
+            [result, *build_callout_paragraphs(block.callouts)]
+          end
+
+          def build_verbatim_block(semantic, block, content_text)
             case semantic
             when :source_code
               Coradoc::AsciiDoc::Model::Block::SourceCode.new(
@@ -159,6 +177,23 @@ module Coradoc
                 delimiter_char: delim_char,
                 delimiter_len: delim_len,
                 lines: content_text.split("\n")
+              )
+            end
+          end
+
+          def verbatim_with_callouts?(semantic, block)
+            return false unless %i[source_code listing].include?(semantic)
+            return false if block.callouts.nil? || block.callouts.empty?
+
+            true
+          end
+
+          # Re-expands typed Callouts back into the AsciiDoc `<N> text`
+          # paragraph form so the round-trip is faithful.
+          def build_callout_paragraphs(callouts)
+            callouts.sort_by { |c| c.index || Float::INFINITY }.map do |callout|
+              Coradoc::AsciiDoc::Model::Paragraph.new(
+                content: create_text_elements("<#{callout.index}> #{callout.content}")
               )
             end
           end

--- a/coradoc-adoc/spec/coradoc/asciidoc/callout_integration_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/callout_integration_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'AsciiDoc callout markers' do
+  def parse_to_core(adoc)
+    Coradoc.parse(adoc, format: :asciidoc)
+  end
+
+  describe 'AsciiDoc → CoreModel' do
+    it 'attaches a single callout annotation to a SourceBlock' do
+      adoc = <<~ADOC
+        [source,ruby]
+        ----
+        get '/hi' do <1>
+        ----
+        <1> Returns hello world
+      ADOC
+
+      core = parse_to_core(adoc)
+
+      expect(core.children.size).to eq(1)
+      src = core.children.first
+      expect(src).to be_a(Coradoc::CoreModel::SourceBlock)
+      expect(src.content).to eq("get '/hi' do <1>")
+      expect(src.callouts.size).to eq(1)
+      callout = src.callouts.first
+      expect(callout).to be_a(Coradoc::CoreModel::Callout)
+      expect(callout.index).to eq(1)
+      expect(callout.content).to eq('Returns hello world')
+    end
+
+    it 'attaches multiple callouts from consecutive annotation lines' do
+      adoc = <<~ADOC
+        [source,ruby]
+        ----
+        get '/hi' do <1>
+        puts "hello" <2>
+        ----
+        <1> Returns hello world
+        <2> Prints greeting
+      ADOC
+
+      core = parse_to_core(adoc)
+
+      src = core.children.first
+      expect(src.callouts.size).to eq(2)
+      expect(src.callouts.map(&:index)).to eq([1, 2])
+      expect(src.callouts.map(&:content)).to eq(['Returns hello world', 'Prints greeting'])
+    end
+
+    it 'attaches callouts separated by blank lines' do
+      adoc = <<~ADOC
+        [source,ruby]
+        ----
+        get '/hi' do <1>
+        ----
+
+        <1> First
+
+        <2> Second
+      ADOC
+
+      core = parse_to_core(adoc)
+
+      src = core.children.first
+      expect(src.callouts.map(&:index)).to eq([1, 2])
+    end
+
+    it 'leaves lone annotation paragraphs alone when no verbatim block precedes' do
+      core = parse_to_core("<1> orphan annotation\n")
+
+      expect(core.children.size).to eq(1)
+      expect(core.children.first).to be_a(Coradoc::CoreModel::ParagraphBlock)
+      expect(core.children.first.callouts).to be_empty
+    end
+
+    it 'works inside sections' do
+      adoc = <<~ADOC
+        == Section
+
+        [source,ruby]
+        ----
+        foo <1>
+        ----
+        <1> bar
+      ADOC
+
+      core = parse_to_core(adoc)
+      section = core.children.first
+      expect(section).to be_a(Coradoc::CoreModel::SectionElement)
+      src = section.children.first
+      expect(src).to be_a(Coradoc::CoreModel::SourceBlock)
+      expect(src.callouts.first.content).to eq('bar')
+    end
+
+    it 'leaves literal <N> code alone when no annotation follows' do
+      adoc = <<~ADOC
+        [source,ruby]
+        ----
+        x = 1 if y < 1
+        ----
+      ADOC
+
+      core = parse_to_core(adoc)
+      src = core.children.first
+      expect(src.callouts).to be_empty
+      expect(src.content).to include('y < 1')
+    end
+  end
+
+  describe 'CoreModel → AsciiDoc round-trip' do
+    it 'preserves callout markers in code and re-emits annotation paragraphs' do
+      adoc = <<~ADOC
+        [source,ruby]
+        ----
+        get '/hi' do <1>
+        ----
+        <1> Returns hello world
+      ADOC
+
+      core = parse_to_core(adoc)
+      out = Coradoc.serialize(core, to: :asciidoc)
+
+      expect(out).to include("get '/hi' do <1>")
+      expect(out).to include('<1> Returns hello world')
+    end
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/nested_block_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/nested_block_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'AsciiDoc nested delimited blocks' do
+  def parse_to_core(adoc)
+    Coradoc.parse(adoc, format: :asciidoc)
+  end
+
+  it 'treats shorter inner delimiters as literal text of the outer source block' do
+    adoc = <<~ADOC
+      [source,asciidoc]
+      ------
+      [yaml2text,strings.yaml,arr]
+      ----
+      {% for item in arr %}
+      === {{forloop.index0}} {{item}}
+      {% endfor %}
+      ----
+      ------
+    ADOC
+
+    core = parse_to_core(adoc)
+
+    expect(core.children.size).to eq(1)
+    src = core.children.first
+    expect(src).to be_a(Coradoc::CoreModel::SourceBlock)
+    expect(src.language).to eq('asciidoc')
+    expect(src.content).to eq(<<~TEXT.chomp)
+      [yaml2text,strings.yaml,arr]
+      ----
+      {% for item in arr %}
+      === {{forloop.index0}} {{item}}
+      {% endfor %}
+      ----
+    TEXT
+  end
+
+  it 'preserves double curly braces verbatim inside source blocks' do
+    adoc = <<~ADOC
+      [source,liquid]
+      ------
+      {% for x in arr %}
+      {{ x }}
+      {% endfor %}
+      ------
+    ADOC
+
+    core = parse_to_core(adoc)
+    src = core.children.first
+    expect(src).to be_a(Coradoc::CoreModel::SourceBlock)
+    expect(src.content).to include('{{ x }}')
+    expect(src.content).to include('{% for x in arr %}')
+  end
+
+  it 'still parses shorter outer blocks normally' do
+    adoc = <<~ADOC
+      [source,ruby]
+      ----
+      puts "hi"
+      ----
+    ADOC
+
+    core = parse_to_core(adoc)
+    expect(core.children.first.content).to eq('puts "hi"')
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/callout_merger_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/callout_merger_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Coradoc::AsciiDoc::Transform::CalloutMerger do
+  describe '.call' do
+    it 'returns an empty array for no children' do
+      expect(described_class.call([])).to eq([])
+    end
+
+    it 'passes through children when no source block is present' do
+      para = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> standalone note')
+
+      result = described_class.call([para])
+
+      expect(result.size).to eq(1)
+      expect(result.first).to eq(para)
+    end
+
+    it 'attaches a single callout paragraph to a preceding SourceBlock' do
+      src = Coradoc::CoreModel::SourceBlock.new(
+        content: "get '/hi' do <1>",
+        language: 'ruby'
+      )
+      para = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> Returns hello world')
+
+      result = described_class.call([src, para])
+
+      expect(result.size).to eq(1)
+      expect(result.first).to be_a(Coradoc::CoreModel::SourceBlock)
+      expect(result.first.callouts.size).to eq(1)
+      expect(result.first.callouts.first.index).to eq(1)
+      expect(result.first.callouts.first.content).to eq('Returns hello world')
+    end
+
+    it 'attaches a single callout paragraph to a preceding ListingBlock' do
+      src = Coradoc::CoreModel::ListingBlock.new(content: "line <1>")
+      para = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> annotation')
+
+      result = described_class.call([src, para])
+
+      expect(result.size).to eq(1)
+      expect(result.first).to be_a(Coradoc::CoreModel::ListingBlock)
+      expect(result.first.callouts.first.index).to eq(1)
+      expect(result.first.callouts.first.content).to eq('annotation')
+    end
+
+    it 'splits a multi-callout paragraph into separate Callouts' do
+      src = Coradoc::CoreModel::SourceBlock.new(content: "a <1>\nb <2>")
+      para = Coradoc::CoreModel::ParagraphBlock.new(
+        content: '<1> First <2> Second'
+      )
+
+      result = described_class.call([src, para])
+
+      callouts = result.first.callouts
+      expect(callouts.size).to eq(2)
+      expect(callouts.map(&:index)).to eq([1, 2])
+      expect(callouts.map(&:content)).to eq(%w[First Second])
+    end
+
+    it 'collects callouts across multiple consecutive paragraphs' do
+      src = Coradoc::CoreModel::SourceBlock.new(content: "code <1>")
+      first = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> First')
+      second = Coradoc::CoreModel::ParagraphBlock.new(content: '<2> Second')
+
+      result = described_class.call([src, first, second])
+
+      expect(result.size).to eq(1)
+      callouts = result.first.callouts
+      expect(callouts.map(&:index)).to eq([1, 2])
+      expect(callouts.map(&:content)).to eq(%w[First Second])
+    end
+
+    it 'stops merging when a non-callout paragraph appears' do
+      src = Coradoc::CoreModel::SourceBlock.new(content: "code <1>")
+      callout = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> note')
+      regular = Coradoc::CoreModel::ParagraphBlock.new(content: 'Just text')
+
+      result = described_class.call([src, callout, regular])
+
+      expect(result.size).to eq(2)
+      expect(result.first).to be_a(Coradoc::CoreModel::SourceBlock)
+      expect(result.first.callouts.size).to eq(1)
+      expect(result.last).to eq(regular)
+    end
+
+    it 'preserves order of unrelated children' do
+      para1 = Coradoc::CoreModel::ParagraphBlock.new(content: 'Intro')
+      src = Coradoc::CoreModel::SourceBlock.new(content: "code <1>")
+      callout = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> note')
+      para2 = Coradoc::CoreModel::ParagraphBlock.new(content: 'Outro')
+
+      result = described_class.call([para1, src, callout, para2])
+
+      expect(result.map(&:class)).to eq([
+                                          Coradoc::CoreModel::ParagraphBlock,
+                                          Coradoc::CoreModel::SourceBlock,
+                                          Coradoc::CoreModel::ParagraphBlock
+                                        ])
+    end
+
+    it 'does not attach a callout paragraph to a non-verbatim block' do
+      quote = Coradoc::CoreModel::QuoteBlock.new(content: "quoted <1>")
+      para = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> note')
+
+      result = described_class.call([quote, para])
+
+      expect(result.size).to eq(2)
+      expect(result.first.callouts).to be_empty
+    end
+  end
+end

--- a/coradoc-html/lib/coradoc/html/drop/block_drop.rb
+++ b/coradoc-html/lib/coradoc/html/drop/block_drop.rb
@@ -26,11 +26,23 @@ module Coradoc
         end
 
         def text
-          if %i[source_code literal listing].include?(resolved_semantic_type)
-            Escape.escape_html(@model.flat_text)
+          if verbatim?
+            Escape.escape_html(stripped_text)
           elsif resolved_semantic_type == :pass
             @model.flat_text.to_s
           end
+        end
+
+        def callouts
+          return [] unless verbatim?
+
+          @callouts ||= CoreModel::CalloutText.ordered(@model.callouts).map do |callout|
+            { 'index' => callout.index, 'content' => Escape.escape_html(callout.content.to_s) }
+          end
+        end
+
+        def callouts?
+          !callouts.empty?
         end
 
         def hidden?
@@ -49,6 +61,14 @@ module Coradoc
 
         def resolved_semantic_type
           @resolved_semantic_type ||= @model.resolve_semantic_type || :paragraph
+        end
+
+        def verbatim?
+          %i[source_code literal listing].include?(resolved_semantic_type)
+        end
+
+        def stripped_text
+          CoreModel::CalloutText.strip_markers(@model.flat_text.to_s, @model.callouts)
         end
       end
 

--- a/coradoc-html/lib/coradoc/html/templates/core_model/block.liquid
+++ b/coradoc-html/lib/coradoc/html/templates/core_model/block.liquid
@@ -5,10 +5,24 @@
 {{ element.text }}
 {% elsif element.semantic_type == "source_code" %}
 <pre{% if element.id %} id="{{ element.id }}"{% endif %}{% if element.title %} title="{{ element.title }}"{% endif %}><code{% if element.language %} data-lang="{{ element.language }}"{% endif %}>{{ element.text }}</code></pre>
+{% if element.callouts? %}
+<ol class="callouts">
+{% for callout in element.callouts %}
+<li value="{{ callout.index }}">{{ callout.content }}</li>
+{% endfor %}
+</ol>
+{% endif %}
 {% elsif element.semantic_type == "literal" %}
 <pre{% if element.id %} id="{{ element.id }}"{% endif %}{% if element.title %} title="{{ element.title }}"{% endif %} class="literal">{{ element.text }}</pre>
 {% elsif element.semantic_type == "listing" %}
 <pre{% if element.id %} id="{{ element.id }}"{% endif %}{% if element.title %} title="{{ element.title }}"{% endif %}>{{ element.text }}</pre>
+{% if element.callouts? %}
+<ol class="callouts">
+{% for callout in element.callouts %}
+<li value="{{ callout.index }}">{{ callout.content }}</li>
+{% endfor %}
+</ol>
+{% endif %}
 {% elsif element.semantic_type == "quote" or element.semantic_type == "verse" %}
 <blockquote{% if element.id %} id="{{ element.id }}"{% endif %}{% if element.title %} title="{{ element.title }}"{% endif %}>
 {{ element.content | render_element }}

--- a/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
@@ -56,7 +56,7 @@ module Coradoc
             when Coradoc::CoreModel::TextContent
               model.text.to_s
             when Array
-              model.map { |item| transform(item) }
+              model.flat_map { |item| flatten_result(transform(item)) }
             else
               model
             end
@@ -281,10 +281,21 @@ module Coradoc
           end
 
           def transform_code_block(block)
-            Coradoc::Markdown::CodeBlock.new(
-              code: block.content.to_s,
+            code = CoreModel::CalloutText.strip_markers(block.content.to_s, block.callouts)
+            code_block = Coradoc::Markdown::CodeBlock.new(
+              code: code,
               language: block.language
             )
+            return code_block if block.callouts.nil? || block.callouts.empty?
+
+            [code_block, transform_callout_list(block.callouts)]
+          end
+
+          def transform_callout_list(callouts)
+            items = CoreModel::CalloutText.ordered(callouts).map do |callout|
+              Coradoc::Markdown::ListItem.new(text: callout.content.to_s)
+            end
+            Coradoc::Markdown::List.new(ordered: true, items: items)
           end
 
           def transform_blockquote(block)
@@ -307,9 +318,7 @@ module Coradoc
                         else
                           Coradoc::Markdown::ListItem.new(text: item.flat_text)
                         end
-              if item.nested_list
-                md_item.sublist = transform_list(item.nested_list)
-              end
+              md_item.sublist = transform_list(item.nested_list) if item.nested_list
               md_item
             end
 

--- a/coradoc-markdown/spec/transform/from_core_model_spec.rb
+++ b/coradoc-markdown/spec/transform/from_core_model_spec.rb
@@ -75,6 +75,78 @@ RSpec.describe Coradoc::Markdown::Transform::FromCoreModel do
       end
     end
 
+    context 'with SourceBlock containing callouts' do
+      let(:core_model) do
+        Coradoc::CoreModel::SourceBlock.new(
+          content: "get '/hi' do <1>\nputs \"hello\" <2>",
+          language: 'ruby',
+          callouts: [
+            Coradoc::CoreModel::Callout.new(index: 1, content: 'Returns hello world'),
+            Coradoc::CoreModel::Callout.new(index: 2, content: 'Prints greeting')
+          ]
+        )
+      end
+
+      it 'returns [CodeBlock, List] with markers stripped from code' do
+        expect(transform).to be_an(Array)
+        expect(transform.size).to eq(2)
+
+        code_block, list = transform
+        expect(code_block).to be_a(Coradoc::Markdown::CodeBlock)
+        expect(code_block.code).to eq("get '/hi' do\nputs \"hello\"")
+        expect(code_block.language).to eq('ruby')
+
+        expect(list).to be_a(Coradoc::Markdown::List)
+        expect(list.ordered).to be(true)
+        expect(list.items.map(&:text)).to eq(['Returns hello world', 'Prints greeting'])
+      end
+    end
+
+    context 'with SourceBlock without callouts but literal <N> in code' do
+      let(:core_model) do
+        Coradoc::CoreModel::SourceBlock.new(
+          content: 'x = 1 if y < 1',
+          language: 'ruby'
+        )
+      end
+
+      it 'leaves literal <N> intact' do
+        expect(transform).to be_a(Coradoc::Markdown::CodeBlock)
+        expect(transform.code).to eq('x = 1 if y < 1')
+      end
+    end
+
+    context 'with two SourceBlocks each carrying their own callouts' do
+      let(:core_model) do
+        [
+          Coradoc::CoreModel::SourceBlock.new(
+            content: "alpha <1>\nbeta",
+            language: 'ruby',
+            callouts: [Coradoc::CoreModel::Callout.new(index: 1, content: 'first block note')]
+          ),
+          Coradoc::CoreModel::SourceBlock.new(
+            content: "gamma <1>\ndelta",
+            language: 'python',
+            callouts: [Coradoc::CoreModel::Callout.new(index: 1, content: 'second block note')]
+          )
+        ]
+      end
+
+      it 'pairs each code block with its own callout list' do
+        expect(transform).to be_an(Array)
+        expect(transform.length).to eq(4)
+
+        first_code, first_list, second_code, second_list = transform
+        expect(first_code.code).to eq("alpha\nbeta")
+        expect(first_code.language).to eq('ruby')
+        expect(first_list.items.first.text).to eq('first block note')
+
+        expect(second_code.code).to eq("gamma\ndelta")
+        expect(second_code.language).to eq('python')
+        expect(second_list.items.first.text).to eq('second block note')
+      end
+    end
+
     context 'with Block (blockquote)' do
       let(:core_model) do
         Coradoc::CoreModel::Block.new(

--- a/coradoc/lib/coradoc/core_model.rb
+++ b/coradoc/lib/coradoc/core_model.rb
@@ -12,6 +12,8 @@ module Coradoc
     # Autoload submodules lazily using relative paths
     autoload :Base, "#{__dir__}/core_model/base"
     autoload :ChildrenContent, "#{__dir__}/core_model/children_content"
+    autoload :Callout, "#{__dir__}/core_model/callout"
+    autoload :CalloutText, "#{__dir__}/core_model/callout_text"
     autoload :Block, "#{__dir__}/core_model/block"
     autoload :AnnotationBlock, "#{__dir__}/core_model/annotation_block"
     autoload :ListBlock, "#{__dir__}/core_model/list_block"

--- a/coradoc/lib/coradoc/core_model/block.rb
+++ b/coradoc/lib/coradoc/core_model/block.rb
@@ -53,10 +53,16 @@ module Coradoc
       #   @return [String, nil] language identifier for source code blocks
       attribute :language, :string
 
+      # @!attribute callouts
+      #   @return [Array<Callout>] callout annotations attached to this
+      #     block. Empty for most block types; populated by format gems
+      #     when AsciiDoc-style `<N>` annotations follow a verbatim block.
+      attribute :callouts, Callout, collection: true, default: -> { [] }
+
       private
 
       def comparable_attributes
-        super + %i[block_semantic_type content]
+        super + %i[block_semantic_type content callouts]
       end
     end
   end

--- a/coradoc/lib/coradoc/core_model/callout.rb
+++ b/coradoc/lib/coradoc/core_model/callout.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    # A single callout annotation attached to a verbatim block.
+    #
+    # Callouts are the AsciiDoc convention for annotating individual lines
+    # of a source/listing block: `<1>` markers appear inside the code and
+    # matching `<1> explanation` lines follow the block. Markdown has no
+    # native equivalent, so each format gem decides how to render them.
+    #
+    # The CoreModel stores each annotation as a typed Callout on its parent
+    # block, with the in-code marker `<index>` preserved in the block's
+    # `content` for verbatim round-trip.
+    class Callout < Base
+      # @!attribute index
+      #   @return [Integer, nil] 1-based callout number matching the
+      #     `<N>` marker embedded in the parent block's content.
+      attribute :index, :integer
+
+      # @!attribute content
+      #   @return [String, nil] human-readable annotation text.
+      attribute :content, :string
+
+      private
+
+      def comparable_attributes
+        super + %i[index content]
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/core_model/callout_text.rb
+++ b/coradoc/lib/coradoc/core_model/callout_text.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    # Shared helpers for rendering Callout-annotated verbatim blocks.
+    #
+    # Both the Markdown and HTML spokes need to (a) order callouts by their
+    # numeric index and (b) strip AsciiDoc-style `<N>` markers from the
+    # raw code so they don't leak as literal text in the output format.
+    # Centralizing these operations here keeps the behavior consistent
+    # across spokes and avoids copy-paste drift.
+    module CalloutText
+      module_function
+
+      def ordered(callouts)
+        Array(callouts).sort_by { |c| c.index || Float::INFINITY }
+      end
+
+      # Removes callout markers (`<N>`) from `code` for the indices
+      # referenced by `callouts`. Returns `code` unchanged when no
+      # callouts are provided or none carry a usable index, so literal
+      # `<N>` sequences in code without callouts are preserved.
+      def strip_markers(code, callouts)
+        list = Array(callouts)
+        return code if list.empty?
+
+        indices = list.filter_map(&:index).uniq
+        return code if indices.empty?
+
+        pattern = /<\s*(?:#{indices.join('|')})\s*>/
+        code.to_s.lines(chomp: true).map { |line| line.gsub(pattern, '').rstrip }.join("\n")
+      end
+    end
+  end
+end

--- a/coradoc/spec/coradoc/core_model/callout_spec.rb
+++ b/coradoc/spec/coradoc/core_model/callout_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Coradoc::CoreModel::Callout do
+  describe '.new' do
+    it 'sets index and content' do
+      callout = described_class.new(index: 2, content: 'Explains line two')
+
+      expect(callout.index).to eq(2)
+      expect(callout.content).to eq('Explains line two')
+    end
+
+    it 'defaults to nil for both attributes' do
+      callout = described_class.new
+
+      expect(callout.index).to be_nil
+      expect(callout.content).to be_nil
+    end
+  end
+
+  describe '#semantically_equivalent?' do
+    it 'is equivalent when index and content match' do
+      a = described_class.new(index: 1, content: 'note')
+      b = described_class.new(index: 1, content: 'note')
+
+      expect(a).to be_semantically_equivalent(b)
+    end
+
+    it 'is not equivalent when index differs' do
+      a = described_class.new(index: 1, content: 'note')
+      b = described_class.new(index: 2, content: 'note')
+
+      expect(a).not_to be_semantically_equivalent(b)
+    end
+
+    it 'is not equivalent when content differs' do
+      a = described_class.new(index: 1, content: 'one thing')
+      b = described_class.new(index: 1, content: 'another')
+
+      expect(a).not_to be_semantically_equivalent(b)
+    end
+  end
+end
+
+RSpec.describe Coradoc::CoreModel::Block do
+  describe 'callouts attribute' do
+    it 'defaults to an empty collection' do
+      block = described_class.new(content: 'code')
+
+      expect(block.callouts).to eq([])
+    end
+
+    it 'accepts typed Callout instances' do
+      callout = Coradoc::CoreModel::Callout.new(index: 1, content: 'note')
+      block = described_class.new(content: 'code', callouts: [callout])
+
+      expect(block.callouts.size).to eq(1)
+      expect(block.callouts.first).to be_a(Coradoc::CoreModel::Callout)
+      expect(block.callouts.first.index).to eq(1)
+    end
+  end
+end

--- a/coradoc/spec/coradoc/core_model/callout_text_spec.rb
+++ b/coradoc/spec/coradoc/core_model/callout_text_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Coradoc::CoreModel::CalloutText do
+  describe '.ordered' do
+    it 'sorts callouts by index ascending' do
+      c1 = Coradoc::CoreModel::Callout.new(index: 1, content: 'one')
+      c2 = Coradoc::CoreModel::Callout.new(index: 2, content: 'two')
+      c3 = Coradoc::CoreModel::Callout.new(index: 3, content: 'three')
+
+      expect(described_class.ordered([c3, c1, c2]).map(&:index)).to eq([1, 2, 3])
+    end
+
+    it 'places nil-indexed callouts at the end' do
+      with_index = Coradoc::CoreModel::Callout.new(index: 1, content: 'one')
+      without_index = Coradoc::CoreModel::Callout.new(content: 'orphan')
+
+      result = described_class.ordered([without_index, with_index])
+      expect(result.first).to be(with_index)
+      expect(result.last).to be(without_index)
+    end
+
+    it 'returns an empty array for nil input' do
+      expect(described_class.ordered(nil)).to eq([])
+    end
+  end
+
+  describe '.strip_markers' do
+    it 'removes callout markers for the given indices' do
+      callouts = [
+        Coradoc::CoreModel::Callout.new(index: 1, content: 'one'),
+        Coradoc::CoreModel::Callout.new(index: 2, content: 'two')
+      ]
+      code = "line one <1>\nline two <2>"
+
+      expect(described_class.strip_markers(code, callouts)).to eq("line one\nline two")
+    end
+
+    it 'preserves literal <N> when no callouts reference that index' do
+      callouts = [Coradoc::CoreModel::Callout.new(index: 1, content: 'one')]
+      code = 'x = 1 if y < 2'
+
+      expect(described_class.strip_markers(code, callouts)).to eq('x = 1 if y < 2')
+    end
+
+    it 'returns code unchanged for empty callouts' do
+      expect(described_class.strip_markers("a <1>\nb", [])).to eq("a <1>\nb")
+    end
+
+    it 'returns code unchanged when callouts have no usable index' do
+      callouts = [Coradoc::CoreModel::Callout.new(content: 'no index')]
+      expect(described_class.strip_markers('a <1>', callouts)).to eq('a <1>')
+    end
+
+    it 'tolerates whitespace inside the marker' do
+      callouts = [Coradoc::CoreModel::Callout.new(index: 1, content: 'one')]
+      expect(described_class.strip_markers('code < 1 >', callouts)).to eq('code')
+    end
+
+    it 'strips trailing whitespace left after marker removal' do
+      callouts = [Coradoc::CoreModel::Callout.new(index: 1, content: 'one')]
+      expect(described_class.strip_markers('code   <1>   ', callouts)).to eq('code')
+    end
+  end
+end

--- a/coradoc/spec/integration/callout_cross_format_spec.rb
+++ b/coradoc/spec/integration/callout_cross_format_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Cross-format regression for the AsciiDoc callout bug (BUG-callout-markers.md).
+# VitePress compiles Markdown into Vue SFCs; literal `<1>` in the output
+# triggers `SyntaxError: Element is missing end tag`. This spec pins the
+# end-to-end behaviour: callouts become a numbered list and `<N>` markers
+# are stripped from the code.
+RSpec.describe 'Callout markers cross-format', type: :integration do
+  let(:adoc_with_callout) do
+    <<~ADOC
+      [source,ruby]
+      ----
+      get '/hi' do <1>
+      ----
+      <1> Returns hello world
+    ADOC
+  end
+
+  let(:adoc_with_multi_callouts) do
+    <<~ADOC
+      [source,ruby]
+      ----
+      get '/hi' do <1>
+      puts "hello" <2>
+      ----
+      <1> Returns hello world
+      <2> Prints greeting
+    ADOC
+  end
+
+  describe 'AsciiDoc → Markdown (VitePress)' do
+    it 'strips <N> from code and emits a numbered list of annotations' do
+      core = Coradoc.parse(adoc_with_callout, format: :asciidoc)
+      md = Coradoc.serialize(core, to: :markdown, markdown_flavor: :vitepress)
+
+      expect(md).to eq("```ruby\nget '/hi' do\n```\n\n1. Returns hello world")
+    end
+
+    it 'emits ordered list items in callout order' do
+      core = Coradoc.parse(adoc_with_multi_callouts, format: :asciidoc)
+      md = Coradoc.serialize(core, to: :markdown, markdown_flavor: :vitepress)
+
+      expect(md).to include("```ruby\nget '/hi' do\nputs \"hello\"\n```")
+      expect(md).to include('1. Returns hello world')
+      expect(md).to include('1. Prints greeting')
+      expect(md).not_to include('<1>')
+      expect(md).not_to include('<2>')
+    end
+
+    it 'produces Vue-safe output (no stray <N> tags)' do
+      core = Coradoc.parse(adoc_with_callout, format: :asciidoc)
+      md = Coradoc.serialize(core, to: :markdown, markdown_flavor: :vitepress)
+
+      expect(md).not_to match(/<\d+>/)
+    end
+  end
+
+  describe 'AsciiDoc → HTML' do
+    it 'renders callouts as an ordered list after the code block' do
+      core = Coradoc.parse(adoc_with_callout, format: :asciidoc)
+      html = Coradoc.serialize(core, to: :html)
+
+      expect(html).to include('<pre><code data-lang="ruby">get &#39;/hi&#39; do</code></pre>')
+      expect(html).to include('<ol class="callouts">')
+      expect(html).to include('<li value="1">Returns hello world</li>')
+    end
+
+    it 'strips callout markers from rendered code' do
+      core = Coradoc.parse(adoc_with_callout, format: :asciidoc)
+      html = Coradoc.serialize(core, to: :html)
+
+      expect(html).not_to include('&lt;1&gt;')
+    end
+  end
+
+  describe 'AsciiDoc → AsciiDoc round-trip' do
+    it 'preserves the marker in code and the annotation paragraph' do
+      core = Coradoc.parse(adoc_with_callout, format: :asciidoc)
+      out = Coradoc.serialize(core, to: :asciidoc)
+
+      expect(out).to include("get '/hi' do <1>")
+      expect(out).to include('<1> Returns hello world')
+    end
+  end
+end

--- a/coradoc/spec/integration/nested_block_cross_format_spec.rb
+++ b/coradoc/spec/integration/nested_block_cross_format_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Cross-format regression for BUG-nested-code-blocks.md. Outer source
+# blocks (------) with shorter inner delimiters (----) must treat the
+# inner delimiters as literal text, preserving structure and double
+# curly braces through to Markdown/HTML output.
+RSpec.describe 'Nested delimited blocks cross-format', type: :integration do
+  let(:adoc) do
+    <<~ADOC
+      [source,asciidoc]
+      ------
+      [yaml2text,strings.yaml,arr]
+      ----
+      {% for item in arr %}
+      === {{forloop.index0}} {{item}}
+      {% endfor %}
+      ----
+      ------
+    ADOC
+  end
+
+  it 'AsciiDoc → CoreModel preserves structure as verbatim content' do
+    core = Coradoc.parse(adoc, format: :asciidoc)
+    expect(core.children.size).to eq(1)
+    src = core.children.first
+    expect(src).to be_a(Coradoc::CoreModel::SourceBlock)
+    expect(src.content).to include('[yaml2text,strings.yaml,arr]')
+    expect(src.content).to include('----')
+    expect(src.content).to include('{{item}}')
+    expect(src.content).to include('{% for item in arr %}')
+  end
+
+  it 'AsciiDoc → Markdown preserves every line and double braces' do
+    core = Coradoc.parse(adoc, format: :asciidoc)
+    md = Coradoc.serialize(core, to: :markdown, markdown_flavor: :vitepress)
+
+    expect(md).to include('```asciidoc')
+    expect(md).to include('[yaml2text,strings.yaml,arr]')
+    expect(md).to include('{% for item in arr %}')
+    expect(md).to include('=== {{forloop.index0}} {{item}}')
+    expect(md).to include('{% endfor %}')
+    expect(md).not_to include('{ {') # corrupted double brace from attribute reference
+  end
+
+  it 'AsciiDoc → HTML preserves every line and double braces' do
+    core = Coradoc.parse(adoc, format: :asciidoc)
+    html = Coradoc.serialize(core, to: :html)
+
+    expect(html).to include('[yaml2text,strings.yaml,arr]')
+    expect(html).to include('{% for item in arr %}')
+    expect(html).to include('{{item}}')
+  end
+
+  it 'AsciiDoc → AsciiDoc round-trip preserves the verbatim content' do
+    core = Coradoc.parse(adoc, format: :asciidoc)
+    out = Coradoc.serialize(core, to: :asciidoc)
+
+    expect(out).to include('[source,asciidoc]')
+    expect(out).to include('[yaml2text,strings.yaml,arr]')
+    expect(out).to include('{{item}}')
+    expect(out).to include('{% for item in arr %}')
+  end
+end


### PR DESCRIPTION
## Summary

Two related bugs in AsciiDoc verbatim block handling, both producing broken Markdown/HTML output for documentation that uses code examples.

### 1. Callout markers leak as literal `<N>` text (BUG-callout-markers)

AsciiDoc callout annotations like:

    [source,ruby]
    ----
    get '/hi' do <1>
    ----
    <1> Returns hello world

were transforming as two independent children. Downstream formats had no signal the `<1>` paragraph belonged to the code block:

- **Markdown / VitePress**: rendered `<N>` literally inside the code fence, breaking Vue SFC compilation (`SyntaxError: Element is missing end tag`).
- **HTML**: rendered `&lt;N&gt;` as visible text in the code block.
- **AsciiDoc round-trip**: worked only by accident.

**Fix:** Introduce a typed `CoreModel::Callout(index, content)` and a `callouts` collection on `CoreModel::Block`. The AsciiDoc transformer runs a `CalloutMerger` pass that folds `<N> text` paragraphs adjacent to a `SourceBlock`/`ListingBlock` into that block's `callouts`. Each spoke then renders them appropriately:

- Markdown: strips `<N>` from code, emits an ordered list of annotations.
- HTML: emits `<ol class="callouts">` after the code block.
- AsciiDoc: preserves the original `<N>` markers and re-emits the annotation paragraphs.

Marker-stripping and ordering logic is centralized in `CoreModel::CalloutText` so Markdown and HTML share a single source of truth.

### 2. Nested delimited blocks corrupted (BUG-nested-code-blocks)

A `[source]` block opened with `------` (6 dashes) was closed prematurely when its body contained a shorter delimiter like `----` (4 dashes). The parser tried to match the inner `----` as a nested block, then collapsed the surrounding structure into paragraph text. Symptoms:

- Multiple source lines collapsed onto one line.
- `{{item}}` corrupted to `{ {item}}` because the inner text was run through inline substitution, which interprets `{{...}}` as an AsciiDoc attribute reference.
- Inner delimiters and attribute lists (`[yaml2text,...]`) dropped.

**Fix:** Per the AsciiDoc spec, source and listing blocks are verbatim — no substitutions, no nested blocks. Stop attempting nested `block`/`list` matches inside verbatim blocks, and capture raw lines (any character until newline) so syntax like Liquid `{{ var }}` survives intact.

## Architecture

- `CoreModel::Callout` is a new typed model — no hashes, no serialization methods.
- `CoreModel::CalloutText` is a stateless helper module (open/closed: a new spoke can reuse it without modifying existing ones).
- `CalloutMerger` is a single-responsibility post-processing pass.
- Verbatim-mode flag was already on `block_style`; the parser change uses it to gate nested-block matching.

## Test plan

- New unit specs for `Callout`, `CalloutText`, `CalloutMerger`.
- New integration specs covering AsciiDoc → CoreModel → {Markdown, HTML, AsciiDoc} for both bugs.
- New multi-source-block coverage in the Markdown transformer spec.
- All existing specs pass: coradoc 970, coradoc-adoc 946, coradoc-markdown 616, coradoc-html 825.
- coradoc-docx has 10 pre-existing failures on `main` (missing `office_theme.xml` in the `uniword` gem install) — unrelated to this PR.

## Files

- `coradoc`: CoreModel::Callout, CoreModel::CalloutText, Block#callouts
- `coradoc-adoc`: CalloutMerger, parser fix for verbatim nested blocks, raw_verbatim_line
- `coradoc-markdown`: use CalloutText, flat_map Array results
- `coradoc-html`: BlockDrop uses CalloutText + memoizes callouts, liquid template renders callouts
- `.gitignore`: exclude BUG-*.md (personal issue-tracking notes)