### PR TITLE
Fix adoc/mirror pipeline bugs (dd dup, // leak, dl shape, img alt, xref escape, literal ws)

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/attribute_list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/attribute_list.rb
@@ -44,7 +44,7 @@ module Coradoc
         end
 
         def positional_value_unquoted
-          match['a-zA-Z0-9_\-%.'].repeat(1)
+          match('[^\]\s,]').repeat(1) >> space.absent?
         end
 
         def positional_value_single_quote

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/citation.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/citation.rb
@@ -14,6 +14,14 @@ module Coradoc
             str('>>')
           ).as(:cross_reference)
         end
+
+        # AsciiDoc escape: `\<<` produces the literal text `<<` without
+        # firing the cross-reference rule. Without this, documentation that
+        # shows AsciiDoc xref syntax as a literal example gets rewritten
+        # into a broken link to a non-existent anchor.
+        def escaped_xref
+          str('\\') >> str('<<').as(:text)
+        end
       end
     end
   end

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
@@ -158,7 +158,8 @@ module Coradoc
             str('+++').present? |
             term_type.present? |
             str('footnote').present? |
-            stem_type.present?
+            stem_type.present? |
+            str('\\<<').present?
         end
 
         def inline
@@ -175,6 +176,7 @@ module Coradoc
             superscript |
             subscript |
             attribute_reference |
+            escaped_xref |
             cross_reference |
             term_inline |
             term_inline2 |
@@ -188,8 +190,12 @@ module Coradoc
         end
 
         def text_unformatted
-          # line_not_text? >>
-          (inline.absent? >>
+          # `str('\\<<').absent?` stops text from consuming the backslash of
+          # an escaped xref (`\<<`). Without this guard, the `\` is taken as
+          # plain text, the `<<` re-enters cross_reference, and the literal
+          # escape is destroyed.
+          (str('\\<<').absent? >>
+            inline.absent? >>
             match("[^\n]")
           ).repeat(1)
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
@@ -130,12 +130,18 @@ module Coradoc
         end
 
         def dlist_item(_delimiter = nil)
-          (((dlist_term.as(:terms).repeat(1) >> line_ending >>
-            empty_line.repeat(0)).repeat(1) >>
-            dlist_definition) |
-            (dlist_term.repeat(1, 1).as(:terms) >> space >>
-              dlist_definition)
-          ).as(:definition_list_item)
+          # Both forms below produce the same AST shape:
+          #   {terms: [<dlist_term>, ...], definition: <text>}
+          # so the transformer's definition_list_item rule matches uniformly.
+          #
+          # Multi-line form: one or more term-lines (`term::` + newline +
+          # optional blank lines), then the definition on its own line(s).
+          # Single-line form: one term + inline space + definition.
+          term_line = dlist_term >> line_ending >> empty_line.repeat(0)
+
+          ((term_line.repeat(1).as(:terms) >> dlist_definition) |
+           (dlist_term.repeat(1, 1).as(:terms) >> space >>
+             dlist_definition)).as(:definition_list_item)
         end
       end
     end

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/paragraph.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/paragraph.rb
@@ -13,7 +13,9 @@ module Coradoc
             list_prefix.absent? >>
             list_continuation.absent? >>
             element_id.absent? >>
-            section_prefix.absent?
+            section_prefix.absent? >>
+            comment_line.absent? >>
+            tag.absent?
         end
 
         # NOTE: many_breaks parameter has three states for different parsing contexts:

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
@@ -16,7 +16,12 @@ module Coradoc
               )
             end
 
-            def transform_source_block(block)
+            # Verbatim blocks (source, listing, literal, pass) must round-trip
+            # their body byte-for-byte. Each source line becomes one content
+            # line; we join with "\n" so whitespace, indentation, and blank
+            # lines are preserved. Treating these as paragraphs would collapse
+            # whitespace and join consecutive lines into a single flowing text.
+            def transform_verbatim_block(block, klass)
               non_break_lines = Array(block.lines).reject do |line|
                 line.is_a?(Coradoc::AsciiDoc::Model::LineBreak) ||
                   line.is_a?(Coradoc::AsciiDoc::Model::Break::PageBreak)
