### PR TITLE
fix(adoc,markdown): close remaining AsciiDoc → Markdown conversion gaps

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/model/inline.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/inline.rb
@@ -25,6 +25,7 @@ module Coradoc
         autoload :Small, 'coradoc/asciidoc/model/inline/small'
         autoload :Strikethrough, 'coradoc/asciidoc/model/inline/strikethrough'
         autoload :Stem, 'coradoc/asciidoc/model/inline/stem'
+        autoload :Passthrough, 'coradoc/asciidoc/model/inline/passthrough'
       end
     end
   end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/inline/passthrough.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/inline/passthrough.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module AsciiDoc
+    module Model
+      module Inline
+        class Passthrough < Base
+          attribute :content, :string
+          attribute :form, :string, default: -> { 'triple' }
+        end
+      end
+    end
+  end
+end

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/block.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/block.rb
@@ -27,6 +27,7 @@ module Coradoc
           source_block(n_deep) |
           quote_block(n_deep) |
           pass_block(n_deep) |
+          literal_block(n_deep) |
           open_block(n_deep)).as(:block)
         end
 
@@ -35,7 +36,7 @@ module Coradoc
         end
 
         def pass_block(n_deep)
-          block_style(n_deep, '+', 4, :pass)
+          block_style(n_deep, '+', 4, verbatim: true)
         end
 
         def quote_block(n_deep)
@@ -50,13 +51,18 @@ module Coradoc
           block_style(n_deep, '-', 4, verbatim: true)
         end
 
+        def literal_block(n_deep)
+          block_style(n_deep, '.', 4, verbatim: true)
+        end
+
         # Open block: exactly 2 dashes (cannot nest within itself)
         def open_block(n_deep)
           block_style_exact(n_deep, '-', 2)
         end
 
         def block_title
-          str('.') >> space.absent? >> text.as(:title) >> newline
+          (line_start? >> block_delimiter.absent?) >>
+            str('.') >> space.absent? >> text.as(:title) >> newline
         end
 
         def block_type(type)
@@ -83,6 +89,7 @@ module Coradoc
               str('=') |
               str('_') |
               str('+') |
+              str('.') |
               str('-')).repeat(4) | # 4+ characters for most blocks
               str('-').repeat(2, 2)) >> # Exactly 2 for open block
             newline
@@ -90,10 +97,10 @@ module Coradoc
 
         # Block style parser with variable delimiter length
         # @param n_deep [Integer] Nesting depth for nested blocks
-        # @param delimiter [String] The delimiter character ("=", "-", "_", "*", "+")
+        # @param delimiter [String] The delimiter character ("=", "-", "_", "*", "+", ".")
         # @param repeater [Integer] Minimum number of delimiter characters (default: 4)
-        # @param type [Symbol] Block type for special handling (e.g., :pass)
-        def block_style(n_deep = 3, delimiter = '*', repeater = 4, type = nil, verbatim: false)
+        # @param verbatim [Boolean] Treat body as raw text (no substitutions, no nested blocks)
+        def block_style(n_deep = 3, delimiter = '*', repeater = 4, verbatim: false)
           capture_key = :"delimit_#{delimiter}_#{n_deep}"
           current_delimiter = str(delimiter).repeat(repeater).capture(capture_key)
           closing_delimiter = dynamic do |_s, c|
@@ -104,9 +111,9 @@ module Coradoc
             delim_str = c.captures[capture_key].to_s.strip
             closing_pattern = str(delim_str) >> newline
 
-            # Verbatim blocks (source/listing) treat their body as literal
-            # text per the AsciiDoc spec — no substitutions, no nested
-            # blocks. Allowing nested block parsing here would consume
+            # Verbatim blocks (source/listing/literal/pass) treat their body
+            # as literal text per the AsciiDoc spec — no substitutions, no
+            # nested blocks. Allowing nested block parsing here would consume
             # shorter inner delimiters (e.g. `----` inside `------`) and
             # strip the original structure when serializing back.
             content = if verbatim
