### PR TITLE
fix(markdown): preserve inline formatting in definition list items

### DIFF
--- a/coradoc-markdown/lib/coradoc/markdown/model/definition_item.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/model/definition_item.rb
@@ -14,8 +14,10 @@ module Coradoc
       # The definition content (text or nested blocks)
       attribute :content, :string
 
-      # Inline content can be an array of text/inline elements
-      attribute :inline_content, :string, collection: true
+      # Inline content as typed Markdown elements (Code, Strong, Text, etc.).
+      # When present, the Flat serializer renders these via
+      # `ctx.serialize_inline_join` so inline formatting is preserved.
+      attribute :inline_content, Coradoc::Markdown::Base, collection: true, default: []
 
       # Nested block content (paragraphs, code blocks, lists, etc.)
       attribute :blocks, :string, collection: true

--- a/coradoc-markdown/lib/coradoc/markdown/model/definition_term.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/model/definition_term.rb
@@ -15,16 +15,22 @@ module Coradoc
       attribute :text, :string
       attribute :definitions, Coradoc::Markdown::DefinitionItem, collection: true, default: []
 
+      # Typed inline children for the term (Code, Strong, Text, etc.).
+      # When present, the Flat serializer renders these via
+      # `ctx.serialize_inline_join` so inline formatting is preserved.
+      attribute :text_children, Coradoc::Markdown::Base, collection: true, default: []
+
       # Optional nested definition list under this term.
       # When present, the flat-PHP-Markdown-Extra syntax is no longer
       # sufficient and the serializer falls back to HTML <dl>/<dt>/<dd>.
       attribute :nested, Coradoc::Markdown::DefinitionList
 
-      def initialize(text: '', definitions: [], nested: nil, **rest)
+      def initialize(text: '', definitions: [], nested: nil, text_children: [], **rest)
         super
         @text = text
         @definitions = definitions
         @nested = nested
+        @text_children = Array(text_children)
       end
     end
   end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/definition_list/flat.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/strategies/definition_list/flat.rb
@@ -24,11 +24,11 @@ module Coradoc
                 list.items.none? { |term| term.nested }
               end
 
-              def render(list, _ctx)
+              def render(list, ctx)
                 list.items.map do |term|
-                  lines = [term.text.to_s]
+                  lines = [render_term(term, ctx)]
                   term.definitions.each do |defn|
-                    content_str = defn.content.to_s
+                    content_str = render_definition(defn, ctx)
                     content_str.lines.each_with_index do |line, i|
                       stripped = line.rstrip
                       next if i.positive? && stripped.empty?
@@ -38,6 +38,22 @@ module Coradoc
                   end
                   lines.join("\n")
                 end.join("\n\n")
+              end
+
+              private
+
+              def render_term(term, ctx)
+                children = term.text_children
+                return term.text.to_s if children.nil? || children.empty?
+
+                ctx.serialize_inline_join(children)
+              end
+
+              def render_definition(defn, ctx)
+                children = defn.inline_content
+                return defn.content.to_s if children.nil? || children.empty?
+
+                ctx.serialize_inline_join(children)
               end
             end
           end

--- a/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
@@ -412,18 +412,32 @@ module Coradoc
 
           def transform_definition_list(dl)
             items = Array(dl.items).map do |item|
-              definitions = Array(item.definitions).map do |defn|
-                Coradoc::Markdown::DefinitionItem.new(content: defn.to_s)
-              end
+              definition = build_definition_item(item)
               nested = item.nested ? transform_definition_list(item.nested) : nil
+              term_children = Array(item.term_children).map { |c| transform_inline_content(c) }
               Coradoc::Markdown::DefinitionTerm.new(
                 text: item.term.to_s,
-                definitions: definitions,
+                text_children: term_children,
+                definitions: [definition],
                 nested: nested
               )
             end
 
             Coradoc::Markdown::DefinitionList.new(items: items)
+          end
+
+          def build_definition_item(item)
+            children = Array(item.definition_children)
+            if children.empty?
+              content = item.definitions&.first&.to_s
+              return Coradoc::Markdown::DefinitionItem.new(content: content)
+            end
+
+            inline = children.map { |c| transform_inline_content(c) }
+            Coradoc::Markdown::DefinitionItem.new(
+              content: item.definitions&.first&.to_s,
+              inline_content: inline
+            )
           end
 
           def transform_footnote(fn)