@@ -25,14 +30,24 @@ module Coradoc
                 ToCoreModel.extract_text_content(line)
               end.join("\n")
 
-              language = ToCoreModel.extract_block_language(block)
-
-              Coradoc::CoreModel::SourceBlock.new(
+              klass.new(
                 id: block.id,
                 title: ToCoreModel.extract_title_text(block.title),
                 content: content_lines,
-                language: language
+                language: ToCoreModel.extract_block_language(block)
               )
+            end
+
+            def transform_source_block(block)
+              transform_verbatim_block(block, Coradoc::CoreModel::SourceBlock)
+            end
+
+            def transform_literal_block(block)
+              transform_verbatim_block(block, Coradoc::CoreModel::LiteralBlock)
+            end
+
+            def transform_pass_block(block)
+              transform_verbatim_block(block, Coradoc::CoreModel::PassBlock)
             end
 
             # Open blocks (`--`) are generic containers. AsciiDoc allows
@@ -86,22 +101,11 @@ module Coradoc
             end
 
             def transform_listing_from_open(block)
-              content_lines = Array(block.lines).map { |line| ToCoreModel.extract_text_content(line) }.join("\n")
-              Coradoc::CoreModel::ListingBlock.new(
-                id: block.id,
-                title: ToCoreModel.extract_title_text(block.title),
-                content: content_lines,
-                language: ToCoreModel.extract_block_language(block)
-              )
+              transform_verbatim_block(block, Coradoc::CoreModel::ListingBlock)
             end
 
             def transform_literal_from_open(block)
-              content_lines = Array(block.lines).map { |line| ToCoreModel.extract_text_content(line) }.join("\n")
-              Coradoc::CoreModel::LiteralBlock.new(
-                id: block.id,
-                title: ToCoreModel.extract_title_text(block.title),
-                content: content_lines
-              )
+              transform_verbatim_block(block, Coradoc::CoreModel::LiteralBlock)
             end
 
             def transform_block(block, semantic_type_or_delimiter)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
@@ -50,9 +50,7 @@ module Coradoc
             {
               Coradoc::AsciiDoc::Model::Block::Quote => Coradoc::CoreModel::QuoteBlock,
               Coradoc::AsciiDoc::Model::Block::Example => Coradoc::CoreModel::ExampleBlock,
-              Coradoc::AsciiDoc::Model::Block::Side => Coradoc::CoreModel::SidebarBlock,
-              Coradoc::AsciiDoc::Model::Block::Literal => Coradoc::CoreModel::LiteralBlock,
-              Coradoc::AsciiDoc::Model::Block::Pass => Coradoc::CoreModel::PassBlock
+              Coradoc::AsciiDoc::Model::Block::Side => Coradoc::CoreModel::SidebarBlock
             }.each do |block_class, core_model_class|
               Registry.register_with_priority(
                 block_class,
@@ -60,6 +58,22 @@ module Coradoc
                 priority: 10
               )
             end
+
+            # Verbatim typed blocks (literal, pass) preserve their body
+            # byte-for-byte — same line-joining strategy as source/listing.
+            # Routing them through `transform_typed_block` would collapse
+            # intra-block whitespace and join consecutive lines as paragraphs.
+            Registry.register_with_priority(
+              Coradoc::AsciiDoc::Model::Block::Literal,
+              ->(model) { Blk.transform_literal_block(model) },
+              priority: 10
+            )
+
+            Registry.register_with_priority(
+              Coradoc::AsciiDoc::Model::Block::Pass,
+              ->(model) { Blk.transform_pass_block(model) },
+              priority: 10
+            )
 
             Registry.register_with_priority(
               Coradoc::AsciiDoc::Model::Block::Open,

--- a/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
@@ -456,6 +456,103 @@ RSpec.describe 'Integration pipeline fixes' do
     end
   end
 
+  # Regression: previously the `line_not_text?` predicate did not reject
+  # `//`-prefixed lines, so the paragraph parser consumed `// tag::x[]`
+  # and `// end::x[]` markers as plain text, producing phantom paragraphs
+  # containing the tag markup.
+  describe 'Fix 15: // comments and tag markers do not leak into paragraphs' do
+    it 'drops // tag:: and // end:: lines instead of treating them as paragraphs' do
+      adoc = <<~ADOC
+        Before.
+
+        // tag::tutorial[]
+        Content.
+        // end::tutorial[]
+
+        After.
+      ADOC
+
+      core = parse_to_core(adoc)
+      paragraphs = core.children.select { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      texts = paragraphs.map { |p| p.content.to_s.strip }
+
+      expect(texts).to eq(%w[Before. Content. After.])
+      expect(texts).not_to include(match(/tag::/))
+      expect(texts).not_to include(match(/end::/))
+    end
+  end
+
+  # Regression: `\<<` is the AsciiDoc escape for a literal `<<`. Without
+  # a dedicated escape rule, the backslash was consumed as plain text and
+  # the `<<` re-entered the cross-reference production, producing a link
+  # to a non-existent anchor with garbage in the link text.
+  describe 'Fix 16: \<< escape produces literal << without firing xref' do
+    it 'does not produce a CrossReference for \\<<' do
+      adoc = "Shows syntax: \\<<formulaB-1>> as text.\n"
+
+      core = parse_to_core(adoc)
+      inline = find_all_xrefs(core)
+      expect(inline).to be_empty
+
+      para = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      expect(para.content.to_s).to include('<<')
+    end
+  end
+
+  # Regression: literal blocks (`....`) preserve their body byte-for-byte.
+  # Previously they were routed through the paragraph-grouping code path,
+  # which collapsed intra-block whitespace, joined consecutive non-blank
+  # lines, and stripped leading indentation.
+  describe 'Fix 17: literal block preserves whitespace and line structure' do
+    it 'keeps newlines and indentation intact across the literal body' do
+      adoc = <<~ADOC
+        ....
+        <clause id="test">
+          <p>Content</p>
+        </clause>
+        ....
+      ADOC
+
+      core = parse_to_core(adoc)
+      literal = core.children.find { |c| c.is_a?(Coradoc::CoreModel::LiteralBlock) }
+      expect(literal).not_to be_nil
+      expect(literal.content).to eq("<clause id=\"test\">\n  <p>Content</p>\n</clause>")
+    end
+  end
+
+  # Regression: `image::file[Alt text]` requires the attribute-list parser
+  # to accept spaces in the unquoted positional value. Previously the
+  # charset rejected spaces, the block-image parser failed, and the line
+  # fell through to paragraph parsing where `image:` matched as an inline
+  # macro with a corrupted path.
+  describe 'Fix 18: image:: block macro accepts alt text with spaces' do
+    it 'parses as a top-level image with src and alt preserved' do
+      adoc = <<~ADOC
+        Para before.
+
+        image::foo.png[Alt text]
+
+        Para after.
+      ADOC
+
+      core = parse_to_core(adoc)
+      images = []
+      gather = lambda do |el|
+        return unless el.is_a?(Coradoc::CoreModel::Base)
+
+        images << el if el.is_a?(Coradoc::CoreModel::Image)
+        if el.class.attributes.key?(:children) && el.children
+          el.children.each { |c| gather.call(c) }
+        end
+      end
+      gather.call(core)
+
+      image = images.find { |i| i.src == 'foo.png' }
+      expect(image).not_to be_nil
+      expect(image.alt).to eq('Alt text')
+    end
+  end
+
   private
 
   def find_first_table(el)

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/definition_list_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/definition_list_spec.rb
@@ -182,4 +182,28 @@ RSpec.describe 'AsciiDoc definition list parsing' do
       expect(reparsed.attrs.to_adoc(show_empty: false)).to eq('[%metadata]')
     end
   end
+
+  # Regression: previously the multi-line form (`term::\ndef`) produced a
+  # different AST shape than the single-line form (`term:: def`), and the
+  # transformer's fallback rule treated the multi-line shape as an array
+  # of separate term/definition hashes — losing the term entirely.
+  describe 'multi-line definition list form' do
+    it 'preserves both term and definition for multi-line items' do
+      core = parse_to_core(<<~ADOC)
+        Software::
+        The Metanorma toolchain.
+
+        Document metamodels::
+        Provides document structure.
+      ADOC
+
+      dl = core.children.find { |c| c.is_a?(Coradoc::CoreModel::DefinitionList) }
+      expect(dl).not_to be_nil
+      expect(dl.items.length).to eq(2)
+      expect(dl.items[0].term).to eq('Software')
+      expect(dl.items[0].definitions.first).to eq('The Metanorma toolchain.')
+      expect(dl.items[1].term).to eq('Document metamodels')
+      expect(dl.items[1].definitions.first).to eq('Provides document structure.')
+    end
+  end
 end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/definition_list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/definition_list.rb
@@ -43,24 +43,26 @@ module Coradoc
           end
 
           def build_description(item, context)
-            definitions = item.definitions
-            return nil unless definitions && !definitions.empty?
-
-            desc_nodes = definitions.map do |defn|
-              context.text_node(defn.to_s)
-            end
-
-            def_children = item.definition_children if item.is_a?(CoreModel::DefinitionItem)
-            if def_children && !def_children.empty?
-              def_children.each do |child|
-                nodes = Handlers::Inline.process_child(child, context)
-                desc_nodes.concat(Array(nodes)) if nodes && !nodes.empty?
-              end
-            end
-
+            desc_nodes = description_nodes(item, context)
             return nil if desc_nodes.empty?
 
             Node::DefinitionDescription.new(content: desc_nodes)
+          end
+
+          # Emit one text node per source — never both. Rich
+          # definition_children (inline nodes) win over plain definitions
+          # (strings) because they preserve formatting; falling back to
+          # the plain string keeps this handler robust for DefinitionItem
+          # instances populated by paths that don't build inline children.
+          def description_nodes(item, context)
+            unless item.is_a?(CoreModel::DefinitionItem)
+              return Array(item.definitions).map { |defn| context.text_node(defn.to_s) }
+            end
+
+            children = item.definition_children
+            return Array(item.definitions).map { |defn| context.text_node(defn.to_s) } if children.empty?
+
+            children.flat_map { |child| Handlers::Inline.process_child(child, context) }
           end
         end
       end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
@@ -26,7 +26,10 @@ module Coradoc
     # full before any caller references it. Mirror-level mark dispatch
     # lives in MarkReverseBuilder (mark_reverse_builder.rb).
     module ReverseBuilder
-      REGISTRY = {}.freeze
+      # Not frozen: subclasses call `register` from their class body at
+      # load time, and `registers` may fire late via autoload. Freezing
+      # here breaks the first mirror-to-core round-trip after load.
+      REGISTRY = {}
 
       module_function
 

--- a/coradoc-mirror/spec/coradoc/mirror/core_model_to_mirror_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/core_model_to_mirror_spec.rb
@@ -257,6 +257,32 @@ RSpec.describe Coradoc::Mirror::CoreModelToMirror do
       expect(mirror_dl.content.first).to be_a(Coradoc::Mirror::Node::DefinitionTerm)
       expect(mirror_dl.content.last).to be_a(Coradoc::Mirror::Node::DefinitionDescription)
     end
+
+    # Regression: previously the handler emitted dd text twice when both
+    # `definitions` and `definition_children` were populated (the latter is
+    # built from the former by ToCoreModel). Each definition source must
+    # produce exactly one text node — never both.
+    it 'does not duplicate definition description text from rich children' do
+      text_inline = Coradoc::CoreModel::InlineElement.new(
+        format_type: 'text', content: 'Bathymetric Publications'
+      )
+      dl = Coradoc::CoreModel::DefinitionList.new(
+        items: [
+          Coradoc::CoreModel::DefinitionItem.new(
+            term: 'B-series',
+            definitions: ['Bathymetric Publications'],
+            definition_children: [text_inline]
+          )
+        ]
+      )
+      doc = make_document(children: [dl])
+      result = transformer.call(doc)
+
+      dd = result.content.first.content.last
+      expect(dd).to be_a(Coradoc::Mirror::Node::DefinitionDescription)
+      expect(dd.content.size).to eq(1)
+      expect(dd.content.first.text).to eq('Bathymetric Publications')
+    end
   end
 
   describe 'table transformation' do


### PR DESCRIPTION
## Summary

Bundles six bug fixes discovered via the BUG-*.md reports plus one pre-existing regression that was blocking the coradoc integration spec suite.

## Fixes

- **`fix(mirror): emit one text node per definition description source`**
  DefinitionList handler iterated both `item.definitions` and `item.definition_children`, producing two text nodes for the same content. Pick one source via a `description_nodes` helper (rich preferred).
- **`fix(adoc): reject // comments and tag markers from paragraph lines`**
  `line_not_text?` didn't reject `//`-prefixed lines, so `// tag::x[]` and `// end::x[]` were absorbed as paragraph text. Added `comment_line.absent?` and `tag.absent?`.
- **`fix(adoc): normalize multi-line definition list AST shape`**
  Single-line `term:: def` and multi-line `term::\ndef` produced different AST shapes; the transformer's fallback treated the multi-line shape as an array and the term was lost. Both forms now produce the same shape.
- **`fix(adoc): accept spaces in unquoted positional attribute values`**
  `positional_value_unquoted` rejected spaces, so `[Alt text]` failed. Block image parser fell through to paragraph, producing a corrupted inline-image match. Switched to a negated charset `[^\]\s,]` plus trailing `space.absent?`.
- **`fix(adoc): make \<< produce literal << without firing xref`**
  Added `escaped_xref` rule placed before `cross_reference` in `inline`, registered in `inline_chars?`, and added `str('\\<<').absent?` guard in `text_unformatted` so the backslash isn't consumed in isolation.
- **`fix(adoc): preserve whitespace in literal and pass blocks`**
  LiteralBlock and PassBlock were routed through `transform_typed_block`, which paragraph-groups lines and collapses intra-block whitespace. Extracted `transform_verbatim_block` helper and routed Literal, Pass, and the open-block literal/listing casts through it.
- **`fix(mirror): allow ReverseBuilder REGISTRY to receive late registrations`**
  `REGISTRY = {}.freeze` broke the first mirror-to-core round-trip when a Builder was autoloaded after the parent module loaded. Dropped the `.freeze`. Fixes 5 pre-existing failures in `metanorma_org_fixtures_spec.rb` and `frontmatter_cross_format_spec.rb`.

## Test coverage

- New regression spec for mirror dd deduplication (`core_model_to_mirror_spec.rb`)
- New regression spec for multi-line dl (`definition_list_spec.rb`)
- Four new integration regression specs (`integration_pipeline_spec.rb`, Fixes 15-18)

## Test results

- coradoc: **1035 examples, 0 failures** (5 previously-failing specs now green)
- coradoc-adoc: **960 examples, 0 failures**, 5 pending
- coradoc-mirror: **195 examples, 0 failures**
- coradoc-html: **616 examples, 0 failures**
- coradoc-markdown: **825 examples, 0 failures**, 1 pending
- coradoc-docx: 10 pre-existing failures (missing `office_theme.xml` in `uniword` gem - unrelated to this PR)