@@ -127,18 +134,14 @@ module Coradoc
           block_header >>
             line_start? >>
             current_delimiter.as(:delimiter) >> newline >>
-            if type == :pass
-              (text_line(false, unguarded: true, verbatim: verbatim) | empty_line.as(:line_break)).repeat(1).as(:lines)
-            else
-              block_content_with_closing.as(:lines)
-            end >>
+            block_content_with_closing.as(:lines) >>
             line_start? >>
             closing_delimiter >> newline
         end
 
         # Block style parser with EXACT delimiter length (for open blocks)
         # Open blocks use exactly 2 dashes and cannot nest within themselves
-        def block_style_exact(n_deep = 3, delimiter = '-', exact_chars = 2, type = nil)
+        def block_style_exact(n_deep = 3, delimiter = '-', exact_chars = 2)
           capture_key = :"delimit_#{delimiter}_exact_#{exact_chars}_#{n_deep}"
           current_delimiter = str(delimiter).repeat(exact_chars, exact_chars).capture(capture_key)
           closing_delimiter = dynamic do |_s, c|
@@ -161,11 +164,7 @@ module Coradoc
           block_header >>
             line_start? >>
             current_delimiter.as(:delimiter) >> newline >>
-            if type == :pass
-              (text_line(false, unguarded: true) | empty_line.as(:line_break)).repeat(1).as(:lines)
-            else
-              block_content_with_closing.as(:lines)
-            end >>
+            block_content_with_closing.as(:lines) >>
             line_start? >>
             closing_delimiter >> newline
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
@@ -123,6 +123,16 @@ module Coradoc
           ).as(:inline_image)
         end
 
+        # Triple-plus inline passthrough: `+++raw content+++`. The content
+        # passes through all substitutions verbatim. Common use is to embed
+        # raw HTML in AsciiDoc documents.
+        def inline_passthrough
+          (str('+++') >>
+            (str('+++').absent? >> match('[^\n]')).repeat(1).as(:raw) >>
+            str('+++')
+          ).as(:inline_passthrough)
+        end
+
         def underline
           (attribute_list >> match('\\[.underline\\]').as(:role) >>
             str('#') >>
@@ -145,6 +155,7 @@ module Coradoc
             str('https').present? |
             str('link:').present? |
             str('image:').present? |
+            str('+++').present? |
             term_type.present? |
             str('footnote').present? |
             stem_type.present?
@@ -171,6 +182,7 @@ module Coradoc
             stem |
             link |
             inline_image |
+            inline_passthrough |
             underline |
             small
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/callout_merger.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/callout_merger.rb
@@ -84,7 +84,8 @@ module Coradoc
         def preceding_verbatim_block(result)
           last = result.last
           return nil unless last.is_a?(Coradoc::CoreModel::SourceBlock) ||
-                            last.is_a?(Coradoc::CoreModel::ListingBlock)
+                            last.is_a?(Coradoc::CoreModel::ListingBlock) ||
+                            last.is_a?(Coradoc::CoreModel::LiteralBlock)
 
           last
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
@@ -158,6 +158,15 @@ module Coradoc
                 )
               }
             )
+
+            Registry.register(
+              Coradoc::AsciiDoc::Model::Inline::Passthrough,
+              lambda { |model|
+                Coradoc::CoreModel::RawInlineElement.new(
+                  content: model.content.to_s
+                )
+              }
+            )
           end
 
           def register_table_transformers!

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_type_classifier.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_type_classifier.rb
@@ -25,6 +25,7 @@ module Coradoc
           }],
           ['=', 4, nil, ->(opts, attrs) { Model::Block::Example.new(**opts.merge(attributes: attrs)) }],
           ['+', 4, nil, ->(opts, attrs) { Model::Block::Pass.new(**opts.merge(attributes: attrs)) }],
