### PR TITLE
chore(ci): add coradoc-mirror to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
           - coradoc-html
           - coradoc-markdown
           - coradoc-docx
+          - coradoc-mirror
       next_version:
         description: >-
           Next release version. Possible values: x.y.z, major, minor,
@@ -46,6 +47,7 @@ jobs:
           (github.event.inputs.gem_name == 'coradoc-html' && 'lib/coradoc/html/version.rb') ||
           (github.event.inputs.gem_name == 'coradoc-markdown' && 'lib/coradoc/markdown/version.rb') ||
           (github.event.inputs.gem_name == 'coradoc-docx' && 'lib/coradoc/docx/version.rb') ||
+          (github.event.inputs.gem_name == 'coradoc-mirror' && 'lib/coradoc/mirror/version.rb') ||
           ''
         }}
     secrets:


### PR DESCRIPTION
## What

Adds `coradoc-mirror` to `.github/workflows/release.yml`:

1. Adds it to the `gem_name` dropdown options.
2. Adds the `version_file` mapping (`lib/coradoc/mirror/version.rb`).

## Why

The mirror gem (currently `0.1.0`) cannot be released via `workflow_dispatch` because it is missing from the dropdown. This PR unblocks the first gem release of `coradoc-mirror`.

## Test plan

- [x] Diff matches the existing pattern for the other 5 format gems.
- [ ] Workflow run on `workflow_dispatch` with `gem_name=coradoc-mirror next_version=patch` succeeds after merge.