### PR TITLE
fix(adoc): cast open blocks via positional attributes

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
@@ -35,6 +35,75 @@ module Coradoc
               )
             end
 
+            # Open blocks (`--`) are generic containers. AsciiDoc allows
+            # casting them to a different block type via positional
+            # attributes: verbatim types (`[source]`, `[listing]`,
+            # `[literal]`) and admonition labels (`[NOTE]`, `[TIP]`,
+            # `[WARNING]`, `[CAUTION]`, `[IMPORTANT]`). When such a cast
+            # is present, the block behaves like the corresponding
+            # delimited block. Anything else stays an OpenBlock.
+            def transform_open_block(block)
+              semantic = open_block_semantic(block)
+              case semantic
+              when :source_code
+                transform_source_block(block)
+              when :listing
+                transform_listing_from_open(block)
+              when :literal
+                transform_literal_from_open(block)
+              when :admonition
+                transform_admonition_from_open(block)
+              else
+                transform_typed_block(block, Coradoc::CoreModel::OpenBlock)
+              end
+            end
+
+            ADMONITION_TYPES = %w[note tip warning caution important].freeze
+
+            def open_block_semantic(block)
+              attrs = block.attributes
+              return nil unless attrs.is_a?(Coradoc::AsciiDoc::Model::AttributeList)
+
+              first = attrs.positional&.first
+              return nil unless first.is_a?(Coradoc::AsciiDoc::Model::AttributeListAttribute)
+
+              case first.value.to_s.downcase
+              when 'source' then :source_code
+              when 'listing' then :listing
+              when 'literal' then :literal
+              when *ADMONITION_TYPES then :admonition
+              end
+            end
+
+            def transform_admonition_from_open(block)
+              type = block.attributes.positional.first.value.to_s.downcase
+              content_lines = Array(block.lines).map { |line| ToCoreModel.extract_text_content(line) }.join("\n")
+              Coradoc::CoreModel::AnnotationBlock.new(
+                annotation_type: type,
+                content: content_lines,
+                title: ToCoreModel.extract_title_text(block.title)
+              )
+            end
+
+            def transform_listing_from_open(block)
+              content_lines = Array(block.lines).map { |line| ToCoreModel.extract_text_content(line) }.join("\n")
+              Coradoc::CoreModel::ListingBlock.new(
+                id: block.id,
+                title: ToCoreModel.extract_title_text(block.title),
+                content: content_lines,
+                language: ToCoreModel.extract_block_language(block)
+              )
+            end
+
+            def transform_literal_from_open(block)
+              content_lines = Array(block.lines).map { |line| ToCoreModel.extract_text_content(line) }.join("\n")
+              Coradoc::CoreModel::LiteralBlock.new(
+                id: block.id,
+                title: ToCoreModel.extract_title_text(block.title),
+                content: content_lines
+              )
+            end
+
             def transform_block(block, semantic_type_or_delimiter)
               content_lines = ToCoreModel.extract_block_lines(block)
               semantic_type = if semantic_type_or_delimiter.is_a?(Symbol)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
@@ -52,7 +52,6 @@ module Coradoc
               Coradoc::AsciiDoc::Model::Block::Example => Coradoc::CoreModel::ExampleBlock,
               Coradoc::AsciiDoc::Model::Block::Side => Coradoc::CoreModel::SidebarBlock,
               Coradoc::AsciiDoc::Model::Block::Literal => Coradoc::CoreModel::LiteralBlock,
-              Coradoc::AsciiDoc::Model::Block::Open => Coradoc::CoreModel::OpenBlock,
               Coradoc::AsciiDoc::Model::Block::Pass => Coradoc::CoreModel::PassBlock
             }.each do |block_class, core_model_class|
               Registry.register_with_priority(
@@ -61,6 +60,12 @@ module Coradoc
                 priority: 10
               )
             end
