### PR TITLE
fix: stop Inline model inspect leaking into admonition and bibliography

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/model/admonition.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/admonition.rb
@@ -28,7 +28,13 @@ module Coradoc
       #   admonition.content = "Be careful!"
       #
       class Admonition < Attached
-        attribute :content, :string
+        attribute :content,
+                  Lutaml::Model::Serializable,
+                  collection: true,
+                  polymorphic: [
+                    Lutaml::Model::Type::String,
+                    Coradoc::AsciiDoc::Model::TextElement
+                  ]
         attribute :type, :string
         attribute :line_break, :string, default: -> { '' }
       end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/bibliography_entry.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/bibliography_entry.rb
@@ -36,9 +36,12 @@ module Coradoc
         # Coerce a raw parser AST value into the canonical ref_text string.
         # Accepts the shapes produced by Parser::Bibliography for `:ref_text`:
         # nil, Parslet::Slice, plain String, single Model::Base, or an Array
-        # of any of these. Keeping this coercion on the model that owns
-        # ref_text (rather than in a transformer rule) keeps the transformer
-        # declarative and lets callers build entries from any source shape.
+        # of any of these. Model objects (TextElement, Inline::Italic, etc.)
+        # are flattened via TextExtractVisitor so their text content is
+        # preserved instead of leaking `#<Class:0x...>` inspect strings.
+        # Keeping this coercion on the model that owns ref_text (rather than
+        # in a transformer rule) keeps the transformer declarative and lets
+        # callers build entries from any source shape.
         # @param raw [Object, nil]
         # @return [String]
         def self.coerce_ref_text(raw)
@@ -47,6 +50,8 @@ module Coradoc
           case raw
           when Array then raw.map { |e| coerce_ref_text(e) }.join
           when String then raw
+          when Coradoc::AsciiDoc::Model::Base
+            Coradoc::AsciiDoc::Transform::TextExtractVisitor.new.extract(raw).to_s
           else raw.to_s
           end
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/admonition.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/admonition.rb
@@ -15,7 +15,7 @@ module Coradoc
 
         def admonition_line
           admonition_type.as(:admonition_type) >> str(': ') >>