--- a/coradoc/spec/integration/deflist_inline_formatting_spec.rb
+++ b/coradoc/spec/integration/deflist_inline_formatting_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Regression for BUG-deflist-backtick-still-stripped.md.
+#
+# Commit 9e77ff7 partially fixed backtick preservation in definition
+# list items, but only when the TERM had backtick formatting. When
+# the term was plain text (especially with spaces), inline formatting
+# in the definition was still being stripped.
+#
+# Root cause: the Markdown transformer used the flattened `item.definitions`
+# string array, losing typed inline elements (MonospaceElement, etc.).
+# Fix: thread `term_children` and `definition_children` through the
+# Markdown DefinitionItem/DefinitionTerm models and render them via
+# `ctx.serialize_inline_join`.
+RSpec.describe 'Definition list inline formatting', type: :integration do
+  let(:source) do
+    <<~ADOC
+      Symbols and abbreviated terms:: `<div class="Symbols">` contents
+    ADOC
+  end
+
+  it 'preserves backticks in definition when term has no formatting' do
+    md = Coradoc.serialize(
+      Coradoc.parse(source, format: :asciidoc),
+      to: :markdown, markdown_flavor: :vitepress
+    )
+    expect(md).to include('`<div class="Symbols">`')
+    expect(md).to include('Symbols and abbreviated terms')
+  end
+
+  it 'preserves backticks in both term and definition' do
+    source = "`Symbols`:: `<div class=\"Symbols\">` contents\n"
+    md = Coradoc.serialize(
+      Coradoc.parse(source, format: :asciidoc),
+      to: :markdown, markdown_flavor: :vitepress
+    )
+    expect(md).to include('`Symbols`')
+    expect(md).to include('`<div class="Symbols">`')
+  end
+
+  it 'preserves bold term and italic definition' do
+    source = "*Bold Term*:: _italic definition_\n"
+    md = Coradoc.serialize(
+      Coradoc.parse(source, format: :asciidoc),
+      to: :markdown, markdown_flavor: :vitepress
+    )
+    expect(md).to include('**Bold Term**')
+    expect(md).to include('*italic definition*')
+  end
+
+  it 'renders plain text definitions unchanged' do
+    source = "Term:: plain text definition\n"
+    md = Coradoc.serialize(
+      Coradoc.parse(source, format: :asciidoc),
+      to: :markdown, markdown_flavor: :vitepress
+    )
+    expect(md).to include('Term')
+    expect(md).to include(': plain text definition')
+  end
+
+  it 'CoreModel preserves typed definition_children' do
+    core = Coradoc.parse(source, format: :asciidoc)
+    item = core.children.first.items.first
+    expect(item.definition_children).not_to be_empty
+    expect(item.definition_children.first).to be_a(Coradoc::CoreModel::MonospaceElement)
+  end
+end


### PR DESCRIPTION
## Problem

Regression for `BUG-deflist-backtick-still-stripped.md`.

Commit `9e77ff7` ("fix(markdown): preserve inline formatting in definition list items") partially fixed backtick preservation, but only worked when the TERM itself had backtick formatting. When the term was plain text (especially with spaces), backticks in the definition were still stripped:

```
Input:  Symbols and abbreviated terms:: `<div class="Symbols">` contents
Output: Symbols and abbreviated terms
        : <div class="Symbols">  contents   ← backticks stripped
```

This breaks VitePress builds for documents that reference CSS class names. The `develop/ref/html.adoc` page has 40+ such items.

## Root cause

`transform_definition_list` in `coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb` used the flattened `item.definitions` string array (which is pre-rendered plain text from `extract_text_content`). The typed inline children (`MonospaceElement`, `BoldElement`, etc.) on `DefinitionItem.definition_children` were never threaded through to the Markdown model layer.

The previous fix (`9e77ff7`) only appeared to work for terms-with-backticks because of incidental flattening behavior in `extract_text_content` — when the term had its own backticks, those got preserved by a different code path.

## Fix

Thread typed inline children through the Markdown model layer and render them in the Flat strategy:

- `DefinitionItem` model: changed `inline_content` from `:string` collection to `Coradoc::Markdown::Base` collection (typed inline elements)
- `DefinitionTerm` model: added `text_children` (typed inline elements)
- `transform_definition_list`: now uses `item.term_children` and `item.definition_children`, converting each to Markdown inline elements via `transform_inline_content`
- `Flat` strategy: renders via `ctx.serialize_inline_join(children)`, so backticks/bold/italic/etc. survive the round trip

## Verification

```ruby
source = "Symbols and abbreviated terms:: `<div class=\"Symbols\">` contents\n"
Coradoc.serialize(Coradoc.parse(source, format: :asciidoc), to: :markdown, markdown_flavor: :vitepress)
# Symbols and abbreviated terms
# : `<div class="Symbols">`  contents       ← backticks now preserved
```

All cases work:
- Plain term + backtick definition → preserved
- Backtick term + backtick definition → preserved
- Bold term + italic definition → preserved
- Plain term + plain definition → unchanged

## Test coverage

New integration spec `coradoc/spec/integration/deflist_inline_formatting_spec.rb` (5 examples). All 3,382 specs pass (995 coradoc + 946 coradoc-adoc + 616 coradoc-markdown + 825 coradoc-html).