+
+            Registry.register_with_priority(
+              Coradoc::AsciiDoc::Model::Block::Open,
+              ->(model) { Blk.transform_open_block(model) },
+              priority: 10
+            )
 
             Registry.register(
               Coradoc::AsciiDoc::Model::Block::Core,

--- a/coradoc/spec/integration/open_block_source_cast_spec.rb
+++ b/coradoc/spec/integration/open_block_source_cast_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Regression for BUG-open-block-delimiter.md.
+#
+# AsciiDoc allows casting an open block (`--`) to a verbatim block
+# via positional attributes: `[source]`, `[listing]`, `[literal]`.
+# The CoreModel transformer was previously always producing an
+# OpenBlock, dropping the code fence entirely.
+#
+# This spec exercises the round trip through CoreModel and asserts
+# the cast dispatches to the correct typed block. Plain open blocks
+# (no cast attribute) continue to produce an OpenBlock.
+RSpec.describe 'Open block cast to verbatim block', type: :integration do
+  let(:source) do
+    <<~ADOC
+      [source,asciidoc]
+      --
+      [bibliography]
+      == References
+
+      * [[[ref1,1]]] <1> text <2>
+      --
+    ADOC
+  end
+
+  it 'CoreModel casts to a SourceBlock with language preserved' do
+    core = Coradoc.parse(source, format: :asciidoc)
+    block = core.children.first
+    expect(block).to be_a(Coradoc::CoreModel::SourceBlock)
+    expect(block.language).to eq('asciidoc')
+  end
+
+  it 'preserves content including callout markers as text' do
+    core = Coradoc.parse(source, format: :asciidoc)
+    block = core.children.first
+    expect(block.content).to include('[[[ref1,1]]]')
+    expect(block.content).to include('<1>')
+    expect(block.content).to include('<2>')
+  end
+
+  it 'VitePress output emits a fenced code block' do
+    md = Coradoc.serialize(
+      Coradoc.parse(source, format: :asciidoc),
+      to: :markdown, markdown_flavor: :vitepress
+    )
+    expect(md).to include("```asciidoc\n")
+    expect(md).to include('[bibliography]')
+    expect(md).to include('== References')
+  end
+
+  context 'with [listing] cast' do
+    let(:source) do
+      <<~ADOC
+        [listing]
+        --
+        preformatted text
+        --
+      ADOC
+    end
+
+    it 'CoreModel casts to a ListingBlock' do
+      core = Coradoc.parse(source, format: :asciidoc)
+      block = core.children.first
+      expect(block).to be_a(Coradoc::CoreModel::ListingBlock)
+    end
+  end
+
+  context 'with [literal] cast' do
+    let(:source) do
+      <<~ADOC
+        [literal]
+        --
+        literal content
+        --
+      ADOC
+    end
+
+    it 'CoreModel casts to a LiteralBlock' do
+      core = Coradoc.parse(source, format: :asciidoc)
+      block = core.children.first
+      expect(block).to be_a(Coradoc::CoreModel::LiteralBlock)
+    end
+  end
+
+  context 'without any cast attribute' do
+    let(:source) do
+      <<~ADOC
+        --
+        Plain open block content.
+        --
+      ADOC
+    end
+
+    it 'stays an OpenBlock' do
+      core = Coradoc.parse(source, format: :asciidoc)
+      block = core.children.first
+      expect(block).to be_a(Coradoc::CoreModel::OpenBlock)
+    end
+
+    it 'renders content as plain text' do
+      md = Coradoc.serialize(
+        Coradoc.parse(source, format: :asciidoc),
+        to: :markdown, markdown_flavor: :vitepress
+      )
+      expect(md).to include('Plain open block content.')
+    end
+  end
+
+  context 'with non-verbatim cast attribute (e.g. [note])' do
+    let(:source) do
+      <<~ADOC
+        [NOTE]
+        --
+        This is a note.
+        --
+      ADOC
+    end
+
+    it 'casts to an AnnotationBlock' do
+      core = Coradoc.parse(source, format: :asciidoc)
+      block = core.children.first
+      expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+      expect(block.annotation_type).to eq('note')
+    end
+
+    it 'VitePress renders as a container admonition' do
+      md = Coradoc.serialize(
+        Coradoc.parse(source, format: :asciidoc),
+        to: :markdown, markdown_flavor: :vitepress
+      )
+      expect(md).to include(':::note')
+      expect(md).to include('This is a note.')
+      expect(md).to include(':::')
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Regression for `BUG-open-block-delimiter.md`.

When `[source,lang]` (or `[listing]`, `[literal]`, `[NOTE]`, etc.) precedes a `--` (2-dash) open block delimiter, coradoc was always producing an `OpenBlock` regardless of attributes. The code fence was dropped entirely and the content leaked into regular paragraph text.

## Root cause

The ToCoreModel registration for `Model::Block::Open` always dispatched to `transform_typed_block` → `CoreModel::OpenBlock`, ignoring any cast attribute on the block.

AsciiDoc allows casting an open block via positional attributes (`[source]`, `[listing]`, `[literal]`, `[NOTE]`, `[TIP]`, `[WARNING]`, `[CAUTION]`, `[IMPORTANT]`). The transformer did not honor this cast.

## Fix

Add `transform_open_block(block)` to `BlockTransformer` that inspects the first positional attribute and dispatches:

- `[source]` → `SourceBlock` (via existing `transform_source_block`)
- `[listing]` → `ListingBlock`
- `[literal]` → `LiteralBlock`
- `[NOTE]` / `[TIP]` / `[WARNING]` / `[CAUTION]` / `[IMPORTANT]` → `AnnotationBlock`
- anything else → `OpenBlock` (unchanged behavior)

The `Model::Block::Open` registration in `to_core_model_registrations.rb` now uses this dispatcher instead of the generic typed-block path.

## Verification

```ruby
source = "[source,asciidoc]\n--\n[bibliography]\n== References\n\n* [[[ref1,1]]] <1> text <2>\n--\n"
Coradoc.serialize(Coradoc.parse(source, format: :asciidoc), to: :markdown, markdown_flavor: :vitepress)
# => ```asciidoc
#    [bibliography]
#    == References
#    * [[[ref1,1]]] <1> text <2>
#    ```
```

Code fence applied with language preserved. Callout markers (`<1>`, `<2>`) preserved as text — this matches the existing `----` source block behavior. (Stripping orphan callout markers would lose user content and is inconsistent with how `----` blocks already work.)

## Scope decision

The original bug suggested stripping orphan `<N>` callouts. I rejected that approach during review because it would silently lose user content. The `----` block already preserves `<N>` as text (the bug author noted this is "a separate concern"), so the consistent behavior is to also preserve them in `--` source blocks.

## Test coverage

New integration spec `coradoc/spec/integration/open_block_source_cast_spec.rb` (9 examples) covers:
- `[source]` cast → `SourceBlock` with language
- `[listing]` cast → `ListingBlock`
- `[literal]` cast → `LiteralBlock`
- `[NOTE]` cast → `AnnotationBlock`
- No cast attribute → stays `OpenBlock`
- VitePress rendering for both source and admonition casts

All 2,557 specs pass (995 coradoc + 946 coradoc-adoc + 616 coradoc-markdown).
