### PR TITLE
fix(adoc): unwrap image:: block from paragraph + accept Markdown dash lists

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/attribute_list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/attribute_list.rb
@@ -44,7 +44,7 @@ module Coradoc
         end
 
         def positional_value_unquoted
-          match('[^\]\s,]').repeat(1) >> space.absent?
+          match('[^\],]').repeat(1)
         end
 
         def positional_value_single_quote

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
@@ -118,6 +118,7 @@ module Coradoc
 
         def inline_image
           (str('image:').present? >> str('image:') >>
+            str(':').absent? >>
             match('[A-Za-z0-9_.\\-:/&?=+,%#~;]+').repeat(1).as(:path) >>
             (str('[') >> match('[^\\]]').repeat(1).as(:text) >> str(']')).maybe
           ).as(:inline_image)

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
@@ -72,9 +72,33 @@ module Coradoc
         def ulist_marker(nesting_level = 1)
           line_start? >>
             (nesting_level > 1 ? literal_space.maybe : str('')) >>
-            str('*' * nesting_level) >>
+            (
+              asterisk_marker(nesting_level) |
+              dash_marker(nesting_level)
+            )
+        end
+
+        # AsciiDoc standard bullet: `*`, `**`, `***`, ... matching the
+        # nesting level. Excludes table delimiters (`|===`) and deeper
+        # asterisk runs that belong to a sibling level.
+        def asterisk_marker(nesting_level)
+          str('*' * nesting_level) >>
             str('*').absent? >>
             str('===').absent?
+        end
+
+        # Markdown-style dash bullet: `-`. Accepted only at the top level
+        # because Markdown nests via indentation rather than multi-char
+        # markers — deeper levels stay on the AsciiDoc `*` form. Guards
+        # exclude em-dashes (`--`), delimited-block fences (`----`),
+        # and negative-number runs (`-1`, `-42`) which are not list
+        # markers in any common dialect.
+        def dash_marker(nesting_level)
+          return match('').absent? unless nesting_level == 1
+
+          str('-') >>
+            str('-').absent? >>
+            match('[0-9]').absent?
         end
 
         def ulist_item(nesting_level = 1)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
@@ -128,7 +128,7 @@ module Coradoc
 
             def transform_typed_block(block, klass, extra_attrs = {})
               raw_lines = Array(block.lines)
-              has_nested_blocks = raw_lines.any?(Coradoc::AsciiDoc::Model::Block::Core)
+              has_nested_blocks = raw_lines.any? { |line| block_level_child?(line) }
 
               if has_nested_blocks
                 children = raw_lines.reject do |line|
@@ -194,6 +194,17 @@ module Coradoc
               end
               groups << current if current.any?
               groups
+            end
+
+            # A line that should be emitted as a direct child of the
+            # enclosing block rather than joined into a paragraph sibling.
+            # The AsciiDoc model layer declares level via `block_level?`
+            # (true for Block::Core delimited blocks, BlockImage, Table,
+            # List::Core, Section, CommentBlock, Attached). Inline content
+            # (String, TextElement, LineBreak, PageBreak) returns false and
+            # stays inside paragraphs.
+            def block_level_child?(line)
+              line.is_a?(Coradoc::AsciiDoc::Model::Base) && line.block_level?
             end
           end
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/other_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/other_transformer.rb
@@ -28,13 +28,18 @@ module Coradoc
               src = image.src.to_s
               src = src[1..] if src.start_with?(':')
               positional = image.attributes&.positional || []
-              alt = positional.first&.value&.to_s
+              positional_alt = positional.first&.value&.to_s || ''
               caption = positional[1]&.value&.to_s
