### PR TITLE
feat(mirror): FrontmatterQuery public API + Partitioner metadata bucket

### DIFF
--- a/coradoc-mirror/lib/coradoc/mirror.rb
+++ b/coradoc-mirror/lib/coradoc/mirror.rb
@@ -14,6 +14,15 @@ module Coradoc
     autoload :CoreModelToMirror, "#{__dir__}/mirror/core_model_to_mirror"
     autoload :MirrorToCoreModel, "#{__dir__}/mirror/mirror_to_core_model"
     autoload :Partitioner, "#{__dir__}/mirror/partitioner"
+    # Shared tree→Hash translator for the frontmatter typed-tree. Read by
+    # ReverseBuilder::Frontmatter and FrontmatterQuery — single source of
+    # truth for the inverse of Handlers::Frontmatter.build_value.
+    autoload :FrontmatterTreeToHash, "#{__dir__}/mirror/frontmatter_tree_to_hash"
+    # Public read-API for downstream consumers (e.g. site generators) that
+    # need a flat Ruby Hash of a Mirror doc's frontmatter without re-parsing
+    # the source YAML. Frontmatter lives in the CoreModel and the Mirror
+    # doc, not in a parallel YAML parse.
+    autoload :FrontmatterQuery, "#{__dir__}/mirror/frontmatter_query"
     # ReverseBuilder's REGISTRY is populated by the built-in builder
     # subclasses (defined inside reverse_builder.rb) at load time. The
     # file is the autoload target, so the registry is full by the time

--- a/coradoc-mirror/lib/coradoc/mirror/core_model_to_mirror.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/core_model_to_mirror.rb
@@ -48,12 +48,17 @@ module Coradoc
         )
       end
 
-      # Partitions flat doc children into [preface?, sections?, *bibliography,
-      # *trailing] per the @metanorma/mirror JS structural contract. See
-      # Partitioner for the bucketing rules.
+      # Partitions flat doc children into [*metadata, preface?, sections?,
+      # *bibliography, *trailing] per the @metanorma/mirror JS structural
+      # contract. See Partitioner for the bucketing rules.
+      #
+      # Metadata blocks (frontmatter) are prepended verbatim so consumers
+      # like FrontmatterQuery can find them by walking content[0..n], and
+      # renderers can skip them via their type ('frontmatter').
       def wrap_structural(children)
         partitioned = Partitioner.partition(children)
         wrapped = []
+        wrapped.concat(partitioned[:metadata])
         wrapped << Node::Preamble.new(content: partitioned[:preface]) if partitioned[:preface].any?
         wrapped << Node::Sections.new(content: partitioned[:sections]) if partitioned[:sections].any?
         wrapped.concat(partitioned[:bibliography])

