### PR TITLE
fix(adoc,markdown): close final 5 AsciiDoc → Markdown conversion gaps

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/callout_merger.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/callout_merger.rb
@@ -35,11 +35,16 @@ module Coradoc
 
         # Walks the input children left-to-right. When a paragraph whose
         # content is composed entirely of `<N> text` lines follows a
-        # verbatim block (SourceBlock or ListingBlock), each `<N>` line
-        # becomes a Callout attached to that block instead of a separate
-        # paragraph.
+        # verbatim block (SourceBlock, ListingBlock, LiteralBlock), each
+        # `<N>` line becomes a Callout attached to that block instead of
+        # a separate paragraph.
         #
-        # Annotations that do not follow a verbatim block are preserved
+        # Annotations that follow any other block (e.g. a Table) cannot
+        # attach as Callouts — those blocks don't carry callouts. Convert
+        # the paragraph to an ordered ListBlock so the downstream
+        # serializer renders `1. text` instead of leaking `<N>` markers.
+        #
+        # Annotations with no preceding block at all are preserved
         # verbatim — they may be legitimate prose.
         def merge(children)
           children.each.with_object([]) do |child, result|
@@ -47,6 +52,8 @@ module Coradoc
             target = annotations && preceding_verbatim_block(result)
             if target
               target.callouts.concat(annotations)
+            elsif annotations && result.any?
+              result << callout_list(annotations)
             else
               result << child
             end
@@ -54,6 +61,21 @@ module Coradoc
         end
 
         private
+
+        def callout_list(annotations)
+          ordered = annotations.sort_by { |c| c.index || Float::INFINITY }
+          items = ordered.map do |callout|
+            Coradoc::CoreModel::ListItem.new(
+              marker: '.',
+              content: callout.content.to_s
+            )
+          end
+          Coradoc::CoreModel::ListBlock.new(
+            marker_type: 'ordered',
+            marker_level: 1,
+            items: items
+          )
+        end
 
         # Returns an Array of Callout if the paragraph is entirely
         # callout annotations, otherwise nil.

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
@@ -150,10 +150,19 @@ module Coradoc
                 )
               else
                 content_lines = lines.map { |line| ToCoreModel.extract_text_content(line) }.join("\n")
+                children = lines.map do |line|
+                  inline = ToCoreModel.transform_inline_content(line)
+                  inline = [Coradoc::CoreModel::TextContent.new(text: "")] if inline.empty?
+                  Coradoc::CoreModel::ParagraphBlock.new(
+                    content: ToCoreModel.extract_text_content(line),
+                    children: Array(inline)
+                  )
+                end
                 klass.new(
                   id: block.id,
                   title: ToCoreModel.extract_title_text(block.title),
                   content: content_lines,
+                  children: children,
                   language: ToCoreModel.extract_block_language(block),
                   **extra_attrs
                 )

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -426,6 +426,8 @@ module Coradoc
               content
             when Array
               content.map { |item| safe_content_to_string(item) }.join
+            when Coradoc::CoreModel::Base
+              content.flat_text
             when Lutaml::Model::Serializable
               if content.is_a?(Coradoc::AsciiDoc::Model::Base)
                 content.to_adoc

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/block_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/block_transformer_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::BlockTransform
       expect(result.title).to eq('Quote')
       expect(result.content).to eq('To be or not to be')
       expect(result.attribution).to eq('Shakespeare')
-      expect(result.children).to be_empty
+      expect(result.children).to all(be_a(Coradoc::CoreModel::ParagraphBlock))
     end
 
     it 'transforms into a specified class with nested blocks' do

--- a/coradoc-markdown/lib/coradoc/markdown/serializer/serializers/pass.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/serializer/serializers/pass.rb
@@ -6,13 +6,22 @@ module Coradoc
   module Markdown
     class Serializer
       module Serializers
-        # Pass block: emit content inside kramdown's nomarkdown extension
-        # so it bypasses Markdown rendering.
+        # Pass block. AsciiDoc pass content is raw and bypasses all
+        # substitutions. Markdown has no equivalent — kramdown's
+        # `{::nomarkdown}` extension is not supported by VitePress /
+        # markdown-it, so emitting it leaks raw HTML that breaks Vue's
+        # template compiler.
+        #
+        # Emit as an HTML comment so the content is preserved (for
+        # debugging or downstream tooling) but never rendered as HTML.
         class Pass < ElementSerializer
           handles_type ::Coradoc::Markdown::Pass
 
           def call(element, _ctx)