+              title = image.title&.to_s
+              # AsciiDoc block-title (`.Caption`) is semantically a caption,
+              # but for compatibility with the existing pipeline that treated
+              # it as alt when no positional alt was supplied, fall back to it.
+              alt = positional_alt.empty? ? title : positional_alt
               Coradoc::CoreModel::Image.new(
                 src: src,
                 alt: alt,
                 caption: caption,
-                title: image.title&.to_s,
+                title: title,
                 width: image.attributes&.[]('width'),
                 height: image.attributes&.[]('height')
               )

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/other_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/other_transformer.rb
@@ -27,9 +27,14 @@ module Coradoc
             def transform_image(image)
               src = image.src.to_s
               src = src[1..] if src.start_with?(':')
+              positional = image.attributes&.positional || []
+              alt = positional.first&.value&.to_s
+              caption = positional[1]&.value&.to_s
               Coradoc::CoreModel::Image.new(
                 src: src,
-                alt: image.title&.to_s,
+                alt: alt,
+                caption: caption,
+                title: image.title&.to_s,
                 width: image.attributes&.[]('width'),
                 height: image.attributes&.[]('height')
               )

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
@@ -46,7 +46,7 @@ module Coradoc
               id = block_image[:id]
               title = block_image[:title]
               path = block_image[:path]