--- a/coradoc-mirror/lib/coradoc/mirror/frontmatter_query.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/frontmatter_query.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    # Public read-API: extract a flat Ruby Hash from a Mirror document's
+    # frontmatter node.
+    #
+    # Why this exists: site generators (e.g. metanorma.org's convert-adoc.rb)
+    # need frontmatter as a plain Hash for templating VitePress/Jekyll
+    # frontmatter output. Without this, callers would either (a) re-parse
+    # the source YAML — violating FrontmatterBlock::Codec's "single source
+    # of truth" rule — or (b) hand-walk the typed FrontmatterEntry /
+    # FrontmatterValue tree themselves, duplicating the reverse builder's
+    # logic. This module is the single entry point for both problems.
+    #
+    # Reuses FrontmatterTreeToHash — same translator the reverse builder
+    # uses — so the read-path is shared (DRY/MECE).
+    module FrontmatterQuery
+      module_function
+
+      # @param mirror_doc [Mirror::Node::Document, nil]
+      # @return [Hash{String,Object}] flat key→value mapping; empty Hash
+      #   if the document has no frontmatter node or no entries
+      def to_hash(mirror_doc)
+        frontmatter = find_frontmatter(mirror_doc)
+        return {} unless frontmatter
+
+        entries = frontmatter.attrs&.entries || []
+        FrontmatterTreeToHash.to_hash(entries)
+      end
+
+      # @param mirror_doc [Mirror::Node::Document, nil] (see #to_hash)
+      # @return [Boolean] true if the document carries a frontmatter node
+      #   with at least one entry
+      def has_frontmatter?(mirror_doc)
+        frontmatter = find_frontmatter(mirror_doc)
+        !frontmatter.nil? && !(frontmatter.attrs&.entries || []).empty?
+      end
+
+      def find_frontmatter(mirror_doc)
+        return nil if mirror_doc.nil?
+
+        content = mirror_doc.content
+        return nil unless content
+
+        content.find { |node| node.is_a?(Node) && node.type == 'frontmatter' }
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/frontmatter_tree_to_hash.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/frontmatter_tree_to_hash.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    # Walks a typed FrontmatterEntry / FrontmatterValue tree (the Mirror
+    # representation of CoreModel::FrontmatterBlock#data) and rebuilds the
+    # flat Ruby Hash. Inverse of Handlers::Frontmatter.build_value.
+    #
+    # Single source of truth for tree → Hash translation. Consumed by:
+    #   - ReverseBuilder::Frontmatter (mirror → CoreModel round-trip)
+    #   - FrontmatterQuery (mirror doc → flat Hash for downstream readers)
+    #
+    # Extracted from ReverseBuilder so the read-path is shared (DRY/MECE)
+    # and FrontmatterQuery does not depend on the reverse-builder constant.
+    module FrontmatterTreeToHash
+      module_function
+
+      def to_hash(entries)
+        entries.each_with_object({}) do |entry, result|
+          result[entry.key] = unwrap_value(entry.value)
+        end
+      end
+
+      def unwrap_value(value)
+        case value.value_type
+        when 'map'     then to_hash(value.entries || [])
+        when 'array'   then (value.items || []).map { |v| unwrap_value(v) }
+        when 'integer'   then value.integer_value
+        when 'float'     then value.float_value
+        when 'boolean'   then value.boolean_value
+        when 'date'      then value.date_value
+        when 'datetime'  then value.datetime_value
+        when 'symbol'    then value.symbol_value&.to_sym
+        when 'nil'       then nil
+        else value.string_value
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/partitioner.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/partitioner.rb
@@ -15,9 +15,15 @@ module Coradoc
       # (clause, annex, abstract, foreword, introduction, terms,
       # definitions, references, content_section, acknowledgements).
       SECTION_TYPES = Set.new(%w[
-        clause annex content_section abstract foreword introduction
-        acknowledgements terms definitions references section
-      ]).freeze
+                                clause annex content_section abstract foreword introduction
+                                acknowledgements terms definitions references section
+                              ]).freeze
+
+      # Mirror node types that are doc-level metadata, not body content.
+      # They pass through the partitioner untouched (in document order)
+      # so the renderer can choose to skip them — they never land in the
+      # preface bucket where they would render as visible body.
+      METADATA_TYPES = Set.new(%w[frontmatter]).freeze
 
       module_function
 
@@ -29,11 +35,16 @@ module Coradoc
       # Once a bibliography appears → :trailing.
       # Footnotes blocks always go into :trailing regardless of state.
       #
+      # Metadata blocks (frontmatter) are returned in their own bucket,
+      # outside the preface/sections/trailing flow, so they survive the
+      # partition round-trip but are never rendered as body content.
+      #
       # @param children [Array<Node>] flat list of built Mirror nodes
       # @return [Hash{Symbol=>Array<Node>}] buckets under :preface,
-      #   :sections, :bibliography, :trailing
+      #   :sections, :bibliography, :trailing, :metadata
       def partition(children)