-            "{::nomarkdown}#{element.content.to_s}{:/}"
+            content = element.content.to_s
+            stripped = content.gsub(/\A\n+|\n+\z/, '')
+            comment_body = stripped.empty? ? '' : " #{stripped} "
+            "<!--#{comment_body}-->"
           end
         end
       end

--- a/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cgi'
+
 module Coradoc
   module Markdown
     module Transform
@@ -417,6 +419,8 @@ module Coradoc
                 text: element.content.to_s,
                 target: element.target.to_s
               )
+            when 'raw_inline'
+              CGI.escapeHTML(element.content.to_s)
             else
               element.content.to_s
             end

--- a/coradoc-markdown/lib/coradoc/markdown/transform/inline_transformer.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/inline_transformer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cgi'
+
 module Coradoc
   module Markdown
     module Transform
@@ -38,7 +40,7 @@ module Coradoc
                 target: element.target.to_s
               )
             when 'raw_inline'
-              element.content.to_s
+              CGI.escapeHTML(element.content.to_s)
             else
               element.content.to_s
             end

--- a/coradoc/spec/integration/final_5_remaining_gaps_spec.rb
+++ b/coradoc/spec/integration/final_5_remaining_gaps_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Regression for BUG-final-5-remaining.md. Five remaining AsciiDoc →
+# Markdown (VitePress flavor) gaps that broke VitePress's Vue template
+# compiler downstream.
+#
+# Scope:
+#   1. Backtick code spans inside example/sidebar blocks must survive —
+#      previously the typed-block transformer flattened lines to plain
+#      text via extract_text_content, dropping the inline formatting.
+#   2. Pass blocks must not emit kramdown's `{::nomarkdown}` extension
+#      (unsupported by VitePress). Emit as an HTML comment so the raw
+#      content is preserved but never parsed as HTML.
+#   3. Inline passthrough (`+++raw+++`) must not leak raw HTML into
+#      Markdown text. HTML-escape the content.
+#   4. Callout annotation paragraphs after non-verbatim blocks (e.g.
+#      Tables) must convert to a numbered list, not stay as `<N>` text.
+#   5. Cross-references inside example blocks must convert to Markdown
+#      links (fixed alongside Bug 1 by populating ParagraphBlock children).
+RSpec.describe 'AsciiDoc → Markdown final 5 conversion gaps (BUG-final-5-remaining)', type: :integration do
+  def to_markdown(src)
+    Coradoc.convert(
+      src + "\n",
+      from: :asciidoc, to: :markdown, markdown_flavor: :vitepress
+    )
+  end
+
+  describe 'Bug 1: backtick code span inside example block' do
+    it 'preserves backticks around inline HTML' do
+      md = to_markdown(<<~ADOC)
+        ====
+        Text with `<div class="test">` here.
+        ====
+      ADOC
+      expect(md).to include('`<div class="test">`')
+      expect(md).not_to match(/Text\s+<div class="test">\s+here/)
+    end
+  end
+
+  describe 'Bug 1b: backtick code span inside sidebar block' do
+    it 'preserves backticks around inline HTML' do
+      md = to_markdown(<<~ADOC)
+        ****
+        Text with `<code>` here.
+        ****
+      ADOC
+      expect(md).to include('`<code>`')
+      expect(md).not_to match(/Text\s+<code>\s+here/)
+    end
+  end
+
+  describe 'Bug 2: pass block' do
+    it 'emits an HTML comment instead of kramdown {::nomarkdown}' do
+      md = to_markdown(<<~ADOC)
+        ++++
+        <raw html/>
+        ++++
+      ADOC
+      expect(md).not_to include('{::nomarkdown}')
+      expect(md).to include('<!--')
+      expect(md).to include('-->')
+      expect(md).to include('<raw html/>')
+    end
+  end
+
+  describe 'Bug 3: inline passthrough' do
+    it 'HTML-escapes the passthrough content' do
+      md = to_markdown('+++ <div class="cta">button</div> +++')
+      expect(md).not_to include('<div')
+      expect(md).to include('&lt;div')
+    end
+  end
+
+  describe 'Bug 4: callout annotation after table' do
+    it 'converts the annotation paragraph to a numbered list' do
+      md = to_markdown(<<~ADOC)
+        |===
+        | Cell text <1>
+        |===
+
+        <1> This is an annotation
+      ADOC
+      expect(md).to include('1. This is an annotation')
+      expect(md).not_to match(/<1>/)
+    end
+  end
+
+  describe 'Bug 5: cross-reference inside example block' do
+    it 'converts the xref to a Markdown link' do
+      md = to_markdown(<<~ADOC)
+        ====
+        See <<id,clause "123">> for details.
+        ====
+      ADOC
+      expect(md).to include('](#id)')
+      expect(md).not_to include('<<')
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Five remaining AsciiDoc → Markdown (VitePress) conversion gaps from `BUG-final-5-remaining.md` still break the VitePress build after PR #220.

