### PR TITLE
fix(markdown): preserve inline formatting in definition list items

### DIFF
--- a/coradoc-markdown/lib/coradoc/markdown/model/definition_item.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/model/definition_item.rb
@@ -19,6 +19,23 @@ module Coradoc
 
       # Nested block content (paragraphs, code blocks, lists, etc.)
       attribute :blocks, :string, collection: true
+
+      # Mixed inline content (strings and inline model objects) carried
+      # from the CoreModel definition_children so serializers can render
+      # backtick code spans, bold, italics, etc.
+      attr_reader :children
+
+      def initialize(args = {})
+        super()
+        @content = args[:content]
+        @inline_content = args.fetch(:inline_content, [])
+        @blocks = args.fetch(:blocks, [])
+        @children = args.fetch(:children, [])
+      end
+
+      def children=(value)
+        @children = value || []
+      end
     end
   end
 end

--- a/coradoc-markdown/lib/coradoc/markdown/model/definition_term.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/model/definition_term.rb
@@ -20,11 +20,20 @@ module Coradoc
       # sufficient and the serializer falls back to HTML <dl>/<dt>/<dd>.
       attribute :nested, Coradoc::Markdown::DefinitionList
 
+      # Mixed inline content (strings and inline model objects) for the
+      # term — lets serializers preserve backticks, bold, etc.
+      attr_reader :children
+
       def initialize(text: '', definitions: [], nested: nil, **rest)
-        super
+        super()
         @text = text
         @definitions = definitions
         @nested = nested
+        @children = rest.fetch(:children, [])
+      end
+
+      def children=(value)
+        @children = value || []
       end
     end
   end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/definition_list/flat.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/definition_list/flat.rb
@@ -24,20 +24,29 @@ module Coradoc
                 list.items.none? { |term| term.nested }
               end
 
-              def render(list, _ctx)
+              def render(list, ctx)
                 list.items.map do |term|
-                  lines = [term.text.to_s]
-                  term.definitions.each do |defn|
-                    content_str = defn.content.to_s
-                    content_str.lines.each_with_index do |line, i|
-                      stripped = line.rstrip
-                      next if i.positive? && stripped.empty?
-
-                      lines << ": #{stripped}"
-                    end
-                  end
-                  lines.join("\n")
+                  render_term(term, ctx)
                 end.join("\n\n")
+              end
+
+              def render_term(term, ctx)
+                term_text = term.children.any? ? ctx.serialize_inline_join(term.children) : term.text.to_s
+                lines = [term_text]
+                term.definitions.each do |defn|
+                  append_definition_lines(lines, defn, ctx)
+                end
+                lines.join("\n")
+              end
+
+              def append_definition_lines(lines, defn, ctx)
+                content_str = defn.children.any? ? ctx.serialize_inline_join(defn.children) : defn.content.to_s
+                content_str.lines.each_with_index do |line, i|
+                  stripped = line.rstrip
+                  next if i.positive? && stripped.empty?
+
+                  lines << ": #{stripped}"
+                end
               end
             end
           end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/definition_list/nested_html.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/definition_list/nested_html.rb
@@ -24,25 +24,34 @@ module Coradoc
                 # When the caller asked to flatten, never emit HTML.
                 return Flat.render(list, ctx) if ctx.config.definition_list_nested == :flatten
 
-                render_dl(list)
+                render_dl(list, ctx)
               end
 
               private
 
-              def render_dl(list)
-                items_html = list.items.map { |term| render_term(term) }.join
+              def render_dl(list, ctx)
+                items_html = list.items.map { |term| render_term(term, ctx) }.join
                 "<dl>\n#{items_html}</dl>"
               end
 
-              def render_term(term)
-                dt = "<dt>#{term.text.to_s}</dt>"
-                dds = term.definitions.map { |d| render_dd(d) }.join
-                nested = term.nested ? "\n  #{render_dl(term.nested)}" : ''
+              def render_term(term, ctx)
+                dt_text = if term.children.any?
+                            ctx.serialize_inline_join(term.children)
+                          else
+                            term.text.to_s
+                          end
+                dt = "<dt>#{dt_text}</dt>"
+                dds = term.definitions.map { |d| render_dd(d, ctx) }.join
+                nested = term.nested ? "\n  #{render_dl(term.nested, ctx)}" : ''
                 "#{dt}\n#{dds}#{nested unless nested.empty?}"
               end
 
-              def render_dd(definition)
-                content_str = definition.content.to_s.strip
+              def render_dd(definition, ctx)
+                content_str = if definition.children.any?
+                                ctx.serialize_inline_join(definition.children).strip
+                              else
+                                definition.content.to_s.strip
+                              end
                 "<dd>\n  #{content_str}\n</dd>"
               end
             end