-        buckets = { preface: [], sections: [], bibliography: [], trailing: [] }
+        buckets = { preface: [], sections: [], bibliography: [],
+                    trailing: [], metadata: [] }
         state = :preface
 
         children.each do |child|
@@ -44,7 +55,9 @@ module Coradoc
             buckets[:bibliography] << child
             state = :trailing
           else
-            if SECTION_TYPES.include?(child.type)
+            if METADATA_TYPES.include?(child.type)
+              buckets[:metadata] << child
+            elsif SECTION_TYPES.include?(child.type)
               buckets[:sections] << child
               state = :sections
             elsif child.type == 'footnotes'

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
@@ -26,7 +26,7 @@ module Coradoc
     # full before any caller references it. Mirror-level mark dispatch
     # lives in MarkReverseBuilder (mark_reverse_builder.rb).
     module ReverseBuilder
-      REGISTRY = {}
+      REGISTRY = {}.freeze
 
       module_function
 
@@ -567,34 +567,6 @@ module Coradoc
 
       LIST_TYPES = %w[bullet_list ordered_list].freeze
       private_constant :LIST_TYPES
-
-      # Walks a typed FrontmatterEntry / FrontmatterValue tree and
-      # rebuilds the CoreModel `data` hash. Inverse of
-      # Handlers::Frontmatter.build_value.
-      module FrontmatterTreeToHash
-        module_function
-
-        def to_hash(entries)
-          entries.each_with_object({}) do |entry, result|
-            result[entry.key] = unwrap_value(entry.value)
-          end
-        end
-
-        def unwrap_value(value)
-          case value.value_type
-          when 'map' then to_hash(value.entries || [])
-          when 'array' then (value.items || []).map { |v| unwrap_value(v) }
-          when 'integer'  then value.integer_value
-          when 'float'    then value.float_value
-          when 'boolean'  then value.boolean_value
-          when 'date'     then value.date_value
-          when 'datetime' then value.datetime_value
-          when 'symbol'   then value.symbol_value&.to_sym
-          when 'nil'      then nil
-          else value.string_value
-          end
-        end
-      end
     end
   end
 end