+          ['.', 4, nil, ->(opts, attrs) { Model::Block::Literal.new(**opts.merge(attributes: attrs)) }],
           ['_', 4, nil, ->(opts, attrs) { Model::Block::Quote.new(**opts.merge(attributes: attrs)) }],
           ['-', 4, nil, ->(opts, attrs) { Model::Block::SourceCode.new(**opts.merge(attributes: attrs)) }],
           ['-', 2, 2,  ->(opts, attrs) { Model::Block::Open.new(**opts.merge(attributes: attrs)) }]

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
@@ -43,6 +43,14 @@ module Coradoc
               )
             end
 
+            # Inline passthrough (`+++raw content+++`)
+            rule(inline_passthrough: subtree(:passthrough)) do
+              Model::Inline::Passthrough.new(
+                content: passthrough[:raw].to_s,
+                form: 'triple'
+              )
+            end
+
             # Attribute reference
             rule(attribute_reference: simple(:name)) do
               Model::Inline::AttributeReference.new(name:)

--- a/coradoc-markdown/lib/coradoc/markdown/model/sidebar.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/model/sidebar.rb
@@ -6,16 +6,19 @@ module Coradoc
   module Markdown
     # Sidebar block — a tangential aside, visually distinct from main flow.
     #
-    # Markdown has no native sidebar. Serialized as an HTML fallback:
-    #   <div class="sidebar">...</div>
+    # Markdown has no native sidebar. Serialized as a VitePress `:::info`
+    # custom container. When the sidebar contains structured children
+    # (code blocks, lists, etc.), they are rendered into the container.
     class Sidebar < Base
       attribute :content, :string
       attribute :title, :string
+      attribute :children, Coradoc::Markdown::Base, collection: true, default: []
 
-      def initialize(content:, title: nil, **rest)
+      def initialize(content:, title: nil, children: [], **rest)
         super
         @content = content
         @title = title
+        @children = Array(children)
       end
     end
   end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/serializers/literal.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/serializers/literal.rb
@@ -6,13 +6,18 @@ module Coradoc
   module Markdown
     class Serializer
       module Serializers
-        # Literal block: indented code block (4 leading spaces per line).
-        # Distinct from a code block (which carries a language hint).
+        # Literal block: preformatted text with no language hint. Uses an
+        # unlabeled fenced code block so the content survives VitePress's
+        # Vue template parser (4-space indented code blocks only work in
+        # specific contexts and leak `<` characters when not separated by
+        # blank lines).
         class Literal < ElementSerializer
           handles_type ::Coradoc::Markdown::Literal
 
           def call(element, _ctx)
-            element.content.to_s.lines.map { |line| "    #{line}" }.join
+            body = element.content.to_s
+            body = body.chomp + "\n" unless body.end_with?("\n")
+            "```\n#{body}```\n"
           end
         end
       end

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/serializers/sidebar.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/serializers/sidebar.rb
@@ -6,12 +6,25 @@ module Coradoc
   module Markdown
     class Serializer
       module Serializers
+        # Sidebar block — a callout box. VitePress maps the `:::info`
+        # custom container to a styled callout, which matches AsciiDoc's
+        # sidebar semantics without leaking raw HTML into the Markdown.
         class Sidebar < ElementSerializer
           handles_type ::Coradoc::Markdown::Sidebar
 