-            (text.as(:text) >>
+            (text_any.as(:text) >>
             line_ending.as(:line_break)
             ).repeat(1)
             .as(:content)

--- a/coradoc-markdown/lib/coradoc/markdown/model/admonition.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/model/admonition.rb
@@ -24,11 +24,17 @@ module Coradoc
       attribute :content, :string
       attribute :title, :string
 
-      def initialize(admonition_type:, content:, title: nil, **rest)
+      # Mixed inline content (strings and inline model objects) carried
+      # from the CoreModel children so serializers can preserve cross
+      # references, code spans, etc. When empty, fall back to `content`.
+      attr_reader :children
+
+      def initialize(admonition_type:, content:, title: nil, children: [], **rest)
         super
         @admonition_type = admonition_type.to_s.downcase
         @content = content
         @title = title
+        @children = Array(children)
       end
     end
   end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/base.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/base.rb
@@ -21,6 +21,17 @@ module Coradoc
               def mode_name
                 name.split('::').last.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase.to_sym
               end
+
+              # Render the admonition body, preferring typed children
+              # (so cross-refs, code spans, etc. survive) and falling
+              # back to the plain-text content attribute when there are
+              # no children or the ctx can't serialize them.
+              def render_body(admonition, ctx)
+                children = admonition.children
+                return admonition.content.to_s if children.nil? || children.empty?
+
+                ctx.serialize_inline_join(children)
+              end
             end
           end
         end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/container.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/container.rb
@@ -20,10 +20,10 @@ module Coradoc
           #   :::
           class Container < Base
             class << self
-              def render(admonition, _ctx)
+              def render(admonition, ctx)
                 type = admonition.admonition_type.to_s
                 title_suffix = admonition.title ? "[#{admonition.title}]" : ''
-                ":::#{type}#{title_suffix}\n#{admonition.content.to_s}\n:::"
+                ":::#{type}#{title_suffix}\n#{render_body(admonition, ctx)}\n:::"
               end
             end
           end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/gfm_alert.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/gfm_alert.rb
@@ -12,9 +12,9 @@ module Coradoc
           # Source: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
           class GfmAlert < Base
             class << self
-              def render(admonition, _ctx)
+              def render(admonition, ctx)
                 type = admonition.admonition_type.to_s.capitalize
-                body = admonition.content.to_s
+                body = render_body(admonition, ctx)
                 body = body.lines.map { |line| "> #{line}".rstrip }.join("\n")
                 title_suffix = admonition.title ? " \"#{admonition.title}\"" : ''
                 "> [!#{type}]#{title_suffix}\n#{body}"

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/github.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/github.rb
@@ -12,9 +12,9 @@ module Coradoc
           # recognize the bold-prefix pattern.
           class Github < Base
             class << self
-              def render(admonition, _ctx)
+              def render(admonition, ctx)
                 type = admonition.admonition_type.to_s.upcase
-                body = admonition.content.to_s
+                body = render_body(admonition, ctx)
                 if admonition.title
                   body = "**#{admonition.title}**\n\n#{body}" unless admonition.title.to_s.strip.empty?
                 end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/github.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/github.rb
@@ -15,9 +15,7 @@ module Coradoc
               def render(admonition, ctx)
                 type = admonition.admonition_type.to_s.upcase
                 body = render_body(admonition, ctx)
-                if admonition.title
-                  body = "**#{admonition.title}**\n\n#{body}" unless admonition.title.to_s.strip.empty?
-                end
+                body = "**#{admonition.title}**\n\n#{body}" if admonition.title && !admonition.title.to_s.strip.empty?
                 "> **#{type}:** #{body}"
               end
             end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/html.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/admonition/html.rb
@@ -11,10 +11,10 @@ module Coradoc
           # `<div class="title">` for the title.
           class Html < Base
             class << self
-              def render(admonition, _ctx)
+              def render(admonition, ctx)
                 type = admonition.admonition_type.to_s
                 title_html = admonition.title ? %(<div class="title">#{admonition.title}</div>\n) : ''
-                %(<div class="#{type}">\n#{title_html}#{admonition.content.to_s}\n</div>)
+                %(<div class="#{type}">\n#{title_html}#{render_body(admonition, ctx)}\n</div>)
               end
             end
           end

--- a/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
@@ -165,6 +165,12 @@ module Coradoc
             end
           end
 
+          def transform_inline_array(renderable)
+            return [] unless renderable.is_a?(Array)
+
+            renderable.map { |c| transform_inline_content(c) }
+          end
+
           def transform_delimited_block(block)
             semantic = resolve_markdown_semantic(block)
 

--- a/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
@@ -255,10 +255,12 @@ module Coradoc
           end
 
           def transform_admonition_block(block, default_type: 'note')
+            children = transform_inline_array(block.renderable_content)
             Coradoc::Markdown::Admonition.new(
               admonition_type: block.respond_to?(:annotation_type) ? (block.annotation_type || default_type) : default_type,
               content: block.flat_text,
-              title: block.respond_to?(:annotation_label) ? block.annotation_label : nil
+              title: block.respond_to?(:annotation_label) ? block.annotation_label : nil,
+              children: children
             )
           end
 

--- a/coradoc/spec/integration/admonition_xref_and_bibliography_italic_spec.rb
+++ b/coradoc/spec/integration/admonition_xref_and_bibliography_italic_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Cross-format regression for BUG-italic-inspect-and-xref-in-admonition.md.
+# Two distinct bugs shared one root cause: AsciiDoc Inline model objects
+# (Italic, CrossReference) were being stringified via Object#to_s, which
+# leaks the Ruby `#<Class:0x...>` inspect string into the output.
+#
+# Bug 1: Bibliography entries containing _italic_ text produced
+#   `#<Coradoc::AsciiDoc::Model::Inline::Italic:0x...>` instead of the
+#   actual title text.
+#
+# Bug 2: `<<anchor>>` cross-references inside `NOTE:` admonitions stayed
+#   literal in Markdown output (or produced inspect strings) instead of
+#   becoming `[anchor](#anchor)` links, breaking VitePress builds.
+RSpec.describe 'Admonition xref and bibliography italic', type: :integration do
+  describe 'cross-reference inside admonition' do
+    let(:adoc) { "NOTE: See <<figureC-1>> for details.\n" }
+
+    it 'CoreModel captures a CrossReferenceElement inside the AnnotationBlock' do
+      core = Coradoc.parse(adoc, format: :asciidoc)
+      block = core.children.first
+
+      expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+      expect(block.children.map(&:class)).to include(Coradoc::CoreModel::CrossReferenceElement)
+    end
+
+    it 'VitePress renders the xref as a Markdown link inside :::note' do
+      core = Coradoc.parse(adoc, format: :asciidoc)
+      md = Coradoc.serialize(core, to: :markdown, markdown_flavor: :vitepress)
+
+      expect(md).to include(':::note')
+      expect(md).to include('[figureC-1](#figureC-1)')
+      expect(md).not_to include('<<figureC-1>>')
+      expect(md).not_to include('#<Coradoc')
+    end
+
+    it 'GitHub-flavor admonition also preserves the xref' do
+      core = Coradoc.parse(adoc, format: :asciidoc)
+      md = Coradoc.serialize(core, to: :markdown, markdown_flavor: :gfm)
+
+      expect(md).to include('> **NOTE:**')
+      expect(md).to include('[figureC-1](#figureC-1)')
+      expect(md).not_to include('#<Coradoc')
+    end
+  end
+
+  describe 'italic text inside bibliography entry' do
+    let(:adoc) do
+      "[bibliography]\n== References\n* [[[iso6322]]] _ISO 6322-1_: Cereals and pulses.\n"
+    end
+
+    it 'does not leak Inline::Italic inspect into Markdown output' do
+      core = Coradoc.parse(adoc, format: :asciidoc)
+      md = Coradoc.serialize(core, to: :markdown, markdown_flavor: :vitepress)
+
+      expect(md).to include('ISO 6322-1')
+      expect(md).not_to include('#<Coradoc')
+      expect(md).not_to include('Inline::Italic')
+    end
+  end
+
+  describe 'plain-text admonition (no inline formatting)' do
+    it 'still serializes via the plain-content fast path' do
+      core = Coradoc.parse("NOTE: Plain text only.\n", format: :asciidoc)
+      md = Coradoc.serialize(core, to: :markdown, markdown_flavor: :vitepress)
+
+      expect(md).to eq(":::note\nPlain text only.\n:::")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Two bugs shared one root cause (BUG-italic-inspect-and-xref-in-admonition.md): AsciiDoc Inline model objects (`Inline::Italic`, `Inline::CrossReference`, etc.) don't define `to_s`, so they were stringified via `Object#to_s` and produced `#<Coradoc::AsciiDoc::Model::Inline::Italic:0x...>` in the output.

**Bug 1 (bibliography italic):** Bibliography entries with `_italic_` text emitted `ISO 6322-1: , #<Coradoc::AsciiDoc::Model::Inline::Italic:0x...>` instead of the actual title.

**Bug 2 (admonition xref):** `<<anchor>>` cross-references inside `NOTE:` admonitions stayed literal in Markdown output (`<<figureC-1>>`), breaking VitePress builds (Vue treats literal `<<` as malformed HTML).

## Fix

### Bug 1 -- bibliography italic
`BibliographyEntry.coerce_ref_text` fell through to `raw.to_s` for non-String/non-Array values, calling `TextElement#to_s` which in turn called `.map(&:to_s).join` on its inline children -- producing the Italic inspect string in `ref_text`. Now `Model::Base` inputs go through `TextExtractVisitor` which knows how to flatten every Inline variant.

### Bug 2 -- admonition xref
Three layers needed fixing:

1. **Parser:** `Parser::Admonition#admonition_line` used the raw `text` rule (no inline parsing). Switched to `text_any` so `<<xref>>` and other inline elements are parsed.
2. **AsciiDoc model:** `Model::Admonition.content` was `:string`. lutaml-model cast the rich `[TextElement]` array on assignment via `.to_s`, losing the inline children. Changed to a polymorphic collection (matching `Model::Paragraph`).
3. **Markdown model + strategies:** `Markdown::Admonition` only had `content` (plain text). Added a `children` attribute and a shared `render_body` helper on the strategy base. All four strategies (container, github, gfm_alert, html) now render children via `ctx.serialize_inline_join` when present, falling back to plain content otherwise.

## Files

**coradoc-adoc**
- `parser/admonition.rb` -- `text` -> `text_any`
- `model/admonition.rb` -- polymorphic content collection
- `model/bibliography_entry.rb` -- `coerce_ref_text` uses TextExtractVisitor for Model::Base

**coradoc-markdown**
- `model/admonition.rb` -- add `children`
- `transform/from_core_model.rb` -- pass children
- `serializer/strategies/admonition/base.rb` -- `render_body` helper
- `serializer/strategies/admonition/{container,github,gfm_alert,html}.rb` -- use `render_body`

**coradoc**
- `spec/integration/admonition_xref_and_bibliography_italic_spec.rb` -- 5 regression tests

## Test coverage

- CoreModel captures CrossReferenceElement inside AnnotationBlock
- VitePress (:::note) renders xref as `[figureC-1](#figureC-1)`
- GitHub flavor (> **NOTE:**) preserves the xref
- Bibliography entry with _italic_ doesn't leak `#<Inline::Italic:...>`
- Plain-text admonition still serializes via the fast path

## Test results

- coradoc: 978 examples, 0 failures (5 new)
- coradoc-adoc: 946 examples, 0 failures
- coradoc-markdown: 616 examples, 0 failures
- coradoc-docx: 10 pre-existing failures (missing \`uniword\` data file, unrelated)
- Rubocop: net reduction of 2 offenses on changed files