### PR TITLE
fix(adoc): accept Markdown-style triple-backtick fenced code blocks

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/block.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/block.rb
@@ -22,7 +22,8 @@ module Coradoc
         # - "|" separates cells within the table
 
         def block(n_deep = 3)
-          (example_block(n_deep) |
+          (markdown_code_block(n_deep) |
+          example_block(n_deep) |
           sidebar_block(n_deep) |
           source_block(n_deep) |
           quote_block(n_deep) |
@@ -60,6 +61,38 @@ module Coradoc
           block_style_exact(n_deep, '-', 2)
         end
 
+        # Markdown-style fenced code block: triple-backtick (or longer)
+        # fence with an optional language tag on the opening line. Behaves
+        # as a verbatim source block — same model as `[source,lang]\n----`.
+        # Pragmatic permissiveness for content that originates from (or is
+        # edited alongside) Markdown; not standard AsciiDoc but widely
+        # accepted (GitHub's renderer treats ``` as a listing delimiter).
+        def markdown_code_block(n_deep = 3)
+          capture_key = :"md_fence_#{n_deep}"
+          opening_fence = str('`').repeat(3).capture(capture_key)
+          closing_fence = dynamic do |_s, c|
+            str(c.captures[capture_key].to_s.strip)
+          end
+          language = (space? >> match("[A-Za-z0-9_+.-]").repeat(1).as(:language)).maybe
+
+          block_content_with_closing = dynamic do |_s, c|
+            fence_str = c.captures[capture_key].to_s.strip
+            closing_pattern = closing_fence >> space? >> newline
+
+            content = text_line(false, unguarded: true, verbatim: true) |
+                        empty_line.as(:line_break)
+
+            (closing_pattern.absent? >> content).repeat(1)
+          end
+
+          block_header >>
+            line_start? >>
+            opening_fence.as(:delimiter) >> language >> newline >>
+            block_content_with_closing.as(:lines) >>
+            line_start? >>
+            closing_fence >> space? >> newline
+        end
+
         def block_title
           (line_start? >> block_delimiter.absent?) >>
             str('.') >> space.absent? >> text.as(:title) >> newline
@@ -80,8 +113,9 @@ module Coradoc
           c.repeat(1)
         end
 
-        # Block delimiter: 4+ identical characters (or 2 for open block)
-        # Used by paragraph.rb to reject lines that look like block delimiters.
+        # Block delimiter: 4+ identical characters, or 2 dashes for open
+        # blocks, or 3+ backticks for Markdown-style code fences. Used by
+        # paragraph.rb to reject lines that look like block delimiters.
         # NOTE: repeat(4,) means 4 or more (not exactly 4)
         def block_delimiter
           line_start? >>
@@ -91,7 +125,8 @@ module Coradoc
               str('+') |
               str('.') |
               str('-')).repeat(4) | # 4+ characters for most blocks
-              str('-').repeat(2, 2)) >> # Exactly 2 for open block
+              str('-').repeat(2, 2) | # Exactly 2 for open block
+              str('`').repeat(3)) >> # 3+ for Markdown code fences
             newline
         end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers.rb
@@ -10,6 +10,7 @@ module Coradoc
         autoload :InlineTransformer, "#{__dir__}/element_transformers/inline_transformer"
         autoload :TableTransformer, "#{__dir__}/element_transformers/table_transformer"
         autoload :OtherTransformer, "#{__dir__}/element_transformers/other_transformer"
+        autoload :IncludeTransformer, "#{__dir__}/element_transformers/include_transformer"
       end
     end
   end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/include_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/include_transformer.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module AsciiDoc
+    module Transform
+      module ElementTransformers
+        # Transforms AsciiDoc {Model::Include} into the canonical
+        # {CoreModel::Include}. The CoreModel node carries the parsed
+        # options as a typed {CoreModel::IncludeOptions} instance plus
+        # the raw bracket body for verbatim round-trip.
+        class IncludeTransformer
+          class << self
+            # @param model [Coradoc::AsciiDoc::Model::Include]
+            # @return [Coradoc::CoreModel::Include]
+            def transform_include(model)
+              options_hash = extract_options_hash(model.attributes)
+              options = CoreModel::IncludeOptions.from_hash(options_hash)
+              raw = extract_raw_options(model.attributes)
+
+              CoreModel::Include.new(
+                target: model.path.to_s,
+                options: options,
+                raw_options: raw,
+                line_break: model.line_break.to_s
+              )
+            end
+
+            private
+
+            def extract_options_hash(attrs)
+              return {} unless attrs.is_a?(Coradoc::AsciiDoc::Model::AttributeList)
+
+              attrs.named.each_with_object({}) do |attr, hash|
+                hash[attr.name.to_s] = serialize_named_value(attr.value)
+              end
+            end
+
+            def serialize_named_value(value)
+              case value
+              when Array then value.map(&:to_s).join(';')
+              else value.to_s
+              end
+            end
+
+            def extract_raw_options(attrs)
+              return '' unless attrs.is_a?(Coradoc::AsciiDoc::Model::AttributeList)
+
+              adoc = attrs.to_adoc(show_empty: false).to_s
+              adoc.gsub(/\A\[|\]\z/, '')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -388,7 +388,50 @@ module Coradoc
             )
           end
 
+          def transform_include(include)
+            Coradoc::AsciiDoc::Model::Include.new(
+              path: include.target.to_s,
+              attributes: build_include_attributes(include),
+              line_break: include.line_break.to_s
+            )
+          end
+
           private
+
+          def build_include_attributes(include)
+            list = Coradoc::AsciiDoc::Model::AttributeList.new
+            options = include.options
+            return list if options.nil?
+
+            add_tag_attribute(list, options)
+            add_simple_attribute(list, 'lines', options.lines_spec)
+            add_leveloffset_attribute(list, options)
+            add_simple_attribute(list, 'indent', options.indent&.to_s)
+            add_simple_attribute(list, 'encoding', options.file_encoding)
+            list
+          end
+
+          def add_simple_attribute(list, name, value)
+            return if value.nil? || value.to_s.empty?
+
+            list.add_named(name, value.to_s)
+          end
+
+          def add_tag_attribute(list, options)
+            if options.tags_wildcard
+              list.add_named('tags', '*')
+            elsif options.tags_inverted
+              list.add_named('tags', '**')
+            elsif options.tags.any?
+              list.add_named('tags', options.tags.join(';'))
+            end
+          end
+
+          def add_leveloffset_attribute(list, options)
+            return if options.leveloffset.nil?
+
+            list.add_named('leveloffset', options.leveloffset.to_s)
+          end
 
           # If the first CoreModel child is a FrontmatterBlock, serialize
           # it to YAML text via Codec (single source of truth) and pop it

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model_registrations.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model_registrations.rb
@@ -120,6 +120,11 @@ module Coradoc
               Coradoc::CoreModel::CommentLine,
               ->(model) { FromCoreModel.transform_comment_line(model) }
             )
+
+            Registry.register(
+              Coradoc::CoreModel::Include,
+              ->(model) { FromCoreModel.transform_include(model) }
+            )
           end
         end
       end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
@@ -10,6 +10,7 @@ module Coradoc
         Inl = ElementTransformers::InlineTransformer
         Tbl = ElementTransformers::TableTransformer
         Oth = ElementTransformers::OtherTransformer
+        Inc = ElementTransformers::IncludeTransformer
 
         class << self
           def register_all!
@@ -231,8 +232,16 @@ module Coradoc
               ->(model) { Oth.transform_bibliography_entry(model) }
             )
 
-            [
+            # Include directives become first-class CoreModel::Include nodes
+            # (link edges in a text graph). To splice their content inline,
+            # call +Coradoc.resolve_includes(doc, base_dir:)+ on the parsed
+            # document — that step is intentionally separate from parse.
+            Registry.register(
               Coradoc::AsciiDoc::Model::Include,
+              ->(model) { Inc.transform_include(model) }
+            )
+
+            [
               Coradoc::AsciiDoc::Model::Audio,
               Coradoc::AsciiDoc::Model::Video,
               Coradoc::AsciiDoc::Model::ContentList,

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
@@ -25,6 +25,10 @@ module Coradoc
                 lines: lines,
                 ordering: ordering
               }
+              # Markdown fences carry the language tag inline (```ruby);
+              # pass it through so the SourceCode classifier entry can set
+              # block.lang directly, which extract_block_language prefers.
+              opts[:lang] = block[:language].to_s if block.key?(:language) && !block[:language].nil?
               BlockTypeClassifier.classify(delimiter, opts, attribute_list)
             end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_type_classifier.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_type_classifier.rb
@@ -28,7 +28,15 @@ module Coradoc
           ['.', 4, nil, ->(opts, attrs) { Model::Block::Literal.new(**opts.merge(attributes: attrs)) }],
           ['_', 4, nil, ->(opts, attrs) { Model::Block::Quote.new(**opts.merge(attributes: attrs)) }],
           ['-', 4, nil, ->(opts, attrs) { Model::Block::SourceCode.new(**opts.merge(attributes: attrs)) }],
-          ['-', 2, 2,  ->(opts, attrs) { Model::Block::Open.new(**opts.merge(attributes: attrs)) }]
+          ['-', 2, 2,  ->(opts, attrs) { Model::Block::Open.new(**opts.merge(attributes: attrs)) }],
+          # Markdown-style triple-backtick fence: behaves as a SourceCode
+          # block. The language tag parsed from the opening fence is passed
+          # through opts[:lang]; extract_block_language prefers block.lang.
+          ['`', 3, nil, ->(opts, attrs) {
+            model_opts = opts.merge(attributes: attrs, delimiter_char: '`')
+            model_opts[:lang] = opts[:lang] if opts.key?(:lang)
+            Model::Block::SourceCode.new(**model_opts)
+          }]
         ].freeze
 
         module_function

--- a/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
@@ -694,6 +694,71 @@ RSpec.describe 'Integration pipeline fixes' do
     end
   end
 