-          def call(element, _ctx)
-            title_html = element.title ? %(<div class="title">#{element.title}</div>\n) : ''
-            %(<div class="sidebar">\n#{title_html}#{element.content.to_s}\n</div>)
+          def call(element, ctx)
+            title = element.title.to_s
+            header = title.empty? ? '' : " #{title}"
+            body = render_body(element, ctx)
+            ":::info#{header}\n#{body}\n:::"
+          end
+
+          private
+
+          def render_body(element, ctx)
+            return element.content.to_s.chomp if element.children.nil? || element.children.empty?
+
+            element.children.map { |c| ctx.serialize(c) }.join("\n\n").chomp
           end
         end
       end

--- a/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
@@ -228,7 +228,11 @@ module Coradoc
           end
 
           def transform_literal_block(block)
-            Coradoc::Markdown::Literal.new(content: block.content.to_s)
+            content = CoreModel::CalloutText.strip_markers(block.content.to_s, block.callouts)
+            literal = Coradoc::Markdown::Literal.new(content: content)
+            return literal if block.callouts.nil? || block.callouts.empty?
+
+            [literal, transform_callout_list(block.callouts)]
           end
 
           def transform_example_block(block)
@@ -241,9 +245,11 @@ module Coradoc
           end
 
           def transform_sidebar_block(block)
+            children = Array(block.children).map { |c| transform(c) }.flat_map { |c| flatten_result(c) }
             Coradoc::Markdown::Sidebar.new(
               content: block.flat_text,
-              title: block.title.to_s
+              title: block.title.to_s,
+              children: children
             )
           end
 
@@ -350,13 +356,13 @@ module Coradoc
 
               # Check if first row is marked as header, or if any of its cells are header cells
               if first_row&.header || first_row_cells.any?(&:header)
-                headers = first_row_cells.map(&:flat_text)
+                headers = first_row_cells.map { |cell| strip_cell_callouts(cell.flat_text) }
                 table_rows = table_rows[1..] || []
               end
 
               # Convert remaining rows to pipe-separated strings
               rows = table_rows.map do |row|
-                Array(row.cells).map(&:flat_text).join(' | ')
+                Array(row.cells).map { |cell| strip_cell_callouts(cell.flat_text) }.join(' | ')
               end
             end
 
@@ -364,6 +370,12 @@ module Coradoc
               headers: headers,
               rows: rows
             )
+          end
+
+          CALLOUT_MARKER_IN_CELL = /\s*<\d+>(?=\s|\z)/.freeze
+
+          def strip_cell_callouts(text)
+            text.to_s.gsub(CALLOUT_MARKER_IN_CELL, '')
           end
 
           def transform_image(image)

--- a/coradoc-markdown/lib/coradoc/markdown/transform/inline_transformer.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/inline_transformer.rb
@@ -37,6 +37,8 @@ module Coradoc
                 text: element.content.to_s,
                 target: element.target.to_s
               )
+            when 'raw_inline'
+              element.content.to_s
             else
               element.content.to_s
             end

--- a/coradoc/lib/coradoc/core_model.rb
+++ b/coradoc/lib/coradoc/core_model.rb
@@ -36,6 +36,7 @@ module Coradoc
     autoload :SpanElement, "#{__dir__}/core_model/inline_element"
     autoload :TermElement, "#{__dir__}/core_model/inline_element"
     autoload :LineBreakElement, "#{__dir__}/core_model/inline_element"
+    autoload :RawInlineElement, "#{__dir__}/core_model/raw_inline_element"
     autoload :StructuralElement, "#{__dir__}/core_model/structural_element"
     autoload :DocumentElement, "#{__dir__}/core_model/structural_element"
     autoload :SectionElement, "#{__dir__}/core_model/structural_element"

--- a/coradoc/lib/coradoc/core_model/raw_inline_element.rb
+++ b/coradoc/lib/coradoc/core_model/raw_inline_element.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    # Inline raw passthrough — content the source format marked as "do not
+    # process". AsciiDoc's `+++raw+++` is the canonical producer. Spokes
+    # that lack a passthrough concept (most of them) should emit the
+    # content verbatim, since the original author explicitly chose raw
+    # markup (often HTML) knowing it would be passed through.
+    class RawInlineElement < InlineElement
+      def self.format_type
+        'raw_inline'
+      end
+    end
+  end
+end

