### PR TITLE
fix(adoc): parse cross-reference text containing commas/quotes

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/citation.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/citation.rb
@@ -4,25 +4,13 @@ module Coradoc
   module AsciiDoc
     module Parser
       module Citation
-        def xref_anchor
-          match('[^,>]').repeat(1).as(:href_arg).repeat(1, 1)
-        end
-
-        def xref_str
-          match('[^,>]').repeat(1).as(:text)
-        end
-
-        def xref_arg
-          (str('section') | str('paragraph') | str('clause') | str('annex') | str('table')).as(:key) >>
-            match('[ =]').as(:delimiter) >>
-            match('[^,>=]').repeat(1).as(:value)
-        end
-
+        # In `<<target,text>>`, the target is everything up to the first comma
+        # or closing `>`. The text is everything else up to `>` — it can
+        # contain commas, quotes, and any other punctuation.
         def cross_reference
-          (str('<<') >> xref_anchor >>
-          ((str(',') >> xref_arg).repeat(1) |
-            (str(',') >> xref_str).repeat(1)
-          ).maybe >>
+          (str('<<') >>
+            match('[^,>]').repeat(1).as(:href) >>
+            (str(',') >> match('[^>]').repeat(0).as(:text)).maybe >>
             str('>>')
           ).as(:cross_reference)
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
@@ -27,20 +27,11 @@ module Coradoc
             end
 
             # Cross reference
-            rule(href: simple(:href)) do
-              Model::Inline::CrossReference.new(href: href.to_s)
-            end
-
-            rule(
-              href: simple(:href),
-              name: simple(:name)
-            ) do
-              Model::Inline::CrossReference.new(href: href.to_s, args: [name.to_s])
-            end
-
-            rule(cross_reference: sequence(:xref)) do
-              args = xref.size > 1 ? xref[1..] : []
-              Model::Inline::CrossReference.new(href: xref[0], args:)
+            rule(cross_reference: subtree(:xref)) do
+              href = xref[:href].to_s
+              text = xref[:text]
+              args = text ? [text.to_s] : []
+              Model::Inline::CrossReference.new(href:, args:)
             end
 
             # Inline image
@@ -86,11 +77,6 @@ module Coradoc
             rule(footnote: sequence(:footnote)) do
               text_str = footnote.map(&:to_s).join
               Coradoc::AsciiDoc::Model::Inline::Footnote.new(text: text_str)
-            end
-
-            # Href arg
-            rule(href_arg: simple(:href_arg)) do
-              href_arg.to_s
             end
 
             # Inline formatting rules generated from a single registry.

--- a/coradoc/spec/integration/xref_with_punctuation_spec.rb
+++ b/coradoc/spec/integration/xref_with_punctuation_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Regression for BUG-xref-with-commas-quotes.md.
+#
+# AsciiDoc cross-references like `<<target,text>>` must convert to
+# Markdown `[text](#target)`. When the text portion contains commas,
+# quotes, or "clause/section" keywords, the parser was over-engineering
+# it into a structured `key/delimiter/value` subtree that no transformer
+# rule consumed, producing empty Markdown output.
+#
+# Root cause: the cross_reference parser rule split the text after the
+# first comma into a structured `xref_arg` (for keywords like "clause N")
+# or a generic `xref_str`, then wrapped both in `.repeat(1)`. The
+# resulting array-of-hashes could not match `sequence(:xref)` in the
+# transformer (Parslet's SequenceBind rejects arrays containing hashes).
+#
+# Fix: simplify the parser to capture everything after the first comma as
+# a single `:text` string. Anything up to `>` is allowed — including
+# commas, quotes, and keyword prefixes.
+RSpec.describe 'Cross-reference text with commas/quotes', type: :integration do
+  def to_markdown(src)
+    Coradoc.serialize(
+      Coradoc.parse(src + "\n", format: :asciidoc),
+      to: :markdown, markdown_flavor: :vitepress
+    ).strip
+  end
+
+  it 'converts a bare target xref' do
+    expect(to_markdown('<<figureC-1>>')).to eq('[figureC-1](#figureC-1)')
+  end
+
+  it 'converts a simple text label' do
+    expect(to_markdown('<<figureC-1,Figure 1>>')).to eq('[Figure 1](#figureC-1)')
+  end
+
+  it 'converts a clause-style label with digits' do
+    expect(to_markdown('<<ISO2382,clause 2121372>>')).to eq('[clause 2121372](#ISO2382)')
+  end
+
+  it 'converts a label containing double quotes' do
+    expect(to_markdown('<<ievtermbank,clause "113-01-08">>'))
+      .to eq('[clause "113-01-08"](#ievtermbank)')
+  end
+
+  it 'preserves additional commas in the label' do
+    expect(to_markdown('<<ISO2382,clause,section 4>>'))
+      .to eq('[clause,section 4](#ISO2382)')
+  end
+
+  it 'threads the label text into CoreModel content' do
+    core = Coradoc.parse("<<ISO2382,clause 2121372>>\n", format: :asciidoc)
+    xref = core.children.first.children.first
+    expect(xref).to be_a(Coradoc::CoreModel::CrossReferenceElement)
+    expect(xref.target).to eq('ISO2382')
+    expect(xref.content).to eq('clause 2121372')
+  end
+end


### PR DESCRIPTION
## Problem

Cross-references where the text portion contained commas or quotes (e.g. `<<ISO2382,clause 2121372>>`, `<<ievtermbank,clause "113-01-08">>`) produced empty Markdown output. See `BUG-xref-with-commas-quotes.md`.

## Root Cause

The parser split the text after the first comma into a structured `xref_arg` subtree (`{key:, delimiter:, value:}`) for keywords like `clause`/`section`, or `xref_str` otherwise. This produced an array of hashes under the `cross_reference:` key.

Parslet's `SequenceBind#can_bind?` rejects arrays containing hashes, so the transformer rule `cross_reference: sequence(:xref)` never fired. Parslet then descended into the array — the `href_arg:` and `text:` rules handled the simple-text case, but the `{key/delimiter/value}` hash had no matching rule and was silently dropped.

## Fix

- **`coradoc-adoc/lib/coradoc/asciidoc/parser/citation.rb`**: Capture everything after the first comma as a single `text` string. Anything up to `>` is allowed — commas, quotes, keyword prefixes all become plain display text, matching AsciiDoc semantics.
- **`coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb`**: Replace `cross_reference: sequence(:xref)` with `cross_reference: subtree(:xref)` so the inner `{href, text}` hash survives parslet's recursive descent and reaches the rule. Remove the obsolete `href:`, `href/name`, and `href_arg:` rules — no parser produced those shapes anymore.

## Verification

```
simple ref:      [figureC-1](#figureC-1)
ref with text:   [Figure 1](#figureC-1)
ref with clause: [clause 2121372](#ISO2382)
ref with quotes: [clause "113-01-08"](#ievtermbank)
```

New spec: `coradoc/spec/integration/xref_with_punctuation_spec.rb` (6 examples, all pass). Full `coradoc` (1006 examples) and `coradoc-adoc` (946 examples) suites pass with no regressions.

Patch release target: `coradoc-adoc`.