+  describe 'Fix 21: Markdown-style fenced code blocks (```)' do
+    it 'parses ```ruby ... ``` as a SourceBlock with language' do
+      adoc = "```ruby\nputs 'hi'\nputs 'bye'\n```\n"
+      core = parse_to_core(adoc)
+
+      source = core.children.find { |c| c.is_a?(Coradoc::CoreModel::SourceBlock) }
+      expect(source).not_to be_nil
+      expect(source.language).to eq('ruby')
+      expect(source.content).to eq("puts 'hi'\nputs 'bye'")
+    end
+
+    it 'parses ```ruby ... ``` (with space) as a SourceBlock with language' do
+      adoc = "``` ruby\ncode\n```\n"
+      core = parse_to_core(adoc)
+
+      source = core.children.find { |c| c.is_a?(Coradoc::CoreModel::SourceBlock) }
+      expect(source).not_to be_nil
+      expect(source.language).to eq('ruby')
+    end
+
+    it 'parses bare ``` ... ``` as a SourceBlock with no language' do
+      adoc = "```\nplain code\n```\n"
+      core = parse_to_core(adoc)
+
+      source = core.children.find { |c| c.is_a?(Coradoc::CoreModel::SourceBlock) }
+      expect(source).not_to be_nil
+      expect(source.language).to be_nil
+      expect(source.content).to eq('plain code')
+    end
+
+    it 'does not collapse a fenced block after a paragraph into one paragraph' do
+      adoc = "Text.\n\n```ruby\nputs 'hi'\n```\n"
+      core = parse_to_core(adoc)
+
+      paras = core.children.select { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      source = core.children.find { |c| c.is_a?(Coradoc::CoreModel::SourceBlock) }
+
+      expect(paras.length).to eq(1)
+      expect(paras.first.content).to eq('Text.')
+      expect(source).not_to be_nil
+      expect(source.language).to eq('ruby')
+    end
+
+    it 'preserves ``` inside a ---- source block as literal text' do
+      adoc = "[source]\n----\nUse ``` for code\n----\n"
+      core = parse_to_core(adoc)
+
+      source = core.children.find { |c| c.is_a?(Coradoc::CoreModel::SourceBlock) }
+      expect(source).not_to be_nil
+      expect(source.content).to include('```')
+    end
+
+    it 'round-trips through mirror_json as a sourcecode node' do
+      require "coradoc-mirror"
+
+      adoc = "```ruby\nputs 'hi'\n```\n"
+      core = parse_to_core(adoc)
+      json = JSON.parse(Coradoc.serialize(core, to: :mirror_json))
+
+      source = json["content"].find { |n| n["type"] == "sourcecode" }
+      expect(source).not_to be_nil
+      expect(source["attrs"]["language"]).to eq("ruby")
+    end
+  end
+
   private
 
   def find_first_table(el)

--- a/coradoc-mirror/lib/coradoc/mirror.rb
+++ b/coradoc-mirror/lib/coradoc/mirror.rb
@@ -111,6 +111,9 @@ module Coradoc
       # ── Frontmatter ──
       registry.register(CoreModel::FrontmatterBlock, Handlers::Frontmatter)
 
+      # ── Include directive (text-graph edge) ──
+      registry.register(CoreModel::Include, Handlers::Include)
+
       # ── Generic Block (catch-all for unrecognized block types) ──
       registry.register(CoreModel::Block, Handlers::GenericBlock)
 

--- a/coradoc-mirror/lib/coradoc/mirror/handlers.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers.rb
@@ -33,6 +33,7 @@ module Coradoc
       autoload :Toc, "#{__dir__}/handlers/toc"
       autoload :Frontmatter, "#{__dir__}/handlers/frontmatter"
       autoload :GenericBlock, "#{__dir__}/handlers/generic_block"
+      autoload :Include, "#{__dir__}/handlers/include"
     end
   end
 end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/include.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/include.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      # Include directive handler.
+      #
+      # Emits a ProseMirror-compatible +include+ node carrying the
+      # target path and parsed options as typed attrs. Graph-mode
+      # preservation: the node survives serialization and round-trips
+      # back to a +CoreModel::Include+ via the reverse builder.
+      module Include
+        def self.call(element, context:)
+          Node::Include.new(attrs: build_attrs(element))
+        end
+
+        class << self
+          private
+
+          def build_attrs(element)
+            options = element.options
+            Node::Include::Attrs.new(
+              target: element.target,
+              tags: tags_value(options),
+              lines: options&.lines_spec,
+              leveloffset: leveloffset_value(options),
+              indent: options&.indent,
+              file_encoding: options&.file_encoding,
+              raw_options: element.raw_options
+            )
+          end
+
+          def tags_value(options)
+            return [] unless options
+
+            options.tags
+          end
+
+          def leveloffset_value(options)
+            return nil unless options&.leveloffset
+
+            options.leveloffset.to_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/node.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/node.rb
@@ -512,6 +512,40 @@ module Coradoc
         end
       end
 
+      # Include directive node — a text-graph edge pointing at another file.
+      # Graph mode emits this; flat mode (ResolveIncludes) replaces it with
+      # the included subtree before serialization.
+      class Include < Node
+        PM_TYPE = 'include'
+
+        class Attrs < Lutaml::Model::Serializable
+          attribute :target, :string
+          attribute :tags, :string, collection: true
+          attribute :lines, :string
+          attribute :leveloffset, :string
+          attribute :indent, :integer
+          attribute :file_encoding, :string
+          attribute :raw_options, :string
+
+          key_value do
+            map 'target', to: :target
+            map 'tags', to: :tags
+            map 'lines', to: :lines
+            map 'leveloffset', to: :leveloffset
+            map 'indent', to: :indent
+            map 'encoding', to: :file_encoding
+            map 'raw_options', to: :raw_options
+          end
+        end
+
+        attribute :attrs, Attrs
+
+        key_value do
+          map 'type', to: :type, render_default: true
+          map 'attrs', to: :attrs
+        end
+      end
+
       # ── Tables ──
 
       class Table < Node

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
@@ -386,6 +386,43 @@ module Coradoc
         end
       end
 
+      # Include directive: round-trips back to a CoreModel::Include link
+      # node. The text graph is preserved through mirror_json → core.
+      class Include < Base
+        registers 'include'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::Include.new(
+            target: attrs&.target,
+            options: build_options(attrs),
+            raw_options: attrs&.raw_options || ''
+          )
+        end
+
+        private
+
+        def build_options(attrs)
+          return CoreModel::IncludeOptions.new unless attrs
+
+          CoreModel::IncludeOptions.new(
+            tags: Array(attrs.tags),
+            tags_wildcard: attrs.tags == ['*'],
+            tags_inverted: attrs.tags == ['**'],
+            lines_spec: attrs.lines,
+            leveloffset: parse_leveloffset(attrs.leveloffset),
+            indent: attrs.indent,
+            file_encoding: attrs.file_encoding
+          )
+        end
+
+        def parse_leveloffset(raw)
+          return nil if raw.nil? || raw.to_s.empty?
+
+          Coradoc::CoreModel::IncludeLevelOffset.parse(raw.to_s)
+        end
+      end
+
       # ── Tables ──
 
       class Table < Base

--- a/coradoc/lib/coradoc/cli.rb
+++ b/coradoc/lib/coradoc/cli.rb
@@ -22,6 +22,16 @@ module Coradoc
     option :section_numbers, desc: 'Enable section numbering', type: :boolean, default: false
     option :section_number_levels, desc: 'Section numbering depth (1-6)', type: :numeric, default: 3
     option :lang, desc: 'Document language code', type: :string, default: 'en'
+    option :resolve_includes, desc: 'Resolve include:: directives inline (default: leave as link nodes)',
+           type: :boolean, default: false
+    option :base_dir, desc: 'Base directory for include resolution (default: dirname of FILE)',
+           type: :string
+    option :missing_include, desc: 'Policy for missing includes: error, warn, silent, passthrough',
+           type: :string, default: 'error'
+    option :max_include_depth, desc: 'Maximum include nesting depth', type: :numeric,
+           default: 64
+    option :allow_unsafe_includes, desc: 'Disable path-traversal protection (asciidoctor :unsafe mode)',
+           type: :boolean, default: false
     def convert(file)
       source_format = resolve_format(file, :from)
       target_format = options[:to] ? Coradoc.normalize_format(options[:to]) : Coradoc.resolve_output_format(options[:output])
@@ -38,8 +48,11 @@ module Coradoc
 
       verbose_log "Converting #{file} (#{source_format}) to #{target_format}"
 
+      doc = Coradoc.parse_file(file, format: source_format)
+      doc = resolve_includes!(doc, file) if options[:resolve_includes]
+
       opts = build_convert_options
-      result = Coradoc.convert_file(file, from: source_format, to: target_format, **opts)
+      result = Coradoc.serialize(doc, to: target_format, **opts)
       write_output(result, options[:output])
     rescue Coradoc::Error => e
       error "Error: #{e.message}"
@@ -214,6 +227,18 @@ module Coradoc
 
         opts[key] = SYMBOL_OPTIONS.include?(key) ? value.to_sym : value
       end
+    end
+
+    def resolve_includes!(doc, source_file)
+      base_dir = options[:base_dir] || File.expand_path(File.dirname(source_file))
+      verbose_log "Resolving includes against #{base_dir}"
+      Coradoc.resolve_includes(
+        doc,
+        base_dir: base_dir,
+        missing_include: options[:missing_include].to_sym,
+        max_depth: options[:max_include_depth],
+        allow_unsafe: options[:allow_unsafe_includes]
+      )
     end
   end
 end

--- a/coradoc/lib/coradoc/coradoc.rb
+++ b/coradoc/lib/coradoc/coradoc.rb
@@ -86,22 +86,27 @@ module Coradoc
       registry.list
     end
 
-    # Parse text to a document model
+    # Parse text to a document model.
     #
-    # This is the main entry point for parsing documents. It automatically
-    # selects the appropriate parser based on the format.
+    # Graph mode is the only mode: +include::+ directives survive as
+    # +CoreModel::Include+ link nodes pointing at other files. NO file
+    # I/O happens during parse. The result is a single document that
+    # references other documents via Include edges — a text graph.
+    #
+    # To splice included content inline, call +Coradoc.resolve_includes+
+    # on the parsed document. This is an explicit, separate step so the
+    # caller controls when (and whether) file I/O happens.
     #
     # @param text [String] the document text to parse
     # @param format [Symbol] the source format (:asciidoc, :html, :markdown)
     # @return [Coradoc::CoreModel::Base, Object] the parsed document model
     # @raise [UnsupportedFormatError] if the format is not registered
     #
-    # @example Parse AsciiDoc
-    #   doc = Coradoc.parse("= Title\n\nContent", format: :asciidoc)
-    #   doc = Coradoc.parse(File.read("doc.adoc"), format: :asciidoc)
+    # @example Parse — Include directives stay as link nodes
+    #   doc = Coradoc.parse(text, format: :asciidoc)
     #
-    # @example Parse and get CoreModel
-    #   core = Coradoc.parse(text, format: :asciidoc)  # Returns CoreModel
+    # @example Then flatten — splice included files inline
+    #   flat = Coradoc.resolve_includes(doc, base_dir: Dir.pwd)
     def parse(text, format:)
       format_module = get_format(format)
       unless format_module
@@ -113,6 +118,56 @@ module Coradoc
       text = Hooks.invoke(:before_parse, text, format: format)
       result = format_module.parse_to_core(text)
       Hooks.invoke(:after_parse, result, format: format)
+    end
+
+    # Resolve +include::+ directives in a parsed document.
+    #
+    # Walks the document tree and replaces every +CoreModel::Include+
+    # link node with the parsed content of its target file, recursing
+    # into the result. The original document is left unchanged; a new
+    # subtree is constructed.
+    #
+    # This is the explicit "flatten" step that turns a text graph into
+    # a single spliced document. Callers control:
+    #   - +base_dir+ — where to root relative include paths
+    #   - +missing_include+ — what to do when a target is missing
+    #   - +max_depth+ — recursion cap
+    #   - +allow_unsafe+ — opt out of path-traversal protection
+    #   - +resolver+ — custom resolution strategy (e.g. HTTP, in-memory)
+    #
+    # @param document [Coradoc::CoreModel::Base] parsed document
+    # @param base_dir [String] base directory for relative include paths
+    # @param missing_include [Symbol] :error (default), :warn, :silent, :passthrough
+    # @param max_depth [Integer] recursion cap (default 64)
+    # @param allow_unsafe [Boolean] disable path-traversal protection
+    # @param resolver [Object, nil] custom resolver. Defaults to
+    #   +Coradoc::IncludeResolver::Filesystem+ rooted at +base_dir+.
+    # @return [Coradoc::CoreModel::Base] new document with includes expanded
+    # @raise [Coradoc::IncludeNotFoundError] when a target is missing
+    #   and policy is :error
+    # @raise [Coradoc::IncludeDepthExceededError] when +max_depth+ is hit
+    # @raise [Coradoc::CircularIncludeError] when an include cycle is detected
+    #
+    # @example
+    #   doc = Coradoc.parse(text, format: :asciidoc)
+    #   flat = Coradoc.resolve_includes(doc, base_dir: Dir.pwd)
+    def resolve_includes(document, base_dir:,
+                         missing_include: :error,
+                         max_depth: Coradoc::ResolveIncludes::DEFAULT_MAX_DEPTH,
+                         allow_unsafe: false,
+                         resolver: nil)
+      resolver = Coradoc::IncludeResolver.coerce(
+        resolver,
+        base_dir: base_dir,
+        allow_unsafe: allow_unsafe
+      )
+      Coradoc::ResolveIncludes.call(
+        document,
+        resolver: resolver,
+        base_dir: base_dir,
+        missing_include: missing_include,
+        max_depth: max_depth
+      )
     end
 
     # Convert document text from one format to another
@@ -459,6 +514,9 @@ module Coradoc
   autoload :DocumentManipulator, "#{__dir__}/document_manipulator"
   autoload :Visitor, "#{__dir__}/visitor"
   autoload :PerformanceRegression, "#{__dir__}/performance_regression"
+  autoload :IncludeResolver, "#{__dir__}/include_resolver"
+  autoload :IncludeSelectors, "#{__dir__}/include_selectors"
+  autoload :ResolveIncludes, "#{__dir__}/resolve_includes"
 end
 
 # Format gems self-register via Coradoc.register_format when they are required.

--- a/coradoc/lib/coradoc/core_model.rb
+++ b/coradoc/lib/coradoc/core_model.rb
@@ -79,5 +79,8 @@ module Coradoc
     autoload :CommentLine, "#{__dir__}/core_model/comment_line"
     autoload :HorizontalRuleBlock, "#{__dir__}/core_model/horizontal_rule_block"
     autoload :IdGenerator, "#{__dir__}/core_model/id_generator"
+    autoload :Include, "#{__dir__}/core_model/include"
+    autoload :IncludeOptions, "#{__dir__}/core_model/include_options"
+    autoload :IncludeLevelOffset, "#{__dir__}/core_model/include_level_offset"
   end
 end

--- a/coradoc/lib/coradoc/core_model/include.rb
+++ b/coradoc/lib/coradoc/core_model/include.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    # First-class include directive node in the canonical document model.
+    #
+    # An include directive is a LINK from one document to another file.
+    # Parsing preserves these nodes verbatim — no file I/O happens during
+    # parse. The result is a text graph: a document referencing other
+    # documents via Include edges.
+    #
+    # Splicing the linked content inline is an explicit, separate step:
+    # +Coradoc.resolve_includes(doc, base_dir:)+ walks the tree and
+    # replaces each Include node with the parsed content of its target,
+    # recursing into the result.
+    #
+    # This separation lets callers:
+    #   - inspect the graph before deciding to flatten
+    #   - resolve with different base dirs / resolvers without re-parsing
+    #   - treat includes as external links (e.g. when parsing a site)
+    #
+    # Attributes:
+    #   target       String           path or URL as authored
+    #   options      IncludeOptions   parsed selectors (tags/lines/leveloffset/indent/encoding)
+    #   raw_options  String           original bracket body, preserved for verbatim round-trip
+    #   line_break   String           trailing line break, default "\n"
+    #
+    # The node is block-level: it appears in the +content+ / +children+
+    # array of any block container (Document, Section, Paragraph, List
+    # item, Table cell, etc.) alongside other block-level nodes.
+    class Include < Base
+      attribute :target, :string
+      attribute :options, Coradoc::CoreModel::IncludeOptions,
+                default: -> { Coradoc::CoreModel::IncludeOptions.new }
+      attribute :raw_options, :string, default: -> { '' }
+      attribute :line_break, :string, default: -> { "\n" }
+
+      def self.semantic_type
+        :include
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/core_model/include_level_offset.rb
+++ b/coradoc/lib/coradoc/core_model/include_level_offset.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    # A leveloffset value parsed from an include directive.
+    #
+    # asciidoctor supports two forms:
+    #   leveloffset=+N   → relative shift (heading.level += N)
+    #   leveloffset=-N   → relative shift (heading.level -= N)
+    #   leveloffset=N    → absolute set (heading.level = N)
+    #
+    # The parsed form keeps the mode and delta separate so that the
+    # selector that applies the offset does not need to re-parse the
+    # string each time it walks a section (DRY).
+    class IncludeLevelOffset < Base
+      # "relative" (+N/-N) or "absolute" (bare N).
+      attribute :mode, :string
+
+      # Signed integer for relative shifts; the absolute target level
+      # for absolute mode.
+      attribute :delta, :integer
+
+      # Construct from a raw asciidoctor-style string ("+2", "-1", "3").
+      # Returns nil if the input is nil or unparsable.
+      #
+      # @param raw [String, nil]
+      # @return [IncludeLevelOffset, nil]
+      def self.parse(raw)
+        return nil if raw.nil? || raw.strip.empty?
+
+        matched_offset(raw.strip)
+      end
+
+      # Apply this offset to a heading level (1-indexed asciidoctor level).
+      #
+      # @param level [Integer] original section level
+      # @return [Integer] new section level, clamped to >= 0
+      def apply(level)
+        case mode
+        when 'relative' then [level + delta, 0].max
+        when 'absolute' then [delta, 0].max
+        else level
+        end
+      end
+
+      # Render back to the asciidoctor wire form ("+2", "-1", "3").
+      #
+      # @return [String]
+      def to_s
+        case mode
+        when 'relative' then format('%+d', delta)
+        when 'absolute' then delta.to_s
+        else ''
+        end
+      end
+
+      class << self
+        private
+
+        def matched_offset(trimmed)
+          %r{\A(?<sign>[+-]?)(?<digits>\d+)\z}.match(trimmed) do |m|
+            digits = m[:digits].to_i
+            signed = m[:sign] == '-' ? -digits : digits
+            mode = m[:sign].empty? ? 'absolute' : 'relative'
+            new(mode: mode, delta: signed)
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/core_model/include_options.rb
+++ b/coradoc/lib/coradoc/core_model/include_options.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    # Typed options for an include directive, parsed once at construction.
+    #
+    # Each asciidoctor selector (tags / lines / leveloffset / indent /
+    # encoding) gets one typed attribute. Selectors downstream operate on
+    # the typed form, never re-parsing the raw string (DRY).
+    #
+    #   tags          Array<String>   ["body"], [] when unspecified
+    #   tags_wildcard Boolean         true for tags=*
+    #   tags_inverted Boolean         true for tags=**
+    #   lines_spec    String?         raw "1..2;5;7..8" — parsed by Lines selector
+    #   leveloffset   IncludeLevelOffset?
+    #   indent        Integer?        0 = strip, N = re-indent, nil = passthrough
+    #   file_encoding String?         passed through to resolver for File.read
+    class IncludeOptions < Base
+      attribute :tags, :string, collection: true, default: -> { [] }
+      attribute :tags_wildcard, :boolean, default: -> { false }
+      attribute :tags_inverted, :boolean, default: -> { false }
+      attribute :lines_spec, :string
+      attribute :leveloffset, Coradoc::CoreModel::IncludeLevelOffset
+      attribute :indent, :integer
+      attribute :file_encoding, :string
+
+      # Whether the lines selector is in effect. Tags are ignored when
+      # lines is set — matches asciidoctor precedence (SPEC 3.5).
+      def lines?
+        !lines_spec.nil? && !lines_spec.strip.empty?
+      end
+
+      # Whether any tag selector is in effect.
+      def tags?
+        tags_wildcard || tags_inverted || !tags.empty?
+      end
+
+      # True when both selectors were specified (lines wins).
+      def conflict_resolved_to_lines?
+        lines? && tags?
+      end
+
+      # Build from a flat hash of asciidoctor-style key/value strings.
+      # Whitespace around keys and values is trimmed (SPEC 6.3).
+      #
+      # @param attrs [Hash{String=>String}] e.g. {"tags"=>"a;b", "leveloffset"=>"+2"}
+      # @return [IncludeOptions]
+      def self.from_hash(attrs)
+        new(build_args(attrs))
+      end
+
+      class << self
+        private
+
+        def build_args(attrs)
+          cleaned = clean_keys(attrs)
+          {
+            tags: parse_tags(cleaned['tags']),
+            tags_wildcard: wildcard?(cleaned['tags']),
+            tags_inverted: inverted?(cleaned['tags']),
+            lines_spec: cleaned['lines'],
+            leveloffset: CoreModel::IncludeLevelOffset.parse(cleaned['leveloffset']),
+            indent: parse_integer(cleaned['indent']),
+            file_encoding: cleaned['encoding']
+          }
+        end
+
+        def clean_keys(attrs)
+          attrs.each_with_object({}) do |(k, v), h|
+            h[k.to_s.strip] = v.to_s.strip
+          end
+        end
+
+        def parse_tags(raw)
+          return [] if raw.nil?
+          trimmed = raw.strip
+          return [] if trimmed.empty? || trimmed == '*' || trimmed == '**'
+
+          trimmed.split(';').map(&:strip).reject(&:empty?)
+        end
+
+        def wildcard?(raw)
+          !raw.nil? && raw.strip == '*'
+        end
+
+        def inverted?(raw)
+          !raw.nil? && raw.strip == '**'
+        end
+
+        def parse_integer(raw)
+          return nil if raw.nil? || raw.strip.empty?
+
+          Integer(raw.strip)
+        rescue ArgumentError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/errors.rb
+++ b/coradoc/lib/coradoc/errors.rb
@@ -283,6 +283,62 @@ module Coradoc
     end
   end
 
+  # Error raised when an include directive's target cannot be located.
+  # Honors the +missing_include+ policy: +:error+ raises this; +:warn+,
+  # +:silent+, and +:passthrough+ swallow it.
+  class IncludeNotFoundError < Error
+    attr_reader :target
+
+    def initialize(target)
+      @target = target
+      super("Include target not found: #{target}")
+    end
+  end
+
+  # Error raised when an include chain exceeds the configured depth limit.
+  class IncludeDepthExceededError < Error
+    attr_reader :depth, :target
+
+    def initialize(target:, depth:, max:)
+      @target = target
+      @depth = depth
+      super("Include depth #{depth} exceeds max #{max} at #{target}")
+    end
+  end
+
+  # Error raised when a cycle is detected in the include graph.
+  # The chain is the list of files leading back to the repeated target.
+  class CircularIncludeError < Error
+    attr_reader :chain, :target
+
+    def initialize(target:, chain:)
+      @target = target
+      @chain = chain
+      super("Circular include detected: #{chain.join(' -> ')} -> #{target}")
+    end
+  end
+
+  # Error raised when an include target escapes the resolver's safe base
+  # directory and +allow_unsafe_includes+ is not set.
+  class UnsafeIncludeError < Error
+    attr_reader :target
+
+    def initialize(target)
+      @target = target
+      super("Unsafe include path blocked: #{target}")
+    end
+  end
+
+  # Error raised when an include target exceeds the resolver's size limit.
+  class IncludeTooLargeError < Error
+    attr_reader :target
+
+    def initialize(target)
+      @target = target
+      super("Include target too large to read: #{target}")
+    end
+  end
+
   # Error raised when a requested format is not supported
   #
   # @example

--- a/coradoc/lib/coradoc/include_resolver.rb
+++ b/coradoc/lib/coradoc/include_resolver.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Coradoc
+  # Include resolver protocol.
+  #
+  # A resolver is anything that responds to +#call(target:, base_dir:,
+  # options:, context:)+ and returns the raw bytes of the included
+  # target, BEFORE tag/line/indent selectors are applied. Selectors
+  # live in the processor; the resolver only fetches bytes.
+  #
+  # The default resolver is {IncludeResolver::Filesystem}. Custom
+  # resolvers (HTTP, database, generated) plug in here without changes
+  # to the processor (OCP).
+  #
+  # Contract:
+  #   call(target:, base_dir:, options:, context:) -> String
+  #     target   String              path/URL as authored
+  #     base_dir String              absolute path to the including file's dir
+  #     options  CoreModel::IncludeOptions
+  #     context  Hash                recursion state (depth, parent_chain, ...)
+  #
+  #   Raises Coradoc::IncludeNotFoundError if the target cannot be located.
+  #   The processor's missing-file policy decides what to do with that.
+  #
+  # This base class is provided for documentation and for is_a? checks.
+  # Custom resolvers do NOT need to inherit — duck typing on the call
+  # signature is sufficient. ( SPEC 13 uses a bare Object with
+  # define_singleton_method, which we support.)
+  class IncludeResolver
+    autoload :Filesystem, "#{__dir__}/include_resolver/filesystem"
+
+    def call(target:, base_dir:, options:, context:)
+      raise NotImplementedError,
+            "#{self.class} must implement #call(target:, base_dir:, options:, context:)"
+    end
+
+    class << self
+      # Coerce +value+ into something that quacks like an IncludeResolver.
+      # - Already-callable objects (respond to :call) are returned as-is.
+      # - Symbols are interpreted as built-in names: +:filesystem+,
+      #   +:filesystem_strict+ (path-traversal protection on).
+      #
+      # @param value [Object, nil] the resolver or built-in name
+      # @param base_dir [String] required for built-in filesystem resolvers
+      # @param allow_unsafe [Boolean] opt-out of path-traversal protection
+      # @return [Object] something callable as a resolver
+      def coerce(value, base_dir:, allow_unsafe: false)
+        return Filesystem.new(base_dir: base_dir, allow_unsafe: allow_unsafe) if value.nil?
+
+        case value
+        when Symbol then coerce_symbol(value, base_dir: base_dir, allow_unsafe: allow_unsafe)
+        else value
+        end
+      end
+
+      private
+
+      def coerce_symbol(name, base_dir:, allow_unsafe:)
+        case name
+        when :filesystem then Filesystem.new(base_dir: base_dir, allow_unsafe: allow_unsafe)
+        else
+          raise ArgumentError, "Unknown include resolver: #{name.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/include_resolver/filesystem.rb
+++ b/coradoc/lib/coradoc/include_resolver/filesystem.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+module Coradoc
+  class IncludeResolver
+    # Default include resolver: reads files from the local filesystem,
+    # rooted at +base_dir+. Path-traversal protection is ON by default
+    # to match asciidoctor's +:safe+ mode.
+    #
+    # Pass +allow_unsafe: true+ to opt out (matches +:unsafe+ mode).
+    class Filesystem < IncludeResolver
+      attr_reader :base_dir, :allow_unsafe, :max_bytes
+
+      # @param base_dir [String] absolute path to the directory includes
+      #   are resolved against. Usually the directory of the including
+      #   document. Relative paths inside the resolver are expanded
+      #   against this.
+      # @param allow_unsafe [Boolean] when false (default), refuses any
+      #   resolved path that escapes +base_dir+ via .. or that is an
+      #   absolute path outside +base_dir+.
+      # @param max_bytes [Integer, nil] if set, refuses files larger
+      #   than this. Defense against accidental megabyte-include loops.
+      def initialize(base_dir:, allow_unsafe: false, max_bytes: nil)
+        @base_dir = File.expand_path(base_dir)
+        @allow_unsafe = allow_unsafe
+        @max_bytes = max_bytes
+      end
+
+      def call(target:, base_dir:, options:, context:)
+        full = File.expand_path(target, base_dir)
+        enforce_safety!(full, base_dir) unless allow_unsafe
+        raise Coradoc::IncludeNotFoundError, target unless File.file?(full)
+
+        enforce_size!(full, target)
+
+        encoding = options&.file_encoding || 'utf-8'
+        read_with_encoding(full, encoding)
+      end
+
+      private
+
+      def enforce_safety!(full_path, base_dir)
+        base_expanded = File.expand_path(base_dir)
+        base_with_sep = "#{base_expanded}#{File::SEPARATOR}"
+
+        return if full_path == base_expanded || full_path.start_with?(base_with_sep)
+
+        raise Coradoc::UnsafeIncludeError, full_path
+      end
+
+      def enforce_size!(full_path, target)
+        return unless max_bytes
+        return unless File.exist?(full_path)
+
+        size = File.size(full_path)
+        return if size <= max_bytes
+
+        raise Coradoc::IncludeTooLargeError, target
+      end
+
+      def read_with_encoding(full_path, encoding_name)
+        content = File.binread(full_path)
+        return content if encoding_name.to_s.downcase == 'binary'
+
+        content.force_encoding(clean_encoding_name(encoding_name))
+        encoded = content.encode('utf-8', invalid: :replace, undef: :replace)
+        normalize_line_endings(encoded)
+      rescue ArgumentError => e
+        raise Coradoc::Error, "Unsupported encoding #{encoding_name.inspect}: #{e.message}"
+      end
+
+      # asciidoctor parity: normalize CRLF and lone CR to LF so the parser
+      # sees consistent line endings regardless of the source platform.
+      def normalize_line_endings(text)
+        text.gsub(/\r\n?/, "\n")
+      end
+
+      def clean_encoding_name(name)
+        name.to_s.downcase.sub(/^utf-8$/, 'utf-8')
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/include_selectors.rb
+++ b/coradoc/lib/coradoc/include_selectors.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Coradoc
+  # Pure-function selectors applied to resolved include content.
+  #
+  # Each selector owns exactly one transformation (MECE):
+  #   Tags         // tag::X[] ... // end::X[] region extraction
+  #   Lines        line-range selection (1..N;2;3..4)
+  #   Indent       leading-whitespace normalization
+  #   LevelOffset  section-level shift (applied AFTER parsing)
+  #
+  # Tags, Lines, and Indent take a String and return a String.
+  # LevelOffset takes a parsed CoreModel and returns a new CoreModel.
+  #
+  # The processor orchestrates the order:
+  #   1. Tags   (or Lines; Lines wins if both specified — SPEC 3.5)
+  #   2. Indent
+  #   3. parse → CoreModel
+  #   4. LevelOffset
+  module IncludeSelectors
+    autoload :Tags, "#{__dir__}/include_selectors/tags"
+    autoload :Lines, "#{__dir__}/include_selectors/lines"
+    autoload :Indent, "#{__dir__}/include_selectors/indent"
+    autoload :LevelOffset, "#{__dir__}/include_selectors/level_offset"
+  end
+end

--- a/coradoc/lib/coradoc/include_selectors/indent.rb
+++ b/coradoc/lib/coradoc/include_selectors/indent.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module IncludeSelectors
+    # Indent normalization. Two modes per asciidoctor:
+    #
+    #   indent=0   strip all leading whitespace from every line
+    #   indent=N   normalize leading whitespace to exactly N spaces
+    #   nil        pass through unchanged
+    module Indent
+      # @param text [String]
+      # @param options [Coradoc::CoreModel::IncludeOptions]
+      # @return [String]
+      def self.call(text, options:)
+        return text if options.indent.nil?
+
+        if options.indent.zero?
+          strip_all(text)
+        else
+          reindent(text, options.indent)
+        end
+      end
+
+      class << self
+        private
+
+        def strip_all(text)
+          text.lines.map { |line| line.sub(/\A[[:space:]]+/, '') }.join
+        end
+
+        def reindent(text, target)
+          min_indent = text.lines
+                           .reject { |l| l.strip.empty? }
+                           .map { |l| l.length - l.lstrip.length }
+                           .min || 0
+
+          pad = ' ' * target
+          text.lines.map do |line|
+            stripped = strip_common_prefix(line, min_indent)
+            if stripped.strip.empty?
+              stripped.strip + "\n"
+            else
+              pad + stripped
+            end
+          end.join
+        end
+
+        def strip_common_prefix(line, count)
+          line.sub(/\A[[:space:]]{0,#{count}}/, '')
+        end
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/include_selectors/level_offset.rb
+++ b/coradoc/lib/coradoc/include_selectors/level_offset.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module IncludeSelectors
+    # Shifts section heading levels in a parsed CoreModel subtree.
+    #
+    # Applied AFTER parsing — works on SectionElement instances. Two modes:
+    #
+    #   relative (+N / -N)   every SectionElement#level += delta
+    #   absolute (N)         the FIRST section's level becomes N, and
+    #                         descendants shift by the same delta so their
+    #                         relative structure is preserved (asciidoctor
+    #                         behavior).
+    #
+    # The processor passes a freshly-parsed subtree to this selector, so
+    # there are no external references and in-place mutation is safe.
+    module LevelOffset
+      # @param core [Coradoc::CoreModel::Base] freshly parsed — mutated
+      # @param options [Coradoc::CoreModel::IncludeOptions]
+      # @return [Coradoc::CoreModel::Base] the same core (mutated)
+      def self.call(core, options:)
+        offset = options.leveloffset
+        return core if offset.nil?
+
+        first_level = find_first_level(core)
+        actual_delta = compute_actual_delta(offset, first_level)
+        return core if actual_delta.zero?
+
+        walk_and_shift(core, actual_delta)
+        core
+      end
+
+      class << self
+        private
+
+        def compute_actual_delta(offset, first_level)
+          case offset.mode
+          when 'relative' then offset.delta
+          when 'absolute'
+            return 0 if first_level.nil?
+
+            offset.delta - first_level
+          else 0
+          end
+        end
+
+        def find_first_level(node)
+          case node
+          when Coradoc::CoreModel::SectionElement
+            node.level || 1
+          when Coradoc::CoreModel::StructuralElement, Coradoc::CoreModel::Block
+            walk_for_first_level(node.children)
+          else
+            nil
+          end
+        end
+
+        def walk_for_first_level(children)
+          return nil if children.nil?
+
+          children.each do |child|
+            lvl = find_first_level(child)
+            return lvl unless lvl.nil?
+          end
+          nil
+        end
+
+        def walk_and_shift(node, delta)
+          case node
+          when Coradoc::CoreModel::SectionElement
+            node.level = [(node.level || 1) + delta, 0].max
+            walk_children(node, delta)
+          when Coradoc::CoreModel::StructuralElement, Coradoc::CoreModel::Block
+            walk_children(node, delta)
+          end
+        end
+
+        def walk_children(node, delta)
+          return if node.children.nil?
+
+          node.children.each { |c| walk_and_shift(c, delta) }
+        end
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/include_selectors/lines.rb
+++ b/coradoc/lib/coradoc/include_selectors/lines.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module IncludeSelectors
+    # Line-range selection. Parses asciidoctor-style specs:
+    #
+    #   N            single line
+    #   A..B         inclusive range
+    #   A..B;C;D..E  multiple, semicolon-separated
+    #
+    # Out-of-bounds clamps gracefully (SPEC 3.4). One-based indexing
+    # (asciidoctor convention).
+    module Lines
+      SPEC_PART = %r{
+        \A
+        (?<start>\d+)
+        (?:\.\.(?<finish>\d+))?
+        \z
+      }x.freeze
+
+      # @param text [String]
+      # @param options [Coradoc::CoreModel::IncludeOptions]
+      # @return [String]
+      def self.call(text, options:)
+        return text unless options.lines?
+
+        ranges = parse_spec(options.lines_spec, max: text.lines.length)
+        return '' if ranges.empty?
+
+        indices = ranges.flat_map { |start, finish| (start..finish).to_a }.uniq.sort
+        text.lines.values_at(*indices.map { |i| i - 1 }).join
+      end
+
+      class << self
+        private
+
+        def parse_spec(spec, max:)
+          spec.split(';').map(&:strip).filter_map do |part|
+            parse_part(part, max: max)
+          end
+        end
+
+        def parse_part(part, max:)
+          SPEC_PART.match(part) do |m|
+            start = m[:start].to_i
+            finish = m[:finish] ? m[:finish].to_i : start
+            [start, finish].minmax.map { |n| clamp(n, max: max) }
+          end
+        end
+
+        def clamp(n, max:)
+          return nil if n < 1
+          return max if n > max
+
+          n
+        end
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/include_selectors/tags.rb
+++ b/coradoc/lib/coradoc/include_selectors/tags.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module IncludeSelectors
+    # Extracts regions delimited by +// tag::name[]+ / +// end::name[]+
+    # markers from included content. Supports single, multiple,
+    # wildcard (*), and inverted (**) selection.
+    #
+    # Tag markers themselves are never emitted as text (SPEC 2.8).
+    # Unknown tag names yield empty content (SPEC 2.6). Nested tag
+    # regions are included when an outer tag is selected (SPEC 2.7).
+    #
+    # Marker forms recognized:
+    #   // tag::name[]      (AsciiDoc line comment)
+    #   ## tag::name[]      (Markdown line comment, permissive)
+    #
+    # Markers may appear on their own line; they must be the first
+    # non-whitespace token on that line (asciidoctor convention).
+    module Tags
+      MARKER_OPEN  = /\A[[:space:]]*(?:\/\/+|#+)[[:space:]]*tag::([^\[\]]+)\[[[:space:]]*\]/
+      MARKER_CLOSE = /\A[[:space:]]*(?:\/\/+|#+)[[:space:]]*end::([^\[\]]+)\[[[:space:]]*\]/
+
+      # @param text [String] raw included file content
+      # @param options [Coradoc::CoreModel::IncludeOptions]
+      # @return [String] filtered content
+      def self.call(text, options:)
+        return text unless options.tags?
+
+        if options.tags_inverted
+          inverted(text)
+        elsif options.tags_wildcard
+          wildcard(text)
+        else
+          named(text, options.tags)
+        end
+      end
+
+      class << self
+        private
+
+        def scan_markers(text)
+          markers = []
+          text.each_line.with_index do |line, idx|
+            if (m = MARKER_OPEN.match(line))
+              markers << [:open, m[1].strip, idx]
+            elsif (m = MARKER_CLOSE.match(line))
+              markers << [:close, m[1].strip, idx]
+            end
+          end
+          markers
+        end
+
+        def named(text, names)
+          wanted_indices = selected_line_indices(text, names).to_set
+          pick_lines(text, wanted_indices)
+        end
+
+        def selected_line_indices(text, wanted_names)
+          markers = scan_markers(text)
+          wanted = wanted_names.to_set
+          open_stack = []
+          emit = {}
+
+          markers.each do |kind, name, idx|
+            case kind
+            when :open
+              next unless wanted.include?(name)
+
+              open_stack.push([name, idx])
+            when :close
+              next unless wanted.include?(name)
+
+              open_idx = open_stack.rindex { |n, _| n == name }
+              next unless open_idx
+
+              _open_name, open_line = open_stack.delete_at(open_idx)
+              (open_line + 1...idx).each { |i| emit[i] = true }
+            end
+          end
+
+          emit.keys
+        end
+
+        def wildcard(text)
+          markers = scan_markers(text)
+          open_stack = []
+          emit = {}
+
+          markers.each do |kind, _name, idx|
+            case kind
+            when :open
+              open_stack.push(idx)
+            when :close
+              next if open_stack.empty?
+
+              open_line = open_stack.pop
+              (open_line + 1...idx).each { |i| emit[i] = true }
+            end
+          end
+
+          pick_lines(text, emit.keys.to_set)
+        end
+
+        def inverted(text)
+          markers = scan_markers(text)
+          open_stack = []
+          excluded = {}
+
+          markers.each do |kind, _name, idx|
+            case kind
+            when :open
+              open_stack.push(idx)
+            when :close
+              next if open_stack.empty?
+
+              open_line = open_stack.pop
+              (open_line..idx).each { |i| excluded[i] = true }
+            end
+          end
+
+          markers.each { |_kind, _name, idx| excluded[idx] = true }
+
+          lines = text.lines
+          kept = lines.each_with_index.reject { |_line, idx| excluded[idx] }
+          kept.map(&:first).join
+        end
+
+        def pick_lines(text, wanted_indices)
+          lines = text.lines
+          lines.each_with_index.select { |_line, idx| wanted_indices.include?(idx) }
+               .map(&:first).join
+        end
+      end
+    end
+  end
+end
+
+require 'set'

--- a/coradoc/lib/coradoc/resolve_includes.rb
+++ b/coradoc/lib/coradoc/resolve_includes.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+module Coradoc
+  # Flat-mode include processor — the explicit "flatten" step.
+  #
+  # Walks a parsed CoreModel and expands every {CoreModel::Include} link
+  # node into the parsed content of its target, recursing into the result.
+  # The original CoreModel is NOT modified — a new subtree is constructed
+  # and spliced into place.
+  #
+  # Invoked via the public API +Coradoc.resolve_includes(doc, base_dir:)+.
+  # Callers control resolution strategy (filesystem, HTTP, custom),
+  # missing-include policy, recursion depth, and path-traversal safety.
+  #
+  # Honors:
+  #   - +missing_include+ policy: :error (default) | :warn | :silent | :passthrough
+  #   - +max_depth+ limit (raises Coradoc::IncludeDepthExceededError)
+  #   - circular detection (raises Coradoc::CircularIncludeError)
+  #   - tags/lines/indent selectors (applied to raw text before parse)
+  #   - leveloffset selector (applied to parsed CoreModel)
+  #   - +base_dir+ re-rooting (recursive includes resolve relative to
+  #     the including file — SPEC 7.2)
+  class ResolveIncludes
+    DEFAULT_MAX_DEPTH = 64
+
+    class << self
+      def call(core, resolver:, base_dir:, **opts)
+        new(resolver: resolver, base_dir: base_dir, **opts).call(core)
+      end
+    end
+
+    # @param resolver [#call] anything responding to +#call(target:, base_dir:, options:, context:)+
+    # @param base_dir [String] absolute path to the document root directory
+    # @param missing_include [Symbol] :error | :warn | :silent | :passthrough
+    # @param max_depth [Integer] recursion cap
+    # @param parse_format [Symbol] format to use when re-parsing included content
+    def initialize(resolver:, base_dir:,
+                   missing_include: :error,
+                   max_depth: DEFAULT_MAX_DEPTH,
+                   parse_format: :asciidoc)
+      @resolver = Coradoc::IncludeResolver.coerce(resolver, base_dir: base_dir)
+      @base_dir = base_dir
+      @missing_policy = missing_include
+      @max_depth = max_depth
+      @parse_format = parse_format
+    end
+
+    # Walk + transform. Returns a NEW CoreModel with includes expanded.
+    def call(core)
+      expand_node(core, base_dir: File.expand_path(@base_dir), chain: [], depth: 0)
+    end
+
+    private
+
+    def expand_node(node, base_dir:, chain:, depth:)
+      return node unless node.is_a?(Coradoc::CoreModel::Base)
+
+      case node
+      when Coradoc::CoreModel::Include
+        expand_include(node, base_dir: base_dir, chain: chain, depth: depth)
+      when Coradoc::CoreModel::StructuralElement, Coradoc::CoreModel::Block
+        expand_container(node, base_dir: base_dir, chain: chain, depth: depth)
+      else
+        node
+      end
+    end
+
+    def expand_container(node, base_dir:, chain:, depth:)
+      return node if node.children.nil? || node.children.empty?
+
+      expanded_children = node.children.flat_map do |child|
+        expanded = expand_node(child, base_dir: base_dir, chain: chain, depth: depth)
+        Array(expanded)
+      end
+
+      return node if expanded_children.equal?(node.children) || same_children?(expanded_children, node.children)
+
+      duplicate_with_children(node, expanded_children)
+    end
+
+    # The processor must not mutate its input. Each container that has
+    # expanded includes is replaced by a shallow copy with a new
+    # +children+ array — the original document tree stays intact so the
+    # caller can re-resolve with different options.
+    def duplicate_with_children(node, new_children)
+      duplicate = node.dup
+      duplicate.children = new_children
+      duplicate
+    end
+
+    def same_children?(expanded, original)
+      return false unless expanded.length == original.length
+
+      expanded.each_with_index.all? { |node, i| node.equal?(original[i]) }
+    end
+
+    def expand_include(include_node, base_dir:, chain:, depth:)
+      enforce_depth!(include_node, depth)
+      enforce_cycle!(include_node, base_dir: base_dir, chain: chain)
+
+      target = include_node.target
+      new_chain = chain + [resolve_target_path(target, base_dir)]
+
+      content = fetch_content(include_node, base_dir: base_dir)
+      return replacement_for_missing(include_node) if missing_content?(content)
+
+      applied = apply_text_selectors(content, include_node.options)
+      parsed = parse_included(applied)
+
+      shifted = Coradoc::IncludeSelectors::LevelOffset.call(parsed, options: include_node.options)
+
+      new_base_dir = File.dirname(resolve_target_path(target, base_dir))
+      expand_subtree(shifted, base_dir: new_base_dir, chain: new_chain, depth: depth + 1)
+    end
+
+    def missing_content?(content)
+      content.nil? || content == :passthrough
+    end
+
+    def fetch_content(include_node, base_dir:)
+      @resolver.call(
+        target: include_node.target,
+        base_dir: base_dir,
+        options: include_node.options,
+        context: {}
+      )
+    rescue Coradoc::IncludeNotFoundError => e
+      handle_missing(include_node, e)
+    end
+
+    def handle_missing(include_node, error)
+      case @missing_policy
+      when :error then raise error
+      when :warn
+        Coradoc::Logger.warn("Include target not found: #{include_node.target}")
+        nil
+      when :silent then nil
+      when :passthrough then :passthrough
+      else raise error
+      end
+    end
+
+    def replacement_for_missing(include_node)
+      return [include_node] if @missing_policy == :passthrough
+
+      []
+    end
+
+    def apply_text_selectors(text, options)
+      text = apply_lines_or_tags(text, options)
+      Coradoc::IncludeSelectors::Indent.call(text, options: options)
+    end
+
+    def apply_lines_or_tags(text, options)
+      # lines wins when both specified (SPEC 3.5)
+      return Coradoc::IncludeSelectors::Lines.call(text, options: options) if options.lines?
+
+      Coradoc::IncludeSelectors::Tags.call(text, options: options)
+    end
+
+    def parse_included(text)
+      return empty_core if text.nil? || text.empty?
+
+      Coradoc.parse(text, format: @parse_format)
+    end
+
+    def empty_core
+      Coradoc::CoreModel::DocumentElement.new
+    end
+
+    def expand_subtree(core, base_dir:, chain:, depth:)
+      expanded = expand_node(core, base_dir: base_dir, chain: chain, depth: depth)
+      return [expanded] unless expanded.is_a?(Coradoc::CoreModel::StructuralElement)
+
+      expanded.children || []
+    end
+
+    def enforce_depth!(include_node, depth)
+      return if depth < @max_depth
+
+      raise Coradoc::IncludeDepthExceededError.new(
+        target: include_node.target,
+        depth: depth,
+        max: @max_depth
+      )
+    end
+
+    def enforce_cycle!(include_node, base_dir:, chain:)
+      full = resolve_target_path(include_node.target, base_dir)
+      return unless chain.include?(full)
+
+      raise Coradoc::CircularIncludeError.new(
+        target: include_node.target,
+        chain: chain
+      )
+    end
+
+    def resolve_target_path(target, base_dir)
+      File.expand_path(target, base_dir)
+    end
+  end
+end

--- a/coradoc/spec/coradoc/core_model/include_spec.rb
+++ b/coradoc/spec/coradoc/core_model/include_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Coradoc::CoreModel::Include do
+  describe 'attribute defaults' do
+    it 'defaults target to nil' do
+      expect(described_class.new.target).to be_nil
+    end
+
+    it 'defaults options to an empty IncludeOptions' do
+      expect(described_class.new.options).to be_a(Coradoc::CoreModel::IncludeOptions)
+    end
+
+    it 'defaults raw_options to empty string' do
+      expect(described_class.new.raw_options).to eq('')
+    end
+
+    it 'defaults line_break to \n' do
+      expect(described_class.new.line_break).to eq("\n")
+    end
+  end
+
+  describe 'semantic_type' do
+    it 'reports :include' do
+      expect(described_class.semantic_type).to eq(:include)
+    end
+  end
+end
+
+RSpec.describe Coradoc::CoreModel::IncludeOptions do
+  describe 'attribute defaults' do
+    subject(:options) { described_class.new }
+
+    it 'defaults tags to an empty array' do
+      expect(options.tags).to eq([])
+    end
+
+    it 'defaults tags_wildcard to false' do
+      expect(options.tags_wildcard).to eq(false)
+    end
+
+    it 'defaults tags_inverted to false' do
+      expect(options.tags_inverted).to eq(false)
+    end
+
+    it 'defaults lines_spec to nil' do
+      expect(options.lines_spec).to be_nil
+    end
+
+    it 'defaults leveloffset to nil' do
+      expect(options.leveloffset).to be_nil
+    end
+
+    it 'defaults indent to nil' do
+      expect(options.indent).to be_nil
+    end
+
+    it 'defaults file_encoding to nil' do
+      expect(options.file_encoding).to be_nil
+    end
+  end
+
+  describe '#tags?' do
+    it 'returns false when no tags are set' do
+      expect(described_class.new).not_to be_tags
+    end
+
+    it 'returns true when named tags are set' do
+      expect(described_class.new(tags: ['body'])).to be_tags
+    end
+
+    it 'returns true when wildcard is set' do
+      expect(described_class.new(tags_wildcard: true)).to be_tags
+    end
+
+    it 'returns true when inverted is set' do
+      expect(described_class.new(tags_inverted: true)).to be_tags
+    end
+  end
+
+  describe '#lines?' do
+    it 'returns false when no lines_spec is set' do
+      expect(described_class.new).not_to be_lines
+    end
+
+    it 'returns true when lines_spec is set' do
+      expect(described_class.new(lines_spec: '1..2')).to be_lines
+    end
+  end
+
+  describe '.from_hash' do
+    it 'parses a single tag string into a one-element array' do
+      options = described_class.from_hash('tags' => 'body')
+      expect(options.tags).to eq(['body'])
+    end
+
+    it 'parses a semicolon-separated tag string into multiple tags' do
+      options = described_class.from_hash('tags' => 'a;b;c')
+      expect(options.tags).to eq(%w[a b c])
+    end
+
+    it 'recognizes tags=* as wildcard' do
+      options = described_class.from_hash('tags' => '*')
+      expect(options.tags_wildcard).to eq(true)
+    end
+
+    it 'recognizes tags=** as inverted' do
+      options = described_class.from_hash('tags' => '**')
+      expect(options.tags_inverted).to eq(true)
+    end
+
+    it 'parses a relative leveloffset string into IncludeLevelOffset' do
+      options = described_class.from_hash('leveloffset' => '+2')
+      expect(options.leveloffset.delta).to eq(2)
+      expect(options.leveloffset.mode).to eq('relative')
+    end
+
+    it 'parses an absolute leveloffset string into IncludeLevelOffset' do
+      options = described_class.from_hash('leveloffset' => '3')
+      expect(options.leveloffset.delta).to eq(3)
+      expect(options.leveloffset.mode).to eq('absolute')
+    end
+
+    it 'parses indent as an integer' do
+      options = described_class.from_hash('indent' => '2')
+      expect(options.indent).to eq(2)
+    end
+  end
+end
+
+RSpec.describe Coradoc::CoreModel::IncludeLevelOffset do
+  describe '.parse' do
+    it 'parses +N as relative positive' do
+      offset = described_class.parse('+2')
+      expect(offset.mode).to eq('relative')
+      expect(offset.delta).to eq(2)
+    end
+
+    it 'parses -N as relative negative' do
+      offset = described_class.parse('-1')
+      expect(offset.mode).to eq('relative')
+      expect(offset.delta).to eq(-1)
+    end
+
+    it 'parses a bare number as absolute' do
+      offset = described_class.parse('3')
+      expect(offset.mode).to eq('absolute')
+      expect(offset.delta).to eq(3)
+    end
+
+    it 'returns nil for empty input' do
+      expect(described_class.parse(nil)).to be_nil
+      expect(described_class.parse('')).to be_nil
+    end
+  end
+
+  describe '#apply' do
+    it 'shifts by delta for relative mode' do
+      offset = described_class.new(mode: 'relative', delta: 2)
+      expect(offset.apply(1)).to eq(3)
+    end
+
+    it 'forces the level for absolute mode' do
+      offset = described_class.new(mode: 'absolute', delta: 4)
+      expect(offset.apply(1)).to eq(4)
+    end
+  end
+
+  describe '#to_s' do
+    it 'renders +N for relative positive' do
+      expect(described_class.new(mode: 'relative', delta: 2).to_s).to eq('+2')
+    end
+
+    it 'renders -N for relative negative' do
+      expect(described_class.new(mode: 'relative', delta: -1).to_s).to eq('-1')
+    end
+
+    it 'renders the bare number for absolute' do
+      expect(described_class.new(mode: 'absolute', delta: 3).to_s).to eq('3')
+    end
+  end
+end

--- a/coradoc/spec/coradoc/include_directives_spec.rb
+++ b/coradoc/spec/coradoc/include_directives_spec.rb
@@ -1,0 +1,576 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'pathname'
+require 'json'
+require 'coradoc/asciidoc'
+require 'coradoc-mirror'
+
+# Parity spec for the +include::+ directive, validated against
+# SPEC-include-directives-parity.md. Covers both the graph mode
+# (Coradoc.parse — Include nodes survive as link edges) and the
+# explicit flat mode (Coradoc.resolve_includes — Include nodes are
+# spliced inline).
+RSpec.describe 'include:: directives', :asciidoc do
+  let(:main_adoc) { 'main.adoc' }
+
+  def with_fixtures(name)
+    Dir.mktmpdir("coradoc-include-#{name}-") do |dir|
+      yield Pathname.new(dir)
+    end
+  end
+
+  def write(dir, mapping)
+    mapping.each do |rel, content|
+      target = dir.join(rel)
+      target.dirname.mkpath
+      target.write(content)
+    end
+  end
+
+  def parse_adoc(text)
+    Coradoc.parse(text, format: :asciidoc)
+  end
+
+  def body_text(core_or_hash)
+    hash = core_or_hash.is_a?(Hash) ? core_or_hash : mirror_json(core_or_hash)
+    texts = []
+    walker = ->(n) {
+      texts << n['text'] if n['type'] == 'text'
+      (n['content'] || []).each { |c| walker.call(c) }
+    }
+    walker.call(hash)
+    texts.join
+  end
+
+  def mirror_json(core)
+    JSON.parse(Coradoc.serialize(core, to: :mirror_json))
+  end
+
+  def all_types(core_or_hash)
+    hash = core_or_hash.is_a?(Hash) ? core_or_hash : mirror_json(core_or_hash)
+    types = []
+    walker = ->(n) {
+      types << n['type']
+      (n['content'] || []).each { |c| walker.call(c) }
+    }
+    walker.call(hash)
+    types
+  end
+
+  # ── Mode 2: Graph-mode AST preservation ──
+
+  describe 'graph mode (Coradoc.parse — no I/O)' do
+    it 'emits an Include node for an include directive' do
+      core = parse_adoc("Before.\n\ninclude::snippet.adoc[]\n\nAfter.\n")
+
+      types = all_types(core)
+      expect(types).to include('include')
+    end
+
+    it 'does not perform file I/O for a missing target' do
+      expect {
+        parse_adoc("include::does_not_exist.adoc[]\n")
+      }.not_to raise_error
+    end
+
+    it 'round-trips the include directive through adoc serialization' do
+      core = parse_adoc("Before.\n\ninclude::snippet.adoc[tags=body,leveloffset=+2]\n\nAfter.\n")
+      expect(Coradoc.serialize(core, to: :asciidoc))
+        .to eq("Before.\n\ninclude::snippet.adoc[tags=body,leveloffset=+2]\n\nAfter.")
+    end
+
+    it 'preserves raw_options verbatim for round-trip' do
+      core = parse_adoc("include::x.adoc[tags=a;b,lines=1..3,indent=2,leveloffset=+1]\n")
+      include_node = core.children.find { |c| c.is_a?(Coradoc::CoreModel::Include) }
+      expect(include_node.raw_options).to eq('tags=a;b,lines=1..3,indent=2,leveloffset=+1')
+    end
+  end
+
+  # ── Mode 1: flat-mode resolution via Coradoc.resolve_includes ──
+
+  describe 'flat mode (Coradoc.resolve_includes — explicit step)' do
+    it 'does not mutate the parsed document' do
+      with_fixtures('immutability') do |dir|
+        write(dir, 'main.adoc' => "Before.\n\ninclude::snippet.adoc[]\n\nAfter.\n",
+                    'snippet.adoc' => "Included content.\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        original_types = all_types(core)
+
+        _ = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(all_types(core)).to eq(original_types)
+      end
+    end
+
+    it 'resolves a whole-file include' do
+      with_fixtures('whole_file') do |dir|
+        write(dir, 'main.adoc' => "Before.\n\ninclude::snippet.adoc[]\n\nAfter.\n",
+                    'snippet.adoc' => "Included content.\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to eq('Before.Included content.After.')
+      end
+    end
+
+    it 'resolves relative subdirectory paths' do
+      with_fixtures('rel_path') do |dir|
+        write(dir, 'main.adoc' => "include::sections/intro.adoc[]\n",
+                    'sections/intro.adoc' => "Intro body.\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to eq('Intro body.')
+      end
+    end
+
+    it 'resolves paths that traverse parent directories (with allow_unsafe)' do
+      with_fixtures('parent_path') do |dir|
+        write(dir, 'sub/main.adoc' => "include::../shared.adoc[]\n",
+                    'shared.adoc' => "Shared body.\n")
+
+        core = parse_adoc(dir.join('sub/main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.join('sub').to_s,
+                                              allow_unsafe: true)
+        expect(body_text(flat)).to eq('Shared body.')
+      end
+    end
+
+    it 'resolves multiple consecutive includes in source order' do
+      with_fixtures('multiple') do |dir|
+        write(dir, 'main.adoc' => "include::a.adoc[]\ninclude::b.adoc[]\ninclude::c.adoc[]\n",
+                    'a.adoc' => "A-body.\n",
+                    'b.adoc' => "B-body.\n",
+                    'c.adoc' => "C-body.\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to eq('A-body.B-body.C-body.')
+      end
+    end
+
+    it 'resolves an include at the start of the document' do
+      with_fixtures('leading') do |dir|
+        write(dir, 'main.adoc' => "include::snippet.adoc[]\n\nTrailing.\n",
+                    'snippet.adoc' => "Leading body.\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to eq('Leading body.Trailing.')
+      end
+    end
+
+    it 'resolves an include at the end of the document' do
+      with_fixtures('trailing') do |dir|
+        write(dir, 'main.adoc' => "Leading.\n\ninclude::snippet.adoc[]\n",
+                    'snippet.adoc' => "Trailing body.\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to eq('Leading.Trailing body.')
+      end
+    end
+  end
+
+  # ── Tag-based selection ──
+
+  describe 'tags= selection' do
+    it 'extracts a single named tag region' do
+      with_fixtures('tag_single') do |dir|
+        write(dir, 'main.adoc' => "include::snippet.adoc[tags=body]\n",
+                    'snippet.adoc' => "// tag::body[]\nIncluded body.\n// end::body[]\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to eq('Included body.')
+      end
+    end
+
+    it 'extracts multiple semicolon-separated tags' do
+      with_fixtures('tag_multi') do |dir|
+        write(dir, 'main.adoc' => "include::snippet.adoc[tags=intro;conclusion]\n",
+                    'snippet.adoc' => %(// tag::intro[]\nIntro body.\n// end::intro[]\n\nmiddle\n\n// tag::conclusion[]\nConclusion body.\n// end::conclusion[]\n))
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        text = body_text(flat)
+        expect(text).to include('Intro body.')
+        expect(text).to include('Conclusion body.')
+        expect(text).not_to include('middle')
+      end
+    end
+
+    it 'treats tags=* as wildcard selecting all tagged regions' do
+      with_fixtures('tag_wildcard') do |dir|
+        write(dir, 'main.adoc' => "include::snippet.adoc[tags=*]\n",
+                    'snippet.adoc' => %(outside\n\n// tag::a[]\nA body.\n// end::a[]\n\nbetween\n\n// tag::b[]\nB body.\n// end::b[]\n))
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        text = body_text(flat)
+        expect(text).to include('A body.')
+        expect(text).to include('B body.')
+        expect(text).not_to include('outside')
+        expect(text).not_to include('between')
+      end
+    end
+
+    it 'treats tags=** as inverted wildcard excluding tagged regions' do
+      with_fixtures('tag_inverted') do |dir|
+        write(dir, 'main.adoc' => "include::snippet.adoc[tags=**]\n",
+                    'snippet.adoc' => %(
+outside-tagged
+
+// tag::a[]
+A body.
+// end::a[]
+).lstrip)
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to include('outside-tagged')
+        expect(body_text(flat)).not_to include('A body.')
+      end
+    end
+
+    it 'yields empty content for an unknown tag name' do
+      with_fixtures('tag_unknown') do |dir|
+        write(dir, 'main.adoc' => "Before.\n\ninclude::snippet.adoc[tags=nonexistent]\n\nAfter.\n",
+                    'snippet.adoc' => "// tag::real[]\nbody\n// end::real[]\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to eq('Before.After.')
+      end
+    end
+
+    it 'does not emit the tag markers as text' do
+      with_fixtures('tag_no_markers') do |dir|
+        write(dir, 'main.adoc' => "include::snippet.adoc[tags=body]\n",
+                    'snippet.adoc' => "// tag::body[]\ninside\n// end::body[]\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        text = body_text(flat)
+        expect(text).not_to include('tag::')
+        expect(text).not_to include('end::')
+      end
+    end
+  end
+
+  # ── Line-based selection ──
+
+  describe 'lines= selection' do
+    it 'extracts a single line by number' do
+      with_fixtures('lines_single') do |dir|
+        snippet = "L1\nL2\nL3\nL4\nL5\n"
+        write(dir, 'main.adoc' => "include::snippet.adoc[lines=2]\n",
+                    'snippet.adoc' => snippet)
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to eq('L2')
+      end
+    end
+
+    it 'extracts a line range' do
+      with_fixtures('lines_range') do |dir|
+        snippet = "L1\nL2\nL3\nL4\nL5\n"
+        write(dir, 'main.adoc' => "include::snippet.adoc[lines=2..4]\n",
+                    'snippet.adoc' => snippet)
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        text = body_text(flat)
+        expect(text).to include('L2', 'L3', 'L4')
+        expect(text).not_to include('L1', 'L5')
+      end
+    end
+
+    it 'extracts discontinuous ranges (semicolon-separated)' do
+      with_fixtures('lines_discontinuous') do |dir|
+        snippet = "L1\nL2\nL3\nL4\nL5\n"
+        write(dir, 'main.adoc' => "include::snippet.adoc[lines=1..2;5]\n",
+                    'snippet.adoc' => snippet)
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        text = body_text(flat)
+        expect(text).to include('L1', 'L2', 'L5')
+        expect(text).not_to include('L3', 'L4')
+      end
+    end
+
+    it 'clamps out-of-bounds ranges gracefully' do
+      with_fixtures('lines_oob') do |dir|
+        snippet = "L1\nL2\nL3\n"
+        write(dir, 'main.adoc' => "include::snippet.adoc[lines=2..99]\n",
+                    'snippet.adoc' => snippet)
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        text = body_text(flat)
+        expect(text).to include('L2', 'L3')
+        expect(text).not_to include('L1')
+      end
+    end
+  end
+
+  # ── Indentation ──
+
+  describe 'indent= selection' do
+    it 'strips all leading whitespace when indent=0' do
+      with_fixtures('indent_zero') do |dir|
+        snippet = "    indented line one\n    indented line two\n"
+        write(dir, 'main.adoc' => "include::snippet.adoc[indent=0]\n",
+                    'snippet.adoc' => snippet)
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        text = body_text(flat)
+        expect(text).to include('indented line one')
+        expect(text).not_to match(/^\s+\S/)
+      end
+    end
+  end
+
+  # ── Recursion ──
+
+  describe 'recursive resolution' do
+    it 'resolves nested includes recursively' do
+      with_fixtures('nested') do |dir|
+        write(dir, 'main.adoc' => "Top.\n\ninclude::a.adoc[]\n",
+                    'a.adoc' => "A.\n\ninclude::b.adoc[]\n",
+                    'b.adoc' => "B body.\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to eq('Top.A.B body.')
+      end
+    end
+
+    it 'resolves recursive includes relative to the including file' do
+      with_fixtures('nested_relative') do |dir|
+        write(dir, 'main.adoc' => "include::sub/a.adoc[]\n",
+                    'sub/a.adoc' => "A.\n\ninclude::b.adoc[]\n",
+                    'sub/b.adoc' => "B body.\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+        expect(body_text(flat)).to eq('A.B body.')
+      end
+    end
+
+    it 'detects circular includes' do
+      with_fixtures('circular') do |dir|
+        write(dir, 'main.adoc' => "include::a.adoc[]\n",
+                    'a.adoc' => "include::b.adoc[]\n",
+                    'b.adoc' => "include::a.adoc[]\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        expect {
+          Coradoc.resolve_includes(core, base_dir: dir.to_s)
+        }.to raise_error(Coradoc::CircularIncludeError)
+      end
+    end
+
+    it 'detects self-including files' do
+      with_fixtures('self_include') do |dir|
+        write(dir, 'main.adoc' => "include::main.adoc[]\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        expect {
+          Coradoc.resolve_includes(core, base_dir: dir.to_s)
+        }.to raise_error(Coradoc::CircularIncludeError)
+      end
+    end
+
+    it 'respects the configured max depth' do
+      with_fixtures('max_depth') do |dir|
+        write(dir, 'main.adoc' => "include::a.adoc[]\n",
+                    'a.adoc' => "include::b.adoc[]\n",
+                    'b.adoc' => "B body.\n")
+
+        core = parse_adoc(dir.join('main.adoc').read)
+        expect {
+          Coradoc.resolve_includes(core, base_dir: dir.to_s, max_depth: 1)
+        }.to raise_error(Coradoc::IncludeDepthExceededError)
+      end
+    end
+  end
+
+  # ── Missing-file handling ──
+
+  describe 'missing_include policy' do
+    before do
+      @core = parse_adoc("Before.\n\ninclude::missing.adoc[]\n\nAfter.\n")
+    end
+
+    describe 'line-ending normalization (Windows parity)' do
+      it 'parses CRLF line endings in resolved includes' do
+        with_fixtures('crlf') do |dir|
+          # Write fixture in binary mode with explicit CRLF to simulate
+          # files produced on Windows. The resolver must normalize CRLF
+          # → LF before handing content to the parser, matching
+          # asciidoctor's line-ending normalization.
+          File.binwrite(dir.join('snippet.adoc'), "Included content.\r\n")
+
+          core = parse_adoc("Before.\n\ninclude::snippet.adoc[]\n\nAfter.\n")
+          flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+          expect(body_text(flat)).to eq('Before.Included content.After.')
+        end
+      end
+
+      it 'parses CRLF line endings in nested includes' do
+        with_fixtures('crlf_nested') do |dir|
+          # main.adoc has clean LF (matches `Pathname#read` text-mode
+          # translation on Windows). a.adoc/b.adoc have CRLF on disk,
+          # matching what File.binread in the resolver returns before
+          # normalization.
+          dir.join('main.adoc').write("Top.\n\ninclude::a.adoc[]\n")
+          File.binwrite(dir.join('a.adoc'), "A.\r\n\r\ninclude::b.adoc[]\r\n")
+          File.binwrite(dir.join('b.adoc'), "B body.\r\n")
+
+          core = parse_adoc(dir.join('main.adoc').read)
+          flat = Coradoc.resolve_includes(core, base_dir: dir.to_s)
+
+          expect(body_text(flat)).to eq('Top.A.B body.')
+        end
+      end
+    end
+
+    it 'raises by default' do
+      expect {
+        Coradoc.resolve_includes(@core, base_dir: Dir.tmpdir)
+      }.to raise_error(Coradoc::IncludeNotFoundError)
+    end
+
+    it 'warns and skips when :warn' do
+      expect(Coradoc::Logger).to receive(:warn).with(/Include target not found/)
+
+      flat = Coradoc.resolve_includes(@core, base_dir: Dir.tmpdir, missing_include: :warn)
+      expect(body_text(flat)).to eq('Before.After.')
+    end
+
+    it 'is silent when :silent' do
+      expect(Coradoc::Logger).not_to receive(:warn)
+
+      flat = Coradoc.resolve_includes(@core, base_dir: Dir.tmpdir, missing_include: :silent)
+      expect(body_text(flat)).to eq('Before.After.')
+    end
+
+    it 'leaves the directive in place when :passthrough' do
+      flat = Coradoc.resolve_includes(@core, base_dir: Dir.tmpdir, missing_include: :passthrough)
+      expect(all_types(flat)).to include('include')
+    end
+  end
+
+  # ── Path security ──
+
+  describe 'path traversal protection' do
+    it 'blocks .. that escapes the base_dir by default' do
+      with_fixtures('traversal') do |dir|
+        write(dir, 'sub/main.adoc' => "include::../secret.adoc[]\n",
+                    'secret.adoc' => "SECRET\n")
+
+        core = parse_adoc(dir.join('sub/main.adoc').read)
+        expect {
+          Coradoc.resolve_includes(core, base_dir: dir.join('sub').to_s)
+        }.to raise_error(Coradoc::UnsafeIncludeError)
+      end
+    end
+
+    it 'allows .. when explicitly enabled' do
+      with_fixtures('traversal_allowed') do |dir|
+        write(dir, 'sub/main.adoc' => "include::../secret.adoc[]\n",
+                    'secret.adoc' => "SECRET\n")
+
+        core = parse_adoc(dir.join('sub/main.adoc').read)
+        flat = Coradoc.resolve_includes(core, base_dir: dir.join('sub').to_s,
+                                              allow_unsafe: true)
+        expect(body_text(flat)).to eq('SECRET')
+      end
+    end
+  end
+
+  # ── Custom resolver ──
+
+  describe 'custom resolver' do
+    it 'invokes the resolver with parsed options' do
+      calls = []
+      resolver = Object.new
+      def resolver.call(target:, base_dir:, options:, context:)
+        self.calls << { target: target, options_tags: options.tags }
+        "from-resolver\n"
+      end
+
+      # Stub the calls capture via a wrapper
+      captured_calls = calls
+      real_resolver = Object.new
+      real_resolver.define_singleton_method(:call) do |target:, base_dir:, options:, context:|
+        captured_calls << { target: target, tags: options.tags }
+        "from-resolver\n"
+      end
+
+      core = parse_adoc("include::custom.adoc[]\n")
+      flat = Coradoc.resolve_includes(core, base_dir: '/tmp', resolver: real_resolver)
+
+      expect(captured_calls.length).to eq(1)
+      expect(captured_calls.first[:target]).to eq('custom.adoc')
+      expect(body_text(flat)).to include('from-resolver')
+    end
+
+    it 'passes the parsed options through to the resolver' do
+      captured = nil
+      resolver = Object.new
+      resolver.define_singleton_method(:call) do |target:, base_dir:, options:, context:|
+        captured = options
+        "body\n"
+      end
+
+      core = parse_adoc("include::custom.adoc[tags=body;intro,lines=1..5]\n")
+      Coradoc.resolve_includes(core, base_dir: '/tmp', resolver: resolver)
+
+      expect(captured).to be_a(Coradoc::CoreModel::IncludeOptions)
+      expect(captured.tags).to eq(%w[body intro])
+      expect(captured.lines_spec).to eq('1..5')
+    end
+
+    it 'routes missing-target errors through the missing_include policy' do
+      resolver = Object.new
+      def resolver.call(target:, base_dir:, options:, context:)
+        raise Coradoc::IncludeNotFoundError.new(target: target)
+      end
+
+      core = parse_adoc("include::missing.adoc[]\n")
+
+      expect(Coradoc::Logger).to receive(:warn).with(/Include target not found/)
+      flat = Coradoc.resolve_includes(core, base_dir: '/tmp',
+                                             missing_include: :warn,
+                                             resolver: resolver)
+      expect(body_text(flat)).to eq('')
+    end
+  end
+end

--- a/coradoc/spec/coradoc/include_selectors_spec.rb
+++ b/coradoc/spec/coradoc/include_selectors_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Pure-function specs for the four include selectors. These do not touch
+# the filesystem — they exercise Tags/Lines/Indent/LevelOffset directly
+# against typed IncludeOptions instances.
+RSpec.describe Coradoc::IncludeSelectors do
+  def opts(attrs = {})
+    Coradoc::CoreModel::IncludeOptions.new(
+      tags: attrs.fetch(:tags, []),
+      tags_wildcard: attrs.fetch(:tags_wildcard, false),
+      tags_inverted: attrs.fetch(:tags_inverted, false),
+      lines_spec: attrs.fetch(:lines_spec, nil),
+      leveloffset: attrs.fetch(:leveloffset, nil),
+      indent: attrs.fetch(:indent, nil)
+    )
+  end
+
+  describe Coradoc::IncludeSelectors::Tags do
+    it 'returns text unchanged when no tags are requested' do
+      expect(described_class.call("body\n", options: opts)).to eq("body\n")
+    end
+
+    it 'extracts the region between tag:: and end:: markers' do
+      text = "// tag::body[]\ninside\n// end::body[]\n"
+      expect(described_class.call(text, options: opts(tags: ['body']))).to eq("inside\n")
+    end
+
+    it 'supports the comment-prefixed form ## tag::name[]' do
+      text = "## tag::body[]\ninside\n## end::body[]\n"
+      expect(described_class.call(text, options: opts(tags: ['body']))).to eq("inside\n")
+    end
+
+    it 'extracts multiple tag regions in source order' do
+      text = %(// tag::a[]\nA\n// end::a[]\nmiddle\n// tag::b[]\nB\n// end::b[]\n)
+      result = described_class.call(text, options: opts(tags: %w[a b]))
+      expect(result).to eq("A\nB\n")
+    end
+
+    it 'returns empty for an unknown tag name' do
+      text = "// tag::body[]\ninside\n// end::body[]\n"
+      expect(described_class.call(text, options: opts(tags: ['nope']))).to eq('')
+    end
+
+    it 'wildcard (*) selects all tagged regions' do
+      text = %(outside\n// tag::a[]\nA\n// end::a[]\nmiddle\n// tag::b[]\nB\n// end::b[]\n)
+      result = described_class.call(text, options: opts(tags_wildcard: true))
+      expect(result).to eq("A\nB\n")
+    end
+
+    it 'inverted (**) selects everything except tagged regions and markers' do
+      text = %(outside\n// tag::a[]\nA\n// end::a[]\nafter\n)
+      result = described_class.call(text, options: opts(tags_inverted: true))
+      expect(result).to include('outside', 'after')
+      expect(result).not_to include('tag::', 'end::', 'A')
+    end
+
+    it 'drops the tag marker lines from the output' do
+      text = "// tag::body[]\ninside\n// end::body[]\n"
+      result = described_class.call(text, options: opts(tags: ['body']))
+      expect(result).not_to include('tag::')
+      expect(result).not_to include('end::')
+    end
+  end
+
+  describe Coradoc::IncludeSelectors::Lines do
+    it 'returns text unchanged when no line spec is set' do
+      expect(described_class.call("body\n", options: opts)).to eq("body\n")
+    end
+
+    it 'selects a single line by 1-indexed number' do
+      expect(described_class.call("a\nb\nc\n", options: opts(lines_spec: '2'))).to eq("b\n")
+    end
+
+    it 'selects an inclusive range' do
+      expect(described_class.call("a\nb\nc\nd\n", options: opts(lines_spec: '2..3')))
+        .to eq("b\nc\n")
+    end
+
+    it 'selects discontinuous ranges separated by semicolons' do
+      expect(described_class.call("a\nb\nc\nd\ne\n", options: opts(lines_spec: '1;3..4')))
+        .to eq("a\nc\nd\n")
+    end
+
+    it 'clamps out-of-bounds ranges to the available content' do
+      expect(described_class.call("a\nb\n", options: opts(lines_spec: '1..99')))
+        .to eq("a\nb\n")
+    end
+  end
+
+  describe Coradoc::IncludeSelectors::Indent do
+    it 'returns text unchanged when no indent is set' do
+      expect(described_class.call("  body\n", options: opts)).to eq("  body\n")
+    end
+
+    it 'strips all leading whitespace when indent=0' do
+      expect(described_class.call("  body\n\ttabs\n", options: opts(indent: 0)))
+        .to eq("body\ntabs\n")
+    end
+  end
+
+  describe Coradoc::IncludeSelectors::LevelOffset do
+    def doc_with_section(level:)
+      Coradoc::CoreModel::DocumentElement.new(
+        children: [Coradoc::CoreModel::SectionElement.new(level: level, title: 'S')]
+      )
+    end
+
+    it 'returns the document unchanged when no offset is set' do
+      doc = doc_with_section(level: 2)
+      result = described_class.call(doc, options: opts)
+      expect(result.children.first.level).to eq(2)
+    end
+
+    it 'shifts levels by a relative offset (+N)' do
+      offset = Coradoc::CoreModel::IncludeLevelOffset.parse('+2')
+      doc = doc_with_section(level: 1)
+      result = described_class.call(doc, options: opts(leveloffset: offset))
+      expect(result.children.first.level).to eq(3)
+    end
+
+    it 'shifts levels by a negative offset' do
+      offset = Coradoc::CoreModel::IncludeLevelOffset.parse('-1')
+      doc = doc_with_section(level: 3)
+      result = described_class.call(doc, options: opts(leveloffset: offset))
+      expect(result.children.first.level).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Markdown-style ```-fenced code blocks collapsed into a single paragraph with fence characters preserved as literal text. See `BUG-markdown-fenced-code-blocks.md`.

## Fix

Add `markdown_code_block` parser rule that recognises 3+ backtick fences with optional language tag. Body is treated as verbatim source. Reuses the existing `Model::Block::SourceCode` pipeline so serializer and ToCoreModel transformer work unchanged.

### Changes
- `parser/block.rb`: new `markdown_code_block` rule + extended `block_delimiter` to recognise backticks so paragraphs reject them
- `transformer/block_rules.rb`: pass `block[:language]` through to opts
- `transformer/block_type_classifier.rb`: new backtick entry → SourceCode factory with `lang` populated
- `spec/coradoc/asciidoc/integration_pipeline_spec.rb`: Fix 21 (6 specs)

### Out of scope
4-space indented code blocks — Markdown convention that conflicts with AsciiDoc's indentation rules; acknowledged as unsupported in the bug report.

### Behaviour

```ruby ... ``` is now a synonym for `[source,ruby]\n---- ... ----`.