### PR TITLE
fix(adoc): join soft-wrapped paragraph lines in list items and typed blocks

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
@@ -52,21 +52,19 @@ module Coradoc
 
         def olist_item(nesting_level = 1)
           item = olist_marker(nesting_level).as(:marker) >>
-                 match("\n").absent? >> space >> text_line(true, unguarded: true)
-          # >>
-          # (list_continuation.present? >> list_continuation >>
-          # paragraph #| example_block(n_deep: 1)
-          # ).repeat(0).as(:attached)
+                 match("\n").absent? >> space >>
+                 (text_line(true, unguarded: true) >>
+                  list_item_continuation_lines).as(:lines)
 
           att = (list_continuation.present? >>
                   list_continuation >>
-                  (admonition_line | paragraph | block) # (n_deep: 1))
+                  (admonition_line | paragraph | block)
                 ).repeat(0).as(:attached)
           item >>= att.maybe
 
           if nesting_level <= 4
             item >>= (list_marker(nesting_level + 1).present? >>
-                   list(nesting_level + 1)).repeat(0).as(:nested) # ).maybe
+                   list(nesting_level + 1)).repeat(0).as(:nested)
           end
           olist_marker(nesting_level).present? >> item.as(:list_item)
         end
@@ -82,19 +80,31 @@ module Coradoc
         def ulist_item(nesting_level = 1)
           item = ulist_marker(nesting_level).as(:marker) >>
                  str(' [[[').absent? >>
-                 match("\n").absent? >> space >> text_line(true, unguarded: true)
+                 match("\n").absent? >> space >>
+                 (text_line(true, unguarded: true) >>
+                  list_item_continuation_lines).as(:lines)
 
           att = (list_continuation.present? >>
                   list_continuation >>
-                  (admonition_line | paragraph | block) # (n_deep: 1))
+                  (admonition_line | paragraph | block)
                 ).repeat(0).as(:attached)
           item >>= att.maybe
 
           if nesting_level <= 4
             item >>= (list_marker(nesting_level + 1).present? >>
-                   list(nesting_level + 1)).repeat(0).as(:nested) # ).maybe
+                   list(nesting_level + 1)).repeat(0).as(:nested)
           end
           ulist_marker(nesting_level).present? >> item.as(:list_item)
+        end
+
+        # Continuation lines of a list item's first paragraph. AsciiDoc
+        # joins consecutive non-blank lines into one paragraph within the
+        # item, but the lines must not start a sibling construct (another
+        # list marker, block delimiter, attribute list, section, element
+        # id, table boundary, list continuation, or list prefix).
+        # `line_not_text?` (from Paragraph) is that exact lookahead.
+        def list_item_continuation_lines
+          (line_not_text? >> text_line(true, unguarded: true)).repeat(0)
         end
 
         def dlist_delimiter

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
@@ -123,15 +123,14 @@ module Coradoc
             end
 
             def transform_typed_block(block, klass, extra_attrs = {})
-              lines = Array(block.lines).reject do |line|
-                line.is_a?(Coradoc::AsciiDoc::Model::LineBreak) ||
-                  line.is_a?(Coradoc::AsciiDoc::Model::Break::PageBreak)
-              end
-
-              has_nested_blocks = lines.any?(Coradoc::AsciiDoc::Model::Block::Core)
+              raw_lines = Array(block.lines)
+              has_nested_blocks = raw_lines.any?(Coradoc::AsciiDoc::Model::Block::Core)
 
               if has_nested_blocks
-                children = lines.filter_map do |line|
+                children = raw_lines.reject do |line|
+                  line.is_a?(Coradoc::AsciiDoc::Model::LineBreak) ||
+                    line.is_a?(Coradoc::AsciiDoc::Model::Break::PageBreak)
+                end.filter_map do |line|
                   result = ToCoreModel.transform(line)
                   next nil if result.nil?
                   next result if result.is_a?(Coradoc::CoreModel::Base)
@@ -149,15 +148,21 @@ module Coradoc
                   **extra_attrs
                 )
               else
-                content_lines = lines.map { |line| ToCoreModel.extract_text_content(line) }.join("\n")
-                children = lines.map do |line|
-                  inline = ToCoreModel.transform_inline_content(line)
-                  inline = [Coradoc::CoreModel::TextContent.new(text: "")] if inline.empty?
+                paragraph_groups = group_block_lines_into_paragraphs(raw_lines)
+
+                content_lines = paragraph_groups.map do |group|
+                  ToCoreModel.extract_text_content(group)
+                end.join("\n\n")
+
+                children = paragraph_groups.map do |group|
+                  inline = ToCoreModel.transform_inline_content(group)
+                  inline = [Coradoc::CoreModel::TextContent.new(text: '')] if inline.empty?
                   Coradoc::CoreModel::ParagraphBlock.new(
-                    content: ToCoreModel.extract_text_content(line),
+                    content: ToCoreModel.extract_text_content(group),
                     children: Array(inline)
                   )
                 end
+
                 klass.new(
                   id: block.id,
                   title: ToCoreModel.extract_title_text(block.title),
@@ -167,6 +172,24 @@ module Coradoc
                   **extra_attrs
                 )
               end