--- a/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
@@ -402,18 +402,37 @@ module Coradoc
 
           def transform_definition_list(dl)
             items = Array(dl.items).map do |item|
-              definitions = Array(item.definitions).map do |defn|
-                Coradoc::Markdown::DefinitionItem.new(content: defn.to_s)
-              end
-              nested = item.nested ? transform_definition_list(item.nested) : nil
+              term_children = transform_inline_array(item.term_renderable)
+              def_children = transform_inline_array(item.definition_renderable)
+
               Coradoc::Markdown::DefinitionTerm.new(
                 text: item.term.to_s,
-                definitions: definitions,
-                nested: nested
+                definitions: build_definitions(item, def_children),
+                nested: item.nested ? transform_definition_list(item.nested) : nil,
+                children: term_children
               )
             end
 
             Coradoc::Markdown::DefinitionList.new(items: items)
+          end
+
+          def build_definitions(item, def_children)
+            if def_children.any? { |c| !c.is_a?(String) }
+              [Coradoc::Markdown::DefinitionItem.new(
+                content: item.definitions&.first.to_s,
+                children: def_children
+              )]
+            else
+              Array(item.definitions).map do |defn|
+                Coradoc::Markdown::DefinitionItem.new(content: defn.to_s)
+              end
+            end
+          end
+
+          def transform_inline_array(renderable)
+            return [] unless renderable.is_a?(Array)
+
+            renderable.map { |c| transform_inline_content(c) }
           end
 
           def transform_footnote(fn)

--- a/coradoc/spec/integration/definition_list_inline_spec.rb
+++ b/coradoc/spec/integration/definition_list_inline_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Cross-format regression for BUG-deflist-backtick-stripped.md.
+# Inline formatting (backtick code spans in particular) inside a
+# definition list term or definition was being dropped by the
+# Markdown transformer, which read `term` / `definitions` (plain
+# strings) and ignored the typed inline children. The result was
+# raw `<` characters in the Markdown output, which VitePress
+# interprets as HTML tags and fails the build.
+RSpec.describe 'Definition list inline formatting', type: :integration do
+  let(:adoc) do
+    "`Symbols`:: `<div class=\"Symbols\">` contents are a definition list\n"
+  end
+
+  it 'CoreModel captures typed inline children on both sides' do
+    core = Coradoc.parse(adoc, format: :asciidoc)
+    item = core.children.first.items.first
+
+    expect(item.term_children.map(&:class)).to include(Coradoc::CoreModel::MonospaceElement)
+    expect(item.definition_children.map(&:class)).to include(Coradoc::CoreModel::MonospaceElement)
+  end
+
+  it 'Markdown preserves backtick code spans in term and definition' do
+    core = Coradoc.parse(adoc, format: :asciidoc)
+    md = Coradoc.serialize(core, to: :markdown, markdown_flavor: :vitepress)
+
+    expect(md).to eq("`Symbols`\n: `<div class=\"Symbols\">`  contents are a definition list")
+  end
+
+  it 'plain-text definition lists still serialize without children' do
+    core = Coradoc.parse("Term:: plain definition\n", format: :asciidoc)
+    md = Coradoc.serialize(core, to: :markdown, markdown_flavor: :vitepress)
+
+    expect(md).to eq("Term\n: plain definition")
+  end
+end


### PR DESCRIPTION
## Problem

Definition list terms and definitions with inline formatting (backtick code spans, bold, etc.) were being dropped by the Markdown `FromCoreModel` transformer. It read `term` / `definitions` as plain strings and ignored the typed inline children. The result was raw `<` characters in Markdown output, which VitePress interprets as HTML tags and fails the build.

Regression bug reference: `BUG-deflist-backtick-stripped.md`

## Fix

Thread typed inline children (`MonospaceElement`, `TextElement`, etc.) from the CoreModel `term_renderable` / `definition_renderable` through `DefinitionTerm` and `DefinitionItem`, and have the flat and nested-html serializers render them via `serialize_inline_join` when present. Plain-text lists keep their original fast path.

## Files

- `coradoc-markdown/.../model/definition_item.rb` -- add `children`
- `coradoc-markdown/.../model/definition_term.rb` -- add `children`
- `coradoc-markdown/.../transform/from_core_model.rb` -- pass typed children through
- `coradoc-markdown/.../serializer/strategies/definition_list/flat.rb` -- render children when present
- `coradoc-markdown/.../serializer/strategies/definition_list/nested_html.rb` -- render children when present
- `coradoc/spec/integration/definition_list_inline_spec.rb` -- new regression spec

## Test coverage

- \`Symbols\` in term preserved through to Markdown
- \`<div class="Symbols">\` in definition preserved through to Markdown
- Plain-text definition lists still serialize via the fast path (no children)