### PR TITLE
fix(perf): support Array input in PerformanceRegression.print_results

### DIFF
--- a/coradoc/lib/coradoc/performance_regression.rb
+++ b/coradoc/lib/coradoc/performance_regression.rb
@@ -23,6 +23,11 @@ module Coradoc
       def passed?
         duration < threshold
       end
+
+      def format_line
+        status = passed? ? 'PASS' : 'FAIL'
+        "  #{status} #{name}: #{duration.round(4)}s (threshold: #{threshold}s)"
+      end
     end
 
     ComparisonResult = Struct.new(:name, :duration, :baseline, keyword_init: true) do
@@ -30,6 +35,12 @@ module Coradoc
         return false if baseline.nil? || baseline.zero?
 
         (duration - baseline).abs / baseline > pct
+      end
+
+      def format_line
+        status = regressed? ? 'WARN' : 'OK'
+        baseline_str = baseline ? "(baseline: #{baseline.round(4)}s)" : '(no baseline)'
+        "  #{status} #{name}: #{duration.round(4)}s #{baseline_str}"
       end
     end
 
@@ -50,14 +61,15 @@ module Coradoc
         { results:, failed_count: failed, total: results.size }
       end
 
-      def print_results(summary)
-        results = summary[:results]
-        results.each do |r|
-          status = r.passed? ? 'PASS' : 'FAIL'
-          puts "  #{status} #{r.name}: #{r.duration.round(4)}s (threshold: #{r.threshold}s)"
+      def print_results(summary_or_results)
+        if summary_or_results.is_a?(Hash)
+          summary = summary_or_results
+          summary[:results].each { |r| puts r.format_line }
+          puts
+          puts "#{summary[:total] - summary[:failed_count]}/#{summary[:total]} passed"
+        else
+          Array(summary_or_results).each { |r| puts r.format_line }
         end
-        puts
-        puts "#{summary[:total] - summary[:failed_count]}/#{summary[:total]} passed"
       end
 
       def compare_with_baseline(baseline_path, iterations: 3)

--- a/coradoc/spec/coradoc/performance_regression_spec.rb
+++ b/coradoc/spec/coradoc/performance_regression_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/performance_regression'
+
+RSpec.describe Coradoc::PerformanceRegression do
+  describe 'BenchmarkResult' do
+    it 'formats a passing result line' do
+      r = described_class::BenchmarkResult.new(name: 'x', duration: 0.1, iterations: 3, threshold: 2.0)
+      expect(r.format_line).to eq('  PASS x: 0.1s (threshold: 2.0s)')
+    end
+
+    it 'formats a failing result line' do
+      r = described_class::BenchmarkResult.new(name: 'x', duration: 5.0, iterations: 3, threshold: 2.0)
+      expect(r.format_line).to eq('  FAIL x: 5.0s (threshold: 2.0s)')
+    end
+  end
+
+  describe 'ComparisonResult' do
+    it 'formats an OK line when within baseline' do
+      r = described_class::ComparisonResult.new(name: 'x', duration: 0.12, baseline: 0.1)
+      expect(r.format_line).to eq('  OK x: 0.12s (baseline: 0.1s)')
+    end
+
+    it 'formats a WARN line when regressed beyond 20%' do
+      r = described_class::ComparisonResult.new(name: 'x', duration: 0.5, baseline: 0.1)
+      expect(r.format_line).to eq('  WARN x: 0.5s (baseline: 0.1s)')
+    end
+
+    it 'reports no baseline when baseline is nil' do
+      r = described_class::ComparisonResult.new(name: 'x', duration: 0.1, baseline: nil)
+      expect(r.format_line).to eq('  OK x: 0.1s (no baseline)')
+    end
+  end
+
+  describe '.print_results' do
+    it 'accepts a summary Hash from run_all_with_summary' do
+      result = described_class::BenchmarkResult.new(name: 'x', duration: 0.1, iterations: 3, threshold: 2.0)
+      summary = { results: [result], failed_count: 0, total: 1 }
+      expect { described_class.print_results(summary) }.to output(
+        "  PASS x: 0.1s (threshold: 2.0s)\n\n1/1 passed\n"
+      ).to_stdout
+    end
+
+    it 'accepts an Array of ComparisonResult from compare_with_baseline' do
+      result = described_class::ComparisonResult.new(name: 'x', duration: 0.12, baseline: 0.1)
+      expect { described_class.print_results([result]) }.to output(
+        "  OK x: 0.12s (baseline: 0.1s)\n"
+      ).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The `compare-baseline` CI job (in `.github/workflows/performance.yml`) crashes with:

```
no implicit conversion of Symbol into Integer (TypeError)
        results = summary[:results]
                          ^^^^^^^^
```

The job passes the return value of `compare_with_baseline` (an Array of `ComparisonResult`) to `print_results`, but `print_results` assumed a Hash shape from `run_all_with_summary`.

## Fix

- Move line formatting into `BenchmarkResult#format_line` and `ComparisonResult#format_line` (OCP).
- `print_results` now accepts either a Hash (summary) or an Array (comparison results) and delegates formatting to each result object.

## Testing

- New spec: `coradoc/spec/coradoc/performance_regression_spec.rb` (7 examples, all pass).
- Full coradoc suite: 977 examples, 0 failures.