--- a/coradoc/spec/integration/all_remaining_gaps_spec.rb
+++ b/coradoc/spec/integration/all_remaining_gaps_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Regression for BUG-all-remaining-gaps.md. AsciiDoc → Markdown
+# (VitePress flavor) conversion previously leaked bare `<` characters
+# for eight construct categories, which broke VitePress's Vue template
+# compiler downstream.
+#
+# Scope:
+#   1. Literal blocks (`....`) → fenced code block (no language)
+#   2. Sidebar blocks (`****`) → `:::info` container
+#   3. Pass blocks (`++++`) → wrapped so raw content does not leak as
+#      prose
+#   4. Callouts (`<N>`) inside literal blocks → stripped, annotation
+#      emitted as numbered list
+#   5. Callouts (`<N>`) inside table cells → stripped from cell text
+#   6. Source blocks inside sidebars → code fence preserved within
+#      `:::info`
+#   7. Example blocks inside open blocks → `:::details` container
+#      preserved
+#   8. Inline passthrough (`+++...+++`) → delimiters stripped
+RSpec.describe 'AsciiDoc → Markdown conversion gaps (BUG-all-remaining-gaps)', type: :integration do
+  def to_markdown(src)
+    Coradoc.convert(
+      src + "\n",
+      from: :asciidoc, to: :markdown, markdown_flavor: :vitepress
+    )
+  end
+
+  describe 'Bug 1: literal block' do
+    it 'renders as a fenced code block without a language' do
+      md = to_markdown(<<~ADOC)
+        ....
+        <clause id="test">
+          <p>Content</p>
+        </clause>
+        ....
+      ADOC
+      expect(md).to include("```\n<clause id=\"test\">")
+      expect(md).to include('</clause>')
+    end
+  end
+
+  describe 'Bug 2: sidebar block' do
+    it 'renders as a :::info container' do
+      md = to_markdown(<<~ADOC)
+        ****
+        Text in sidebar.
+        ****
+      ADOC
+      expect(md).to include(':::info')
+      expect(md).to include('Text in sidebar.')
+      expect(md).to include(':::')
+      expect(md).not_to include('<div')
+    end
+  end
+
+  describe 'Bug 3: pass block' do
+    it 'wraps raw content so it does not leak as prose' do
+      md = to_markdown(<<~ADOC)
+        ++++
+        <raw html/>
+        ++++
+      ADOC
+      expect(md).to include('<raw html/>')
+      expect(md).not_to include('++++')
+    end
+  end
+
+  describe 'Bug 4: callouts inside literal blocks' do
+    it 'strips the marker and emits annotation as numbered list' do
+      md = to_markdown(<<~ADOC)
+        ....
+        code <1>
+        ....
+        <1> Annotation
+      ADOC
+      expect(md).to include('```')
+      expect(md).not_to match(/code\s*<1>/)
+      expect(md).to include('1. Annotation')
+    end
+  end
+
+  describe 'Bug 5: callouts inside table cells' do
+    it 'strips the marker from cell text' do
+      md = to_markdown(<<~ADOC)
+        |===
+        | Cell text <1>
+        |===
+
+        <1> Annotation
+      ADOC
+      expect(md).not_to match(/Cell text\s*<1>/)
+      expect(md).to include('Cell text')
+    end
+  end
+
+  describe 'Bug 6: source block inside sidebar' do
+    it 'preserves the code fence inside the container' do
+      md = to_markdown(<<~ADOC)
+        ****
+        [source,ruby]
+        ----
+        puts 'hi'
+        ----
+        ****
+      ADOC
+      expect(md).to include(':::info')
+      expect(md).to include("```ruby")
+      expect(md).to include("puts 'hi'")
+      expect(md).to include(':::')
+    end
+  end
+
+  describe 'Bug 7: example block inside open block' do
+    it 'renders as :::details container' do
+      md = to_markdown(<<~ADOC)
+        --
+        ====
+        Example text.
+        ====
+        --
+      ADOC
+      expect(md).to include(':::details')
+      expect(md).to include('Example text.')
+      expect(md).to include(':::')
+      expect(md).not_to include('<div class="example">')
+    end
+  end
+
+  describe 'Bug 8: inline passthrough' do
+    it 'strips the triple-plus delimiters' do
+      md = to_markdown('+++ <div class="cta">Click</div> +++')
+      expect(md).not_to include('+++')
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Eight AsciiDoc → Markdown (VitePress flavor) conversion gaps caused bare `<` characters to leak into output files, breaking VitePress's Vue template compiler. See `BUG-all-remaining-gaps.md`.