-              attrs = AttributeListNormalizer.coerce(block_image[:attribute_list])
+              attrs = AttributeListNormalizer.coerce(block_image[:attribute_list_macro])
               Model::Image::BlockImage.new(
                 title: title,
                 id: id,

--- a/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
@@ -591,6 +591,58 @@ RSpec.describe 'Integration pipeline fixes' do
     end
   end
 
+  describe 'Fix 19: Markdown-style dash bullet lists (- item)' do
+    it 'parses bare dash list as a bullet_list' do
+      adoc = "- Item 1\n- Item 2\n- Item 3\n"
+      core = parse_to_core(adoc)
+
+      list = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      expect(list).not_to be_nil
+      expect(list.marker_type).to eq('unordered')
+      expect(list.items.length).to eq(3)
+      expect(list.items.map { |i| i.content }).to eq(['Item 1', 'Item 2', 'Item 3'])
+    end
+
+    it 'parses dash list preceded by a paragraph' do
+      adoc = "Intro.\n\n- A\n- B\n"
+      core = parse_to_core(adoc)
+
+      paras = core.children.select { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      list = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+
+      expect(paras.length).to eq(1)
+      expect(list).not_to be_nil
+      expect(list.items.length).to eq(2)
+    end
+
+    it 'does not confuse em-dash (--) with a list marker' do
+      adoc = "Text -- with em-dash.\n"
+      core = parse_to_core(adoc)
+
+      list = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      expect(list).to be_nil
+
+      para = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      expect(para.content.to_s).to include('--')
+    end
+
+    it 'does not confuse negative number (-1) with a list marker' do
+      adoc = "-1 is negative.\n"
+      core = parse_to_core(adoc)
+
+      list = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      expect(list).to be_nil
+    end
+
+    it 'does not confuse horizontal rule (---) with a list marker' do
+      adoc = "Before.\n\n---\n\nAfter.\n"
+      core = parse_to_core(adoc)
+
+      list = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      expect(list).to be_nil
+    end
+  end
+
   private
 
   def find_first_table(el)

--- a/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
@@ -536,20 +536,58 @@ RSpec.describe 'Integration pipeline fixes' do
       ADOC
 
       core = parse_to_core(adoc)
-      images = []
-      gather = lambda do |el|
-        return unless el.is_a?(Coradoc::CoreModel::Base)
 
-        images << el if el.is_a?(Coradoc::CoreModel::Image)
-        if el.class.attributes.key?(:children) && el.children
-          el.children.each { |c| gather.call(c) }
-        end
+      # Image must be a direct child of the document (block sibling of the
+      # paragraphs), not nested inside a paragraph. Walking the full tree
+      # would mask Bug D — the image was previously a child of a
+      # ParagraphBlock, which produced invalid `<p><figure>` HTML.
+      top_level_image = core.children.find do |c|
+        c.is_a?(Coradoc::CoreModel::Image) && c.src == 'foo.png'
       end
-      gather.call(core)
+      expect(top_level_image).not_to be_nil
+      expect(top_level_image.alt).to eq('Alt text')
 
-      image = images.find { |i| i.src == 'foo.png' }
+      # And the surrounding siblings must be paragraphs, not a paragraph
+      # that wraps the image.
+      paragraphs = core.children.select { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      expect(paragraphs.length).to eq(2)
+      paragraphs.each do |para|
+        para.children.each { |child| expect(child).not_to be_a(Coradoc::CoreModel::Image) }
+      end
+    end
+
+    it 'parses caption from second positional attribute' do
+      adoc = <<~ADOC
+        image::diagram.png[Architecture, Figure 1]
+      ADOC
+
+      core = parse_to_core(adoc)
+      image = core.children.find { |c| c.is_a?(Coradoc::CoreModel::Image) }
+
       expect(image).not_to be_nil
-      expect(image.alt).to eq('Alt text')
+      expect(image.src).to eq('diagram.png')
+      expect(image.alt).to eq('Architecture')
+      expect(image.caption).to eq('Figure 1')
+    end
+
+    it 'distinguishes image:: (block) from image: (inline)' do
+      adoc = <<~ADOC
+        Click image:icon.png[magnify] to zoom.
+
+        image::photo.png[Photo]
+      ADOC
+
+      core = parse_to_core(adoc)
+
+      # Block image: direct child of document
+      block_image = core.children.find { |c| c.is_a?(Coradoc::CoreModel::Image) && c.src == 'photo.png' }
+      expect(block_image).not_to be_nil
+      expect(block_image.alt).to eq('Photo')
+
+      # Inline image: nested inside a paragraph
+      para = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      inline_image = para&.children&.find { |c| c.is_a?(Coradoc::CoreModel::Image) && c.src == 'icon.png' }
+      expect(inline_image).not_to be_nil
     end
   end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
@@ -643,6 +643,57 @@ RSpec.describe 'Integration pipeline fixes' do
     end
   end
 
+  describe 'Fix 20: image:: block macro unwrapped from paragraph inside typed blocks' do
+    it 'emits image:: inside ==== example block as a direct child' do
+      adoc = "====\nimage::foo.png[Alt text]\n====\n"
+      core = parse_to_core(adoc)
+
+      example = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ExampleBlock) }
+      expect(example).not_to be_nil
+
+      expect(example.children.any? { |c| c.is_a?(Coradoc::CoreModel::Image) }).to eq(true)
+      expect(example.children.none? { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }).to eq(true)
+
+      image = example.children.find { |c| c.is_a?(Coradoc::CoreModel::Image) }
+      expect(image.src).to eq('foo.png')
+      expect(image.alt).to eq('Alt text')
+    end
+
+    it 'emits image:: inside -- open block as a direct child' do
+      adoc = "--\nimage::inside-open.jpg[]\n--\n"
+      core = parse_to_core(adoc)
+
+      open_block = core.children.find { |c| c.is_a?(Coradoc::CoreModel::OpenBlock) }
+      expect(open_block).not_to be_nil
+
+      expect(open_block.children.any? { |c| c.is_a?(Coradoc::CoreModel::Image) }).to eq(true)
+      expect(open_block.children.none? { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }).to eq(true)
+    end
+
+    it 'preserves alt and caption from positional attributes' do
+      adoc = "====\nimage::diagram.png[Diagram, Figure 1]\n====\n"
+      core = parse_to_core(adoc)
+
+      example = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ExampleBlock) }
+      image = example.children.find { |c| c.is_a?(Coradoc::CoreModel::Image) }
+
+      expect(image.alt).to eq('Diagram')
+      expect(image.caption).to eq('Figure 1')
+    end
+
+    it 'round-trips through mirror_json with image as direct child of example' do
+      require "coradoc-mirror"
+
+      adoc = "====\nimage::foo.png[Alt text]\n====\n"
+      core = parse_to_core(adoc)
+      json = JSON.parse(Coradoc.serialize(core, to: :mirror_json))
+
+      example = json["content"].find { |n| n["type"] == "example" }
+      expect(example["content"].map { |n| n["type"] }).to eq(["image"])
+      expect(example["content"].none? { |n| n["type"] == "paragraph" }).to eq(true)
+    end
+  end
+
   private
 
   def find_first_table(el)