+            end
+
+            # AsciiDoc joins consecutive non-blank lines into one paragraph;
+            # blank lines (parsed as Model::LineBreak) separate paragraphs.
+            def group_block_lines_into_paragraphs(lines)
+              groups = []
+              current = []
+              lines.each do |line|
+                if line.is_a?(Coradoc::AsciiDoc::Model::LineBreak) ||
+                   line.is_a?(Coradoc::AsciiDoc::Model::Break::PageBreak)
+                  groups << current if current.any?
+                  current = []
+                else
+                  current << line
+                end
+              end
+              groups << current if current.any?
+              groups
             end
           end
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/list_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/list_rules.rb
@@ -47,8 +47,12 @@ module Coradoc
             rule(list_item: subtree(:list_item)) do
               marker = list_item[:marker]
               id = list_item[:id]
-              text = list_item[:text]
-              text = list_item[:text].to_s if list_item[:text].instance_of?(Parslet::Slice)
+              lines = list_item[:lines]
+              content = if lines
+                          Transformer.lines_to_text_elements(lines)
+                        else
+                          list_item[:text].to_s
+                        end
               attached = list_item[:attached]
               nested = list_item[:nested]
               line_break = list_item[:line_break]
@@ -70,7 +74,7 @@ module Coradoc
               end
 
               Model::List::Item.new(
-                content: text, id:, marker:, attached:, nested:, line_break:
+                content: content, id:, marker:, attached:, nested:, line_break:
               )
             end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/block_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/block_transformer_spec.rb
@@ -146,6 +146,27 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::BlockTransform
       expect(result.children).to all(be_a(Coradoc::CoreModel::ParagraphBlock))
     end
 
+    it 'groups consecutive soft-wrapped lines into a single paragraph' do
+      block = Coradoc::AsciiDoc::Model::Block::Example.new(
+        lines: [
+          Coradoc::AsciiDoc::Model::TextElement.new(content: 'First paragraph line 1.'),
+          Coradoc::AsciiDoc::Model::TextElement.new(content: 'First paragraph line 2.'),
+          Coradoc::AsciiDoc::Model::LineBreak.new,
+          Coradoc::AsciiDoc::Model::TextElement.new(content: 'Second paragraph here.')
+        ]
+      )
+
+      result = described_class.transform_typed_block(
+        block, Coradoc::CoreModel::ExampleBlock
+      )
+
+      paragraphs = result.children
+      expect(paragraphs.size).to eq(2)
+      expect(paragraphs.all?(Coradoc::CoreModel::ParagraphBlock)).to be(true)
+      expect(paragraphs[0].content).to eq('First paragraph line 1. First paragraph line 2.')
+      expect(paragraphs[1].content).to eq('Second paragraph here.')
+    end
+
     it 'transforms into a specified class with nested blocks' do
       nested = Coradoc::AsciiDoc::Model::Block::Core.new(
         lines: [Coradoc::AsciiDoc::Model::TextElement.new(content: 'Inner')]


### PR DESCRIPTION
## Problem

AsciiDoc treats consecutive non-blank lines as a single paragraph (soft-wrap), but the parser/transformer was splitting them into separate elements:

### List items (`entering-bib.adoc`)

```adoc
. Enter the anchor name like this: `[bibliography]`
To specify a location within the cited document, you can add
localities in the brackets like so: `[bibliography,page=23]`.
```

The continuation lines were becoming a sibling paragraph at the document level instead of staying inside the list item.

### Typed blocks (`approach.adoc`)

```adoc
[NOTE]
====
This is the first line of the note.
This is the second line of the note.
This is the third line of the note.
====
```

The 3 soft-wrapped lines were rendered as 3 separate paragraphs.

## Root cause

Both bugs share a common shape: a multi-line paragraph was being represented as N elements instead of 1.

- **List items:** `olist_item`/`ulist_item` in `parser/list.rb` only matched one `text_line` after the marker; subsequent lines of the same paragraph fell through to the document level.
- **Typed blocks:** `transform_typed_block` in `block_transformer.rb` created one `CoreModel::ParagraphBlock` per `TextElement` in `block.lines`, ignoring paragraph boundaries.

## Fix

### List items (`parser/list.rb`, `transformer/list_rules.rb`)

Add `list_item_continuation_lines` — uses the existing `line_not_text?` lookahead (already shared with paragraph parsing) to consume consecutive non-blank lines that don't start a sibling construct (list marker, block delimiter, attribute list, section, element id, table boundary, list continuation). The collected lines are wrapped under the item's `:lines` key and run through `Transformer.lines_to_text_elements` (the same helper paragraphs use).

### Typed blocks (`block_transformer.rb`)

Replace the per-line `ParagraphBlock` loop with `group_block_lines_into_paragraphs`: split `block.lines` on `Model::LineBreak`/`Break::PageBreak` boundaries, then emit one `ParagraphBlock` per group. Within a group, `extract_text_content` and `transform_inline_content` already handle `Array<TextElement>` correctly (the visitors insert spaces between soft-wrapped TextElements whose `line_break` is not `+`).

The nested-block branch is unchanged in behaviour — it just rejects break markers inline now instead of upfront, since the grouping pass needs them.

## Tests

- New regression spec: `groups consecutive soft-wrapped lines into a single paragraph` in `block_transformer_spec.rb`.
- Full `coradoc-adoc` suite: 953 examples, 0 failures.
- `coradoc`, `coradoc-markdown`, `coradoc-html` suites: all green.