## Root Causes & Fixes

| # | Construct | Root Cause | Fix |
|---|-----------|------------|-----|
| 1 | Literal block (`....`) | Parser lacked a `literal_block` rule; `block_title` greedily consumed `....` as a title attribute | Add `literal_block(n_deep)` parser using `block_style(n_deep, '.', 4, verbatim: true)`; guard `block_title` against delimiter lines; register in `block_type_classifier` |
| 2 | Sidebar block (`****`) | Markdown serializer emitted `<div class="sidebar">` HTML | New `Serializers::Sidebar` emits `:::info` container in VitePress flavor; sidebar model gains `children` attribute |
| 3 | Pass block (`++++`) | `:pass` special case in `block_style` lacked `closing_pattern.absent?` guard — text_line consumed the closing `++++` | Remove `:pass` special case; use `verbatim: true` so the standard closing guard applies |
| 4 | Callouts in literal blocks | `CalloutMerger` only attached callouts to `SourceBlock` / `ListingBlock`; Markdown `transform_literal_block` didn't strip markers | Add `LiteralBlock` to merger's eligible types; `transform_literal_block` now strips markers via `CalloutText.strip_markers` and emits annotations as a numbered list (mirrors `transform_code_block`) |
| 5 | Callouts in table cells | `transform_table` rendered `flat_text` verbatim, including any `<N>` | Strip callout markers from cell text during Markdown table transform |
| 6 | Code inside sidebar | Sidebar model had no `children`; sidebar serializer didn't recurse | Sidebar model gains `children`; serializer renders nested children |
| 7 | Example in open block | Worked with explicit `:vitepress` flavor but fell through to HTML under `Coradoc.convert` default | No code change — behavior is correct with `markdown_flavor: :vitepress`. Regression spec covers it. |
| 8 | Inline passthrough (`+++...+++`) | No parser rule, no transformer rule, no CoreModel type | Add `inline_passthrough` parser rule; new `Model::Inline::Passthrough`; new `CoreModel::RawInlineElement`; register `Passthrough → RawInlineElement` transformer; Markdown renders content verbatim (correct for a passthrough) |

## Verification

New regression spec: `coradoc/spec/integration/all_remaining_gaps_spec.rb` — 8 examples, all pass.

End-to-end conversion outputs (VitePress flavor):

```
Bug 1 (literal):              ```\n<clause>...\n```
Bug 2 (sidebar):              :::info\nText in sidebar.\n:::
Bug 3 (pass):                 {::nomarkdown}<raw html/>{:/}
Bug 4 (callouts in literal):  ```\ncode\n```\n\n1. Annotation
Bug 5 (callouts in tables):   |  Cell text |
Bug 6 (code in sidebar):      :::info\n```ruby\nputs 'hi'\n```\n:::
Bug 7 (example in open):      :::details Example:\nExample text.\n:::
Bug 8 (inline passthrough):   <div class="cta">...</div>   (delimiters stripped)
```

Full test suites pass with no regressions:
- `coradoc` 1014 examples, 0 failures
- `coradoc-adoc` 946 examples, 0 failures, 5 pending
- `coradoc-markdown` 616 examples, 0 failures
- `coradoc-html` 825 examples, 0 failures, 1 pending

Pre-existing `coradoc-docx` failures (10) are unrelated — they fail identically on `main`.

## Patch Release Targets

- `coradoc` 2.0.20 → 2.0.21
- `coradoc-adoc` 2.0.14 → 2.0.15
- `coradoc-markdown` 1.0.6 → 1.0.7