--- a/coradoc-mirror/spec/coradoc/mirror/frontmatter_query_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/frontmatter_query_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# FrontmatterQuery is the public read-API for downstream consumers (e.g.
+# metanorma.org's convert-adoc.rb) that need a flat Ruby Hash of a Mirror
+# doc's frontmatter without re-parsing source YAML. Locks in:
+#   1. Round-trip fidelity (CoreModel frontmatter data → mirror → flat Hash)
+#   2. Graceful nil/empty handling
+#   3. Nested values, arrays, dates — all preserved through the typed tree
+RSpec.describe Coradoc::Mirror::FrontmatterQuery do
+  describe '.to_hash' do
+    it 'returns an empty hash when the doc has no frontmatter node' do
+      doc = Coradoc::Mirror::Node::Document.new(
+        content: [Coradoc::Mirror::Node::Paragraph.new]
+      )
+      expect(described_class.to_hash(doc)).to eq({})
+    end
+
+    it 'returns an empty hash when the doc is nil' do
+      expect(described_class.to_hash(nil)).to eq({})
+    end
+
+    it 'returns an empty hash when the frontmatter node has no entries' do
+      frontmatter = Coradoc::Mirror::Node::Frontmatter.new(
+        attrs: Coradoc::Mirror::Node::Frontmatter::Attrs.new
+      )
+      doc = Coradoc::Mirror::Node::Document.new(content: [frontmatter])
+      expect(described_class.to_hash(doc)).to eq({})
+    end
+
+    it 'round-trips a simple title-only frontmatter block through the mirror' do
+      core = Coradoc::CoreModel::DocumentElement.new(
+        children: [
+          Coradoc::CoreModel::FrontmatterBlock.new(data: { 'title' => 'Hello' })
+        ]
+      )
+      mirror = Coradoc::Mirror.transform(core, partition_structural: true)
+      expect(described_class.to_hash(mirror)).to eq({ 'title' => 'Hello' })
+    end
+
+    it 'preserves nested maps, arrays, integers, booleans, dates' do
+      data = {
+        'title'    => 'Doc',
+        'tags'     => %w[a b c],
+        'count'    => 7,
+        'draft'    => false,
+        'published'=> Date.new(2026, 6, 24),
+        'author'   => { 'name' => 'Ada', 'email' => 'ada@example.com' }
+      }
+      core = Coradoc::CoreModel::DocumentElement.new(
+        children: [Coradoc::CoreModel::FrontmatterBlock.new(data: data)]
+      )
+      mirror = Coradoc::Mirror.transform(core, partition_structural: true)
+      result = described_class.to_hash(mirror)
+      expect(result).to eq(data)
+    end
+
+    it 'finds frontmatter even when wrapped in partitioned structural buckets' do
+      core = Coradoc::CoreModel::DocumentElement.new(
+        children: [
+          Coradoc::CoreModel::FrontmatterBlock.new(data: { 'title' => 'T' }),
+          Coradoc::CoreModel::SectionElement.new(title: 'S', level: 1)
+        ]
+      )
+      mirror = Coradoc::Mirror.transform(core, partition_structural: true)
+      expect(described_class.to_hash(mirror)).to eq({ 'title' => 'T' })
+    end
+  end
+
+  describe '.has_frontmatter?' do
+    it 'is false for a doc with no frontmatter' do
+      doc = Coradoc::Mirror::Node::Document.new(
+        content: [Coradoc::Mirror::Node::Paragraph.new]
+      )
+      expect(described_class.has_frontmatter?(doc)).to be false
+    end
+
+    it 'is false for nil' do
+      expect(described_class.has_frontmatter?(nil)).to be false
+    end
+
+    it 'is true when the frontmatter node has at least one entry' do
+      core = Coradoc::CoreModel::DocumentElement.new(
+        children: [
+          Coradoc::CoreModel::FrontmatterBlock.new(data: { 'title' => 'X' })
+        ]
+      )
+      mirror = Coradoc::Mirror.transform(core, partition_structural: true)
+      expect(described_class.has_frontmatter?(mirror)).to be true
+    end
+
+    it 'is false when the frontmatter node exists but has no entries' do
+      frontmatter = Coradoc::Mirror::Node::Frontmatter.new(
+        attrs: Coradoc::Mirror::Node::Frontmatter::Attrs.new
+      )
+      doc = Coradoc::Mirror::Node::Document.new(content: [frontmatter])
+      expect(described_class.has_frontmatter?(doc)).to be false
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/frontmatter_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/frontmatter_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Coradoc::Mirror::Handlers::Frontmatter do
       element = Coradoc::CoreModel::FrontmatterBlock.new(data: data)
 
       node = described_class.call(element, context: context)
-      roundtrip = Coradoc::Mirror::ReverseBuilder::FrontmatterTreeToHash.to_hash(node.attrs.entries)
+      roundtrip = Coradoc::Mirror::FrontmatterTreeToHash.to_hash(node.attrs.entries)
       expect(roundtrip).to eq(data)
     end
   end