## Root Causes & Fixes

| # | Construct | Root Cause | Fix |
|---|-----------|------------|-----|
| 1 | Backticks/inline formatting inside example, sidebar, quote, and other typed delimited blocks | `BlockTransformer#transform_typed_block` flattened each line via `extract_text_content` when no nested block was present, losing typed inline elements | Wrap each line as a `ParagraphBlock` with inline-transformed `children`, mirroring `transform_paragraph` |
| 2 | Pass block (`++++`) | Markdown `Pass` serializer emitted `{::nomarkdown}…{:/}` kramdown extension, unsupported by VitePress | Wrap content in an HTML comment instead — preserved but never parsed as HTML |
| 3 | Inline passthrough (`+++raw+++`) | `RawInlineElement` passed through verbatim, leaking raw HTML into prose | Add `raw_inline` branch to both `FromCoreModel#transform_inline` and `InlineTransformer.transform_inline` that HTML-escapes the content |
| 4 | Callout annotation after non-verbatim block | `CalloutMerger` only attached annotations to verbatim blocks; paragraphs following tables, etc. leaked `<N>` markers | When no verbatim block precedes, convert the annotation paragraph to an ordered `ListBlock` so it renders as `1. text` |
| 5 | Cross-references inside example blocks | Same root cause as Bug 1 — the xref was inside a typed block whose lines were flattened | Fixed automatically by the Bug 1 fix; xrefs now ride the `ParagraphBlock` children path |

A small AsciiDoc-side follow-up was needed: `FromCoreModel#safe_content_to_string` now delegates to `CoreModel::Base#flat_text` for CoreModel inputs so the AsciiDoc → CoreModel → AsciiDoc round-trip still emits the textual body of these blocks.

## Verification

New spec: `coradoc/spec/integration/final_5_remaining_gaps_spec.rb` — 6 examples, all pass.

One existing spec updated: `coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/block_transformer_spec.rb:129` — the assertion `expect(result.children).to be_empty` no longer holds because typed blocks now always produce `ParagraphBlock` children. Replaced with `expect(result.children).to all(be_a(Coradoc::CoreModel::ParagraphBlock))`.

Reproduction script from the bug report (VitePress flavor):

```
[OK] 1a. backtick in example   Text `<code>`  here.
[OK] 1b. backtick in sidebar   Text `<code>`  here.
[OK] 2. pass block             <!-- <raw/> -->
[OK] 3. passthrough            &lt;div&gt;x&lt;/div&gt;
[OK] 4. callout after table    1. note
[OK] 5. xref in example        See [clause "123"](#id) .
```

Full suites pass with no regressions:
- `coradoc` 1014 examples, 0 failures
- `coradoc-adoc` 946 examples, 0 failures, 5 pending
- `coradoc-markdown` 616 examples, 0 failures
- `coradoc-html` 825 examples, 0 failures, 1 pending

Pre-existing `coradoc-docx` failures (10) are unrelated — they fail identically on `main`.

## Patch Release Targets

- `coradoc-adoc` (currently 2.0.15) — callout merger + typed block transformer
- `coradoc-markdown` (currently 1.0.7) — pass serializer + inline transformer

Version bumps to be performed by `release.yml` with `next_version: patch` (no manual edits).
