### PR TITLE
fix(markdown): preserve nested code blocks inside example blocks

### DIFF
--- a/coradoc-markdown/lib/coradoc/markdown/model/example_block.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/model/example_block.rb
@@ -15,11 +15,13 @@ module Coradoc
     class ExampleBlock < Base
       attribute :content, :string
       attribute :caption, :string
+      attribute :children, Coradoc::Markdown::Base, collection: true, default: []
 
-      def initialize(content:, caption: nil, **rest)
+      def initialize(content:, caption: nil, children: [], **rest)
         super
         @content = content
         @caption = caption
+        @children = Array(children)
       end
     end
   end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/serializers/example_block.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/serializers/example_block.rb
@@ -15,23 +15,31 @@ module Coradoc
           handles_type ::Coradoc::Markdown::ExampleBlock
 
           def call(element, ctx)
+            body = render_body(element, ctx)
             if ctx.config.admonition_style == :container
-              render_container(element)
+              render_container(element, body)
             else
-              render_html(element)
+              render_html(element, body)
             end
           end
 
           private
 
-          def render_html(element)
-            caption_html = element.caption ? %(<h4>Example: #{element.caption}</h4>\n) : ''
-            %(<div class="example">\n#{caption_html}<p>#{element.content.to_s}</p>\n</div>)
+          def render_body(element, ctx)
+            return element.content.to_s if element.children.nil? || element.children.empty?
+
+            element.children.map { |c| ctx.serialize(c) }.join("\n\n")
           end
 
-          def render_container(element)
+          def render_html(element, body)
+            caption_html = element.caption ? %(<h4>Example: #{element.caption}</h4>\n) : ''
+            inner = element.children&.any? ? body : "<p>#{body}</p>"
+            %(<div class="example">\n#{caption_html}#{inner}\n</div>)
+          end
+
+          def render_container(element, body)
             title = element.caption ? " Example: #{element.caption}" : ''
-            ":::details#{title}\n#{element.content.to_s}\n:::"
+            ":::details#{title}\n#{body}\n:::"
           end
         end
       end

--- a/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
@@ -232,9 +232,11 @@ module Coradoc
           end
 
           def transform_example_block(block)
+            children = Array(block.children).map { |c| transform(c) }.flat_map { |c| flatten_result(c) }
             Coradoc::Markdown::ExampleBlock.new(
               content: block.flat_text,
-              caption: block.title.to_s
+              caption: block.title.to_s,
+              children: children
             )
           end
 

--- a/coradoc/spec/integration/example_block_nested_code_spec.rb
+++ b/coradoc/spec/integration/example_block_nested_code_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Regression for BUG-codeblock-in-example-block.md.
+#
+# AsciiDoc example blocks (`====`) can contain other delimited blocks
+# such as source blocks (`----`). The CoreModel parser correctly
+# produces a nested ExampleBlock -> SourceBlock tree, but the Markdown
+# transformer was flattening it via `flat_text`, which collapses
+# everything to a single string and drops the code fence entirely.
+#
+# This spec exercises the round trip through CoreModel and asserts the
+# nested code block is preserved with its fence, language, and content.
+RSpec.describe 'Code block nested inside example block', type: :integration do
+  let(:source) do
+    <<~ADOC
+      .Hint
+      [%collapsible]
+      ====
+      Text before code.
+
+      [source,asciidoc]
+      ----
+      <<anchor>>
+      ----
+
+      Text after code.
+      ====
+    ADOC
+  end
+
+  it 'CoreModel captures a SourceBlock inside the ExampleBlock' do
+    core = Coradoc.parse(source, format: :asciidoc)
+    example = core.children.first
+    expect(example).to be_a(Coradoc::CoreModel::ExampleBlock)
+    source_blocks = example.children.select { |c| c.is_a?(Coradoc::CoreModel::SourceBlock) }
+    expect(source_blocks.length).to eq(1)
+    expect(source_blocks.first.language).to eq('asciidoc')
+    expect(source_blocks.first.content).to eq('<<anchor>>')
+  end
+
+  it 'VitePress output preserves the code block with fence and content' do
+    md = Coradoc.serialize(
+      Coradoc.parse(source, format: :asciidoc),
+      to: :markdown, markdown_flavor: :vitepress
+    )
+    expect(md).to include(':::details Example: Hint')
+    expect(md).to include('Text before code.')
+    expect(md).to include('Text after code.')
+    expect(md).to include("```asciidoc\n<<anchor>>\n```")
+  end
+
+  it 'default Markdown output also preserves the nested code block' do
+    md = Coradoc.serialize(
+      Coradoc.parse(source, format: :asciidoc),
+      to: :markdown
+    )
+    expect(md).to include('<div class="example">')
+    expect(md).to include('Text before code.')
+    expect(md).to include('Text after code.')
+    expect(md).to include("```asciidoc\n<<anchor>>\n```")
+  end
+
+  it 'does not collapse text and code onto a single line' do
+    md = Coradoc.serialize(
+      Coradoc.parse(source, format: :asciidoc),
+      to: :markdown, markdown_flavor: :vitepress
+    )
+    expect(md).not_to match(/Text before code\.<<anchor>>/)
+    expect(md).not_to match(/<<anchor>>Text after code\./)
+  end
+end


### PR DESCRIPTION
## Problem

Reported in `BUG-codeblock-in-example-block.md`. When an AsciiDoc `====` example block (e.g. `[%collapsible]` Hint) contains a `[source]\n----` code block, the code fence and structure were lost on the way to Markdown:

```markdown
:::details Example: Hint
Text before code.<<anchor>>Text after code.
:::
```

The code fence disappeared, the code body leaked into surrounding paragraphs, and the `<<anchor>>` xref sat as raw text in the wrong place. Every Hint section with embedded code examples was broken, and the leaked `<<` also broke the VitePress build.

## Root cause

The CoreModel parser actually captured the nested `ExampleBlock -> SourceBlock` tree correctly. The bug was on the Markdown side: `FromCoreModel#transform_example_block` called `block.flat_text`, which recursively flattens every descendant to a single concatenated string. The fence, language tag, and line structure were destroyed before the serializer ever ran.

## Fix

- `Markdown::ExampleBlock`: add a typed `children` collection (mirrors `OpenBlock`).
- `FromCoreModel#transform_example_block`: populate `children` from `block.children`, falling back to the existing `content` fast path when there are none.
- `Serializer::Serializers::ExampleBlock`: when children are present, render each via `ctx.serialize` and join with a blank line. The plain-text path is unchanged.

## Verification

```
:::details Example: Hint
Text before code.

```asciidoc
<<anchor>>
```

Text after code.
:::
```

Matches the expected output in the bug report exactly.

- New spec: `coradoc/spec/integration/example_block_nested_code_spec.rb` (4 examples).
- `bundle exec rake spec` in coradoc / coradoc-adoc / coradoc-markdown: all green (982 / 946 / 616).