--- a/coradoc-mirror/spec/coradoc/mirror/partitioner_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/partitioner_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Partitioner is a single-pass state machine that buckets built Mirror
+# nodes for the JS-shape doc structure. These specs lock in the bucketing
+# rules — including the metadata (frontmatter) bucket — so accidental
+# regressions are caught.
+RSpec.describe Coradoc::Mirror::Partitioner do
+  def para(text = 'x')
+    Coradoc::Mirror::Node::Paragraph.new(
+      content: [Coradoc::Mirror::Node::Text.new(text: text)]
+    )
+  end
+
+  def clause(title = 'C')
+    Coradoc::Mirror::Node::Section.new(
+      type: 'clause',
+      attrs: Coradoc::Mirror::Node::Section::Attrs.new(title: title, level: 1)
+    )
+  end
+
+  def frontmatter_with(entries)
+    Coradoc::Mirror::Node::Frontmatter.new(
+      attrs: Coradoc::Mirror::Node::Frontmatter::Attrs.new(entries: entries)
+    )
+  end
+
+  describe '.partition' do
+    it 'places frontmatter in the metadata bucket, NOT preface' do
+      fm = frontmatter_with([
+        Coradoc::Mirror::Node::FrontmatterEntry.new(
+          key: 'title',
+          value: Coradoc::Mirror::Node::FrontmatterValue.new(
+            value_type: 'string', string_value: 'Doc'
+          )
+        )
+      ])
+      buckets = described_class.partition([fm, para, clause])
+
+      expect(buckets[:metadata]).to eq([fm])
+      expect(buckets[:preface]).to eq([para])
+      expect(buckets[:sections]).to eq([clause])
+    end
+
+    it 'preserves document order when frontmatter is sandwiched' do
+      # Documents always emit frontmatter first; the partitioner must not
+      # reorder it relative to other metadata-bearing nodes.
+      fm = frontmatter_with([])
+      buckets = described_class.partition([fm, para, clause])
+
+      expect(buckets[:metadata]).to eq([fm])
+      expect(buckets[:preface]).to eq([para])
+      expect(buckets[:sections]).to eq([clause])
+    end
+
+    it 'always returns the five-bucket shape' do
+      buckets = described_class.partition([])
+      expect(buckets.keys).to contain_exactly(:preface, :sections, :bibliography,
+                                              :trailing, :metadata)
+    end
+
+    it 'routes footnotes to trailing regardless of frontmatter presence' do
+      fn = Coradoc::Mirror::Node::Footnotes.new
+      buckets = described_class.partition([frontmatter_with([]), fn])
+      expect(buckets[:trailing]).to eq([fn])
+      expect(buckets[:metadata]).to eq([frontmatter_with([])])
+    end
+  end
+
+  describe 'integration with CoreModelToMirror (partition_structural: true)' do
+    it 'emits frontmatter before preface in the wrapped doc' do
+      core = Coradoc::CoreModel::DocumentElement.new(
+        children: [
+          Coradoc::CoreModel::FrontmatterBlock.new(data: { 'title' => 'T' }),
+          Coradoc::CoreModel::ParagraphBlock.new(content: 'intro'),
+          Coradoc::CoreModel::SectionElement.new(title: 'S', level: 1)
+        ]
+      )
+      mirror = Coradoc::Mirror.transform(core, partition_structural: true)
+      types = mirror.content.map(&:type)
+      expect(types).to eq(%w[frontmatter preface sections])
+    end
+
+    it 'does not include frontmatter inside the preface bucket' do
+      core = Coradoc::CoreModel::DocumentElement.new(
+        children: [
+          Coradoc::CoreModel::FrontmatterBlock.new(data: { 'title' => 'T' }),
+          Coradoc::CoreModel::ParagraphBlock.new(content: 'intro')
+        ]
+      )
+      mirror = Coradoc::Mirror.transform(core, partition_structural: true)
+      preface = mirror.content.find { |n| n.type == 'preface' }
+      expect(preface.content.map(&:type)).to eq(%w[paragraph])
+    end
+  end
+end