--- a/coradoc-adoc/spec/coradoc/asciidoc/nested_block_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/nested_block_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe 'AsciiDoc nested delimited blocks' do
     core = parse_to_core(adoc)
     open_block = core.children.first
     expect(open_block).to be_a(Coradoc::CoreModel::OpenBlock)
-    paragraph = open_block.children.first
-    expect(paragraph.children.map { |c| c.class.name }).to include('Coradoc::CoreModel::Image')
+    image = open_block.children.first
+    expect(image).to be_a(Coradoc::CoreModel::Image)
+    expect(image.src).to eq('inside-open.jpg')
   end
 end


### PR DESCRIPTION
## Summary

Three AsciiDoc parser bugs from `BUG-mirror-json-pipeline.md` and `BUG-markdown-dash-lists.md`, all fixed in this PR.

## Bug D: `image::` block wrapped inside `<paragraph>`

Three coupled root causes:

1. **`attribute_list.rb`**: `positional_value_unquoted` rejected spaces (`[^\]\s,]`), so `[Alt text]` failed to parse. `block_image` fell through to `paragraph` parsing, where `image::foo.png[Alt text]` was consumed by `inline_image:` with a corrupted path `:foo.png`. The previous "fix" for this rule (commit `c934c9a`) claimed to allow spaces but the negated charset still excluded `\s`.

2. **`inline.rb`**: `inline_image` did not exclude a second colon, so the block form `image::` could match `inline_image` whenever `block_image` failed. Added `str(':').absent?` after `image:` as defense in depth.

3. **`block_rules.rb`**: the block-image transformer looked up `block_image[:attribute_list]`, but the parser captures the macro attribute list under `:attribute_list_macro` (because `block_image` in `text.rb` calls `attribute_list(:attribute_list_macro)`). The attributes were silently dropped.

4. **`other_transformer.rb`**: `transform_image` sourced `alt` from `image.title` (block-level title), not from the first positional attribute. AsciiDoc puts alt in `[alt]`, caption in `[alt, caption]`; the transformer now extracts both positional slots, with the block title preserved as a fallback for the existing `.Caption\nimage::logo.png[]` flow.

## Bug: Markdown-style dash bullet lists (`- item`)

The parser only recognized `*` as a bullet marker. The metanorma.org corpus has 165 `.adoc` files using Markdown-style `-`, which all collapsed into single paragraphs with literal `-` text.

Refactored `ulist_marker` to delegate to two marker rules:
- `asterisk_marker` (existing): `*`, `**`, ... matching nesting level
- `dash_marker` (new): single `-` at nesting level 1 only

Markdown nests via indentation rather than multi-char markers, so deeper levels stay on the AsciiDoc `*` form. Guards exclude `--` (em-dash), `---` (horizontal rule / delimited block fence), and `-1` / `-42` (negative numbers).

## Test coverage

- `Fix 18` (extended): image is a direct child of the document (not nested in a paragraph); surrounding paragraphs do not contain image children; caption extracted from second positional; `image::` vs `image:` distinguished.
- `Fix 19` (new): bare dash list parses as `bullet_list`; dash list preceded by a paragraph parses correctly; `--`, `-1`, `---` are NOT recognized as list markers.

## Verification

All gem specs pass: coradoc 1035/1035, coradoc-adoc 967/967 (5 pending), coradoc-mirror 195/195, coradoc-markdown 616/616, coradoc-html 825/825. (coradoc-docx has 10 pre-existing environmental failures unrelated to these changes.)