--- a/coradoc/lib/coradoc/core_model/frontmatter/frontmatter_value.rb
+++ b/coradoc/lib/coradoc/core_model/frontmatter/frontmatter_value.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    class FrontmatterBlock
+      # Single typed value node in a FrontmatterBlock entry tree.
+      #
+      # Replaces the previous `attribute :data, :hash` representation.
+      # Each value carries a `value_type` discriminator plus one populated
+      # slot matching that type. Container types (`array`, `map`) hold
+      # nested FrontmatterValue / FrontmatterEntry children.
+      #
+      # Supported value types (mirror what YAML.safe_load returns given
+      # the Codec's PERMITTED_CLASSES):
+      #
+      #   scalar  -> string, integer, float, boolean, date, datetime, symbol, nil
+      #   container -> array, map
+      #
+      # Adding a new scalar type is purely additive: declare a new typed
+      # slot and extend the case in Codec::ValueBridge (OCP).
+      class FrontmatterValue < Base
+        SCALAR_TYPES = %w[
+          string integer float boolean date datetime symbol nil
+        ].freeze
+        CONTAINER_TYPES = %w[array map].freeze
+        ALL_TYPES = (SCALAR_TYPES + CONTAINER_TYPES).freeze
+
+        attribute :value_type, :string
+
+        # Scalar slots — exactly one populated, selected by value_type.
+        attribute :string_value, :string
+        attribute :integer_value, :integer
+        attribute :float_value, :float
+        attribute :boolean_value, :boolean
+        attribute :date_value, :date
+        attribute :datetime_value, :date_time
+        attribute :symbol_value, :symbol
+
+        # Container slots — populated when value_type is array/map.
+        attribute :items, FrontmatterValue, collection: true
+        attribute :entries, FrontmatterEntry, collection: true
+
+        # Convenience: return the Ruby-native scalar value for this node,
+        # or nil for containers / nil-typed values. Used by callers that
+        # don't care about the type discriminator.
+        def ruby_value
+          case value_type
+          when 'string'   then string_value
+          when 'integer'  then integer_value
+          when 'float'    then float_value
+          when 'boolean'  then boolean_value
+          when 'date'     then date_value
+          when 'datetime' then datetime_value
+          when 'symbol'   then symbol_value
+          when 'nil'      then nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Two commits delivering the frontmatter read-API that downstream consumers (notably `metanorma.org/convert-adoc.rb`) need to template VitePress/Jekyll frontmatter output without re-parsing source YAML.

### 1. `feat(mirror): expose frontmatter as flat Hash via FrontmatterQuery`

- **Extracts** `ReverseBuilder::FrontmatterTreeToHash` to a top-level `Coradoc::Mirror::FrontmatterTreeToHash` so the tree→Hash translator is shared (DRY/MECE) between the reverse builder and the new query API.
- **Adds** `Coradoc::Mirror::FrontmatterQuery` — public entry point:
  - `FrontmatterQuery.to_hash(mirror_doc)` → flat `Hash{String,Object}`
  - `FrontmatterQuery.has_frontmatter?(mirror_doc)` → boolean
- **Adds** a `:metadata` bucket to `Partitioner` so frontmatter survives the structural partition round-trip without polluting the preface bucket (which would render as visible body). `CoreModelToMirror` prepends the metadata bucket verbatim.
- **Specs**: `frontmatter_query_spec.rb` locks round-trip fidelity (nested maps, arrays, dates, integers, booleans). `partitioner_spec.rb` locks bucketing rules.

### 2. `feat(core_model): draft FrontmatterValue typed discriminator class`

Draft of the typed value node intended to replace `FrontmatterBlock`'s `attribute :data, :hash` (which violates the project's no-hashes-in-models rule). Discriminated union: one `value_type` slot selects which scalar field is populated; `array`/`map` types hold nested children.

**Not yet autoloaded or wired in.** Lands now so the follow-up migration has the type definition in place. Adding a new scalar type is purely additive (declare a slot, extend the case in `Codec::ValueBridge`).

## Tests

- `coradoc-mirror` suite: 194 examples, 0 failures.
- `coradoc` suite: 1035 examples, 0 failures.
- All other gem suites still green.

## Why this shape

- **One PR** because both commits serve the same consumer (site generators reading frontmatter).
- **Two commits** because they touch different gems and the second is exploratory/draft work that future migrations will build on.
- The partitioner metadata bucket is required for `FrontmatterQuery` to locate frontmatter in docs that opt into `partition_structural: true`.