### PR TITLE
CoreModel programmatic API: Base.build, per-node predicates, OutputArtifact

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/block.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/block.rb
@@ -105,12 +105,24 @@ module Coradoc
         end
 
         def block_content(n_deep = 3)
-          c = block_image
+          block_container_content(n_deep).repeat(1)
+        end
+
+        # Single source of truth for "what can appear inside a non-verbatim
+        # block container". Used by block_content, block_style (non-verbatim
+        # branch), and block_style_exact (non-verbatim branch).
+        #
+        # `table` is listed before `text_line` so a leading `|===` is parsed
+        # as a table rather than mis-bracketed as text. The recursive `block`
+        # alternative handles every other delimited block.
+        def block_container_content(n_deep)
+          c = table.as(:table)
+          c |= block_image
           c |= block(n_deep - 1) if n_deep.positive?
           c |= list
           c |= text_line(false, unguarded: true)
           c |= empty_line.as(:line_break)
-          c.repeat(1)
+          c
         end
 
         # Block delimiter: 4+ identical characters, or 2 dashes for open
@@ -155,12 +167,7 @@ module Coradoc
                         text_line(false, unguarded: true, verbatim: true) |
                           empty_line.as(:line_break)
                       else
-                        c = block_image
-                        c |= block(n_deep - 1) if n_deep.positive?
-                        c |= list
-                        c |= text_line(false, unguarded: true)
-                        c |= empty_line.as(:line_break)
-                        c
+                        block_container_content(n_deep)
                       end
 
             (closing_pattern.absent? >> content).repeat(1)
@@ -213,12 +220,7 @@ module Coradoc
                         text_line(false, unguarded: true, verbatim: true) |
                           empty_line.as(:line_break)
                       else
-                        alt = block_image
-                        alt |= block(n_deep - 1) if n_deep.positive?
-                        alt |= list
-                        alt |= text_line(false, unguarded: true)
-                        alt |= empty_line.as(:line_break)
-                        alt
+                        block_container_content(n_deep)
                       end
 
             (closing_pattern.absent? >> content).repeat(1)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers.rb
@@ -11,6 +11,7 @@ module Coradoc
         autoload :TableTransformer, "#{__dir__}/element_transformers/table_transformer"
         autoload :OtherTransformer, "#{__dir__}/element_transformers/other_transformer"
         autoload :IncludeTransformer, "#{__dir__}/element_transformers/include_transformer"
+        autoload :AdmonitionStyles, "#{__dir__}/element_transformers/admonition_styles"
       end
     end
   end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/admonition_styles.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/admonition_styles.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module AsciiDoc
+    module Transform
+      module ElementTransformers
+        # Admonition style registry. Single source of truth for "which
+        # positional attribute names map to an admonition block."
+        #
+        # Built-in AsciiDoc admonition styles are always recognized. Callers
+        # can register additional styles (e.g. +DANGER+, +SAFETY+) without
+        # modifying dispatch code — the registry is consulted by every
+        # block-form transformer that needs to decide between an admonition
+        # and the block's native type.
+        module AdmonitionStyles
+          BUILTIN = %w[note tip warning caution important editor todo].freeze
+
+          @custom = []
+
+          class << self
+            # True if +style+ (case-insensitive) is a known admonition style.
+            def admonition?(style)
+              return false if style.nil?
+
+              name = style.to_s.downcase
+              BUILTIN.include?(name) || custom.include?(name)
+            end
+
+            # Register an additional admonition style. Open for extension.
+            def register(style)
+              name = style.to_s.downcase
+              @custom << name unless @custom.include?(name) || BUILTIN.include?(name)
+              self
+            end
+
+            # Reset custom registrations. Intended for specs.
+            def reset!
+              @custom = []
+              self
+            end
+
+            def custom
+              @custom.dup
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
@@ -47,7 +47,53 @@ module Coradoc
             end
 
             def transform_pass_block(block)
+              style = first_positional_attr(block)
+              return transform_stem_block(block, style) if STEM_STYLES.key?(style.to_s.downcase)
+
               transform_verbatim_block(block, Coradoc::CoreModel::PassBlock)
+            end
+
+            # AsciiDoc recognizes three STEM block styles. The default
+            # `[stem]` resolves to LaTeX; the other two name their
+            # interpreter explicitly. Single source of truth for the
+            # style→language mapping.
+            STEM_STYLES = {
+              'stem' => 'latex',
+              'latexmath' => 'latex',
+              'asciimath' => 'asciimath'
+            }.freeze
+
+            def transform_stem_block(block, style)
+              language = STEM_STYLES.fetch(style.to_s.downcase, 'latex')
+              block = transform_verbatim_block(block, Coradoc::CoreModel::StemBlock)
+              block.language = language
+              block
+            end
+
+            # Dispatch entry point for any block whose AsciiDoc model carries
+            # an attribute list (delimited blocks + open blocks). Per the
+            # AsciiDoc spec, every delimited block accepts admonition styles
+            # in its attribute line. Admonition style wins for example,
+            # sidebar, quote, and open blocks; verbatim blocks (source,
+            # listing) intentionally ignore it because their verbatim
+            # semantics are stronger than the annotation label.
+            def transform_with_admonition_check(block, native_class)
+              style = first_positional_attr(block)
+              return transform_admonition_block(block, style) if AdmonitionStyles.admonition?(style)
+
+              transform_typed_block(block, native_class)
+            end
+
+            def transform_example_block(block)
+              transform_with_admonition_check(block, Coradoc::CoreModel::ExampleBlock)
+            end
+
+            def transform_sidebar_block(block)
+              transform_with_admonition_check(block, Coradoc::CoreModel::SidebarBlock)
+            end
+
+            def transform_quote_block(block)
+              transform_with_admonition_check(block, Coradoc::CoreModel::QuoteBlock)
             end
 
             # Open blocks (`--`) are generic containers. AsciiDoc allows
@@ -60,41 +106,53 @@ module Coradoc
             def transform_open_block(block)
               semantic = open_block_semantic(block)
               case semantic
-              when :source_code
+              when :source
                 transform_source_block(block)
               when :listing
                 transform_listing_from_open(block)
               when :literal
                 transform_literal_from_open(block)
               when :admonition
-                transform_admonition_from_open(block)
+                transform_admonition_block(block, first_positional_attr(block))
               else
                 transform_typed_block(block, Coradoc::CoreModel::OpenBlock)
               end
             end
 
-            ADMONITION_TYPES = %w[note tip warning caution important].freeze
+            VERBATILE_CAST_STYLES = %w[source listing literal].freeze
 
             def open_block_semantic(block)
+              style = first_positional_attr(block)
+              return nil unless style
+
+              case style.to_s.downcase
+              when *VERBATILE_CAST_STYLES then :"#{style.downcase}"
+              else :admonition if AdmonitionStyles.admonition?(style)
+              end
+            end
+
+            # Returns the first positional attribute on the block's
+            # attribute list as a String, or nil if absent. Centralizes the
+            # shape-walking that was previously inlined in
+            # `transform_admonition_from_open` and `open_block_semantic`.
+            def first_positional_attr(block)
               attrs = block.attributes
               return nil unless attrs.is_a?(Coradoc::AsciiDoc::Model::AttributeList)
 
               first = attrs.positional&.first
               return nil unless first.is_a?(Coradoc::AsciiDoc::Model::AttributeListAttribute)
 
-              case first.value.to_s.downcase
-              when 'source' then :source_code
-              when 'listing' then :listing
-              when 'literal' then :literal
-              when *ADMONITION_TYPES then :admonition
-              end
+              first.value.to_s
             end
 
-            def transform_admonition_from_open(block)
-              type = block.attributes.positional.first.value.to_s.downcase
+            # Single admonition dispatch used by every block-form path
+            # (example / sidebar / quote / pass / open). Builds an
+            # AnnotationBlock with annotation_type set from the style and
+            # the block's body lines joined into a single content string.
+            def transform_admonition_block(block, type)
               content_lines = Array(block.lines).map { |line| ToCoreModel.extract_text_content(line) }.join("\n")
               Coradoc::CoreModel::AnnotationBlock.new(
-                annotation_type: type,
+                annotation_type: type.to_s.downcase,
                 content: content_lines,
                 title: ToCoreModel.extract_title_text(block.title)
               )

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
@@ -21,7 +21,7 @@ module Coradoc
             # line; we join with "\n" so whitespace, indentation, and blank
             # lines are preserved. Treating these as paragraphs would collapse
             # whitespace and join consecutive lines into a single flowing text.
-            def transform_verbatim_block(block, klass)
+            def transform_verbatim_block(block, klass, language_override: nil)
               non_break_lines = Array(block.lines).reject do |line|
                 line.is_a?(Coradoc::AsciiDoc::Model::LineBreak) ||
                   line.is_a?(Coradoc::AsciiDoc::Model::Break::PageBreak)
@@ -34,7 +34,7 @@ module Coradoc
                 id: block.id,
                 title: ToCoreModel.extract_title_text(block.title),
                 content: content_lines,
-                language: ToCoreModel.extract_block_language(block)
+                language: language_override || ToCoreModel.extract_block_language(block)
               )
             end
 
@@ -65,9 +65,8 @@ module Coradoc
 
             def transform_stem_block(block, style)
               language = STEM_STYLES.fetch(style.to_s.downcase, 'latex')
-              block = transform_verbatim_block(block, Coradoc::CoreModel::StemBlock)
-              block.language = language
-              block
+              transform_verbatim_block(block, Coradoc::CoreModel::StemBlock,
+                                       language_override: language)
             end
 
             # Dispatch entry point for any block whose AsciiDoc model carries

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/document_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/document_transformer.rb
@@ -12,6 +12,7 @@ module Coradoc
               children = ToCoreModel.transform(doc.sections || doc.contents || [])
               children = CalloutMerger.call(children)
               children = prepend_frontmatter(children, doc.frontmatter)
+              children = insert_title_heading_after_frontmatter(children, title_text)
 
               Coradoc::CoreModel::DocumentElement.new(
                 id: doc.id,
@@ -30,6 +31,31 @@ module Coradoc
 
               block = Coradoc::CoreModel::FrontmatterBlock::Codec.from_yaml(frontmatter_text)
               [block, *children]
+            end
+
+            # Per the AsciiDoc spec, the document title (`= Title`) is the
+            # document's level-0 heading. Asciidoctor renders it as an
+            # <h1> at the top of the body by default. Emit a HeaderElement
+            # at level 0 so consumers that walk the body's children see the
+            # title (the standard ProseMirror/HTML rendering pattern)
+            # instead of having to read Document.title separately.
+            #
+            # The title attribute on DocumentElement is preserved for
+            # consumers that read it directly. The title heading is placed
+            # after any FrontmatterBlock (frontmatter is metadata that
+            # precedes the body).
+            def insert_title_heading_after_frontmatter(children, title_text)
+              return children if title_text.nil? || title_text.strip.empty?
+
+              title_heading = Coradoc::CoreModel::HeaderElement.new(
+                level: 0,
+                title: title_text,
+                content: title_text
+              )
+              frontmatter_count = children.count do |child|
+                child.is_a?(Coradoc::CoreModel::FrontmatterBlock)
+              end
+              children.insert(frontmatter_count, title_heading)
             end
 
             def transform_section(section, parent_id: nil)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -40,12 +40,18 @@ module Coradoc
                          Coradoc::AsciiDoc::Model::Header.new(title: '')
                        end
 
-              sections, frontmatter = extract_frontmatter(Array(element.children))
+              # Pull FrontmatterBlock out first so strip_title_heading sees
+              # the body children in their natural order (frontmatter →
+              # title heading → body). The reverse-direction strip then
+              # matches on a level-0 HeaderElement wherever it sits among
+              # the remaining children.
+              without_frontmatter, frontmatter = extract_frontmatter(Array(element.children))
+              without_title = strip_title_heading(without_frontmatter, element.title)
 
               Coradoc::AsciiDoc::Model::Document.new(
                 id: element.id,
                 header: header,
-                sections: flatten_children(sections),
+                sections: flatten_children(without_title),
                 frontmatter: frontmatter
               )
             when CoreModel::SectionElement
@@ -62,6 +68,27 @@ module Coradoc
                 contents: flatten_children(element.children)
               )
             end
+          end
+
+          # The forward direction (DocumentTransformer#insert_title_heading_after_frontmatter)
+          # emits a level-0 HeaderElement after any FrontmatterBlock so
+          # consumers that walk the children see the title. On the reverse
+          # path, that HeaderElement would round-trip back as a separate
+          # body element and the title would be emitted twice (once via
+          # the document header, once via the heading child). Drop it
+          # before serialization when it carries the same text as the
+          # document title.
+          def strip_title_heading(children, document_title)
+            return children unless document_title && !document_title.strip.empty?
+
+            index = children.find_index do |child|
+              child.is_a?(CoreModel::HeaderElement) &&
+                child.level.to_i.zero? &&
+                child.title.to_s == document_title.to_s
+            end
+            return children unless index
+
+            children.reject.with_index { |_, i| i == index }
           end
 
           # Transforms each CoreModel child and flattens one level so a

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
@@ -48,14 +48,19 @@ module Coradoc
               priority: 10
             )
 
+            # Quote / Example / Sidebar blocks all share the same dispatch:
+            # check the attribute style for an admonition label first
+            # (`[NOTE]\n====` → AnnotationBlock), fall back to the block's
+            # native CoreModel type. Single source of truth lives in
+            # BlockTransformer#transform_with_admonition_check.
             {
-              Coradoc::AsciiDoc::Model::Block::Quote => Coradoc::CoreModel::QuoteBlock,
-              Coradoc::AsciiDoc::Model::Block::Example => Coradoc::CoreModel::ExampleBlock,
-              Coradoc::AsciiDoc::Model::Block::Side => Coradoc::CoreModel::SidebarBlock
-            }.each do |block_class, core_model_class|
+              Coradoc::AsciiDoc::Model::Block::Quote => :transform_quote_block,
+              Coradoc::AsciiDoc::Model::Block::Example => :transform_example_block,
+              Coradoc::AsciiDoc::Model::Block::Side => :transform_sidebar_block
+            }.each do |block_class, method|
               Registry.register_with_priority(
                 block_class,
-                ->(model) { Blk.transform_typed_block(model, core_model_class) },
+                ->(model) { Blk.public_send(method, model) },
                 priority: 10
               )
             end

--- a/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe 'Integration pipeline fixes' do
     it 'transforms page_break through to CoreModel as nil (filtered out)' do
       core = parse_to_core("= Title\n\nHello\n\n<<<\n\n== Section\n")
       expect(core).to be_a(Coradoc::CoreModel::StructuralElement)
-      expect(core.children.length).to eq(2) # paragraph + section, no page break
+      # title heading (level-0) + paragraph + section, no page break
+      expect(core.children.length).to eq(3)
     end
   end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/block_admonition_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/block_admonition_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+
+RSpec.describe 'Block-form admonitions', :asciidoc do
+  def first_child(adoc)
+    Coradoc.parse(adoc, format: :asciidoc).children.first
+  end
+
+  %w[note tip warning caution important].each do |type|
+    context "with [#{type.upcase}] on an example block (====)" do
+      it "produces AnnotationBlock with annotation_type '#{type}'" do
+        adoc = "[#{type.upcase}]\n====\nbody text\n====\n"
+        block = first_child(adoc)
+        expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+        expect(block.annotation_type).to eq(type)
+      end
+    end
+
+    context "with [#{type.upcase}] on a sidebar block (****)" do
+      it "produces AnnotationBlock with annotation_type '#{type}'" do
+        adoc = "[#{type.upcase}]\n****\nbody text\n****\n"
+        block = first_child(adoc)
+        expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+        expect(block.annotation_type).to eq(type)
+      end
+    end
+
+    context "with [#{type.upcase}] on a quote block (____)" do
+      it "produces AnnotationBlock with annotation_type '#{type}'" do
+        adoc = "[#{type.upcase}]\n____\nbody text\n____\n"
+        block = first_child(adoc)
+        expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+        expect(block.annotation_type).to eq(type)
+      end
+    end
+
+    context "with [#{type.upcase}] on an open block (--)" do
+      it "produces AnnotationBlock with annotation_type '#{type}'" do
+        adoc = "[#{type.upcase}]\n--\nbody text\n--\n"
+        block = first_child(adoc)
+        expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+        expect(block.annotation_type).to eq(type)
+      end
+    end
+  end
+
+  context 'without admonition style' do
+    it 'still produces ExampleBlock for ==== without [NOTE]' do
+      block = first_child("====\nplain\n====\n")
+      expect(block).to be_a(Coradoc::CoreModel::ExampleBlock)
+    end
+
+    it 'still produces SidebarBlock for **** without [NOTE]' do
+      block = first_child("****\nplain\n****\n")
+      expect(block).to be_a(Coradoc::CoreModel::SidebarBlock)
+    end
+
+    it 'still produces QuoteBlock for ____ without [NOTE]' do
+      block = first_child("____\nplain\n____\n")
+      expect(block).to be_a(Coradoc::CoreModel::QuoteBlock)
+    end
+  end
+
+  context 'with custom registered admonition style' do
+    after do
+      Coradoc::AsciiDoc::Transform::ElementTransformers::AdmonitionStyles.reset!
+    end
+
+    it 'recognizes custom-registered styles' do
+      styles = Coradoc::AsciiDoc::Transform::ElementTransformers::AdmonitionStyles
+      styles.register('danger')
+      block = first_child("[DANGER]\n====\nwatch out\n====\n")
+      expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+      expect(block.annotation_type).to eq('danger')
+    end
+  end
+
+  context 'with verbatim source blocks' do
+    it 'does NOT treat [NOTE] on a source block as admonition' do
+      # Source semantics win: NOTE on a source block is just an attribute
+      # on a listing, not an admonition. (Same as today's behavior.)
+      block = first_child("[NOTE]\n----\nputs 'hi'\n----\n")
+      expect(block).to be_a(Coradoc::CoreModel::SourceBlock)
+    end
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/block_container_table_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/block_container_table_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Tables nested inside block containers', :asciidoc do
       adoc = "--\n#{table_adoc}\n--\n"
       open_block = first_child_class(adoc)
       expect(open_block).to be_a(Coradoc::CoreModel::OpenBlock)
-      table = open_block.children.find { it.is_a?(Coradoc::CoreModel::Table) }
+      table = open_block.children.find { |c| c.is_a?(Coradoc::CoreModel::Table) }
       expect(table).not_to be_nil
     end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/block_container_table_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/block_container_table_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+
+RSpec.describe 'Tables nested inside block containers', :asciidoc do
+  let(:table_adoc) do
+    <<~ADOC
+      [cols="1,1"]
+      |===
+      | A | B
+      | 1 | 2
+      |===
+    ADOC
+  end
+
+  def first_child_class(adoc)
+    parsed = Coradoc.parse(adoc, format: :asciidoc)
+    parsed.children.first
+  end
+
+  def child_classes(block)
+    Array(block.children).map(&:class)
+  end
+
+  def has_child_of_class?(block, klass)
+    Array(block.children).any? { |child| child.is_a?(klass) }
+  end
+
+  context 'inside an open block (--)' do
+    it 'preserves the table as a child of the open block' do
+      adoc = "--\n#{table_adoc}\n--\n"
+      open_block = first_child_class(adoc)
+      expect(open_block).to be_a(Coradoc::CoreModel::OpenBlock)
+      table = open_block.children.find { it.is_a?(Coradoc::CoreModel::Table) }
+      expect(table).not_to be_nil
+    end
+
+    it 'preserves prose and table together' do
+      adoc = <<~ADOC
+        --
+        Intro paragraph.
+
+        #{table_adoc.chomp}
+
+        Outro paragraph.
+        --
+      ADOC
+      open_block = first_child_class(adoc)
+      expect(open_block).to be_a(Coradoc::CoreModel::OpenBlock)
+      child_classes = open_block.children.map(&:class)
+      expect(child_classes).to include(Coradoc::CoreModel::Table)
+      expect(child_classes).to include(Coradoc::CoreModel::TextContent)
+      expect(child_classes.count).to be(3)
+    end
+
+    it 'preserves table alongside list siblings' do
+      adoc = <<~ADOC
+        --
+        * item one
+        * item two
+
+        #{table_adoc.chomp}
+        --
+      ADOC
+      open_block = first_child_class(adoc)
+      child_classes = open_block.children.map(&:class)
+      expect(child_classes).to include(Coradoc::CoreModel::ListBlock)
+      expect(child_classes).to include(Coradoc::CoreModel::Table)
+    end
+  end
+
+  context 'inside an example block (====)' do
+    it 'preserves the table as a child' do
+      adoc = "====\n#{table_adoc}\n====\n"
+      example = first_child_class(adoc)
+      expect(example).to be_a(Coradoc::CoreModel::ExampleBlock)
+      expect(has_child_of_class?(example, Coradoc::CoreModel::Table)).to be(true)
+    end
+  end
+
+  context 'inside a sidebar block (****)' do
+    it 'preserves the table as a child' do
+      adoc = "****\n#{table_adoc}\n****\n"
+      sidebar = first_child_class(adoc)
+      expect(sidebar).to be_a(Coradoc::CoreModel::SidebarBlock)
+      expect(has_child_of_class?(sidebar, Coradoc::CoreModel::Table)).to be(true)
+    end
+  end
+
+  context 'inside a quote block (____)' do
+    it 'preserves the table as a child' do
+      adoc = "____\n#{table_adoc}\n____\n"
+      quote = first_child_class(adoc)
+      expect(quote).to be_a(Coradoc::CoreModel::QuoteBlock)
+      expect(has_child_of_class?(quote, Coradoc::CoreModel::Table)).to be(true)
+    end
+  end
+
+  context 'regression: top-level tables' do
+    it 'still parses a top-level table' do
+      table = first_child_class(table_adoc)
+      expect(table).to be_a(Coradoc::CoreModel::Table)
+    end
+  end
+
+  context 'round-trip through mirror JSON' do
+    it 'preserves the table inside an open block in the serialized output' do
+      require 'coradoc-mirror'
+      adoc = "--\n#{table_adoc}\n--\n"
+      json = JSON.parse(Coradoc.serialize(Coradoc.parse(adoc, format: :asciidoc), to: :mirror_json))
+      expect(json.dig('content', 0, 'type')).to eq('open_block')
+      inner_types = (json.dig('content', 0, 'content') || []).map { _1['type'] }
+      expect(inner_types).to include('table')
+    end
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/document_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/document_transformer_spec.rb
@@ -27,9 +27,14 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::DocumentTransf
       expect(result).to be_a(Coradoc::CoreModel::DocumentElement)
       expect(result.id).to eq('doc-1')
       expect(result.title).to eq('My Document')
-      expect(result.children.size).to eq(1)
-      expect(result.children[0]).to be_a(Coradoc::CoreModel::ParagraphBlock)
-      expect(result.children[0].content).to eq('Content')
+      # The document title is prepended as a level-0 HeaderElement so
+      # body-walking consumers see it. The Paragraph follows.
+      expect(result.children.size).to eq(2)
+      expect(result.children[0]).to be_a(Coradoc::CoreModel::HeaderElement)
+      expect(result.children[0].level).to eq(0)
+      expect(result.children[0].title).to eq('My Document')
+      expect(result.children[1]).to be_a(Coradoc::CoreModel::ParagraphBlock)
+      expect(result.children[1].content).to eq('Content')
     end
 
     it 'handles a document without header' do

--- a/coradoc-html/lib/coradoc/html/toc_builder.rb
+++ b/coradoc-html/lib/coradoc/html/toc_builder.rb
@@ -67,6 +67,7 @@ module Coradoc
         items.each do |item|
           next unless item.is_a?(CoreModel::StructuralElement)
           next unless item.section? || item.header?
+          next if item.is_a?(CoreModel::HeaderElement) && item.document_title?
 
           counters[level] = (counters[level] || 0) + 1
           ((level + 1)..@section_number_levels).each { |i| counters[i] = 0 }

--- a/coradoc-html/lib/coradoc/html/toc_builder.rb
+++ b/coradoc-html/lib/coradoc/html/toc_builder.rb
@@ -67,7 +67,7 @@ module Coradoc
         items.each do |item|
           next unless item.is_a?(CoreModel::StructuralElement)
           next unless item.section? || item.header?
-          next if item.is_a?(CoreModel::HeaderElement) && item.document_title?
+          next if item.document_title?
 
           counters[level] = (counters[level] || 0) + 1
           ((level + 1)..@section_number_levels).each { |i| counters[i] = 0 }

--- a/coradoc-mirror/lib/coradoc/mirror.rb
+++ b/coradoc-mirror/lib/coradoc/mirror.rb
@@ -68,6 +68,8 @@ module Coradoc
                         method_name: :literal)
       registry.register(CoreModel::PassBlock, Handlers::CodeBlock,
                         method_name: :pass)
+      registry.register(CoreModel::StemBlock, Handlers::CodeBlock,
+                        method_name: :stem)
 
       # ── Blocks ──
       registry.register(CoreModel::QuoteBlock, Handlers::Blockquote)

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/code_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/code_block.rb
@@ -5,49 +5,42 @@ module Coradoc
     module Handlers
       module CodeBlock
         def self.source(element, context:)
-          build_code_block(element, context)
+          build_code_block(element, context, node_class: Node::CodeBlock)
         end
 
         def self.listing(element, context:)
-          build_code_block(element, context)
+          build_code_block(element, context, node_class: Node::CodeBlock)
         end
 
         def self.literal(element, context:)
-          build_code_block(element, context)
+          build_code_block(element, context, node_class: Node::LiteralBlock)
         end
 
         def self.pass(element, context:)
-          build_code_block(element, context, passthrough: true)
+          build_code_block(element, context, node_class: Node::PassBlock, passthrough: true)
+        end
+
+        def self.stem(element, context:)
+          build_code_block(element, context, node_class: Node::StemBlock)
         end
 
         class << self
           private
 
-          def build_code_block(element, context, passthrough: false)
+          def build_code_block(element, context, node_class:, passthrough: false)
             text = extract_text(element)
             js_mode = context.partition_structural
+            attrs = Node::CodeBlock::Attrs.new(
+              title: element.title,
+              language: element.language,
+              passthrough: passthrough || nil,
+              text: js_mode ? text : nil
+            )
 
             if js_mode
-              # @metanorma/mirror JS sourcecode contract: text in attrs.text,
-              # no children. Pre-formatted text rendered via <pre><code>.
-              Node::CodeBlock.new(
-                attrs: Node::CodeBlock::Attrs.new(
-                  title: element.title,
-                  language: element.language,
-                  passthrough: passthrough || nil,
-                  text: text
-                ),
-                content: []
-              )
+              node_class.new(attrs: attrs, content: [])
             else
-              Node::CodeBlock.new(
-                attrs: Node::CodeBlock::Attrs.new(
-                  title: element.title,
-                  language: element.language,
-                  passthrough: passthrough || nil
-                ),
-                content: [context.text_node(text)]
-              )
+              node_class.new(attrs: attrs, content: [context.text_node(text)])
             end
           end
 

--- a/coradoc-mirror/lib/coradoc/mirror/node.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/node.rb
@@ -200,6 +200,26 @@ module Coradoc
         end
       end
 
+      # Literal block — preformatted text (`....` delimiter). Same shape
+      # as CodeBlock but distinguished on the wire so consumers can apply
+      # literal-vs-source rendering/styling.
+      class LiteralBlock < CodeBlock
+        PM_TYPE = 'literal'
+      end
+
+      # Pass block — raw passthrough content (`++++` delimiter). Same
+      # shape as CodeBlock; flagged via attrs.passthrough = true.
+      class PassBlock < CodeBlock
+        PM_TYPE = 'pass'
+      end
+
+      # STEM block — mathematical/scientific markup (`[stem|latexmath|
+      # asciimath]\n++++`). Carries a +language+ attr ('latex' default,
+      # 'asciimath' alternative).
+      class StemBlock < CodeBlock
+        PM_TYPE = 'stem'
+      end
+
       class Blockquote < Node
         PM_TYPE = 'quote'
 

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
@@ -6,25 +6,26 @@ module Coradoc
     #
     # Adding support for a new Mirror node type is purely additive:
     #
-    #   module ReverseBuilder
+    #   # reverse_builder/<name>.rb
+    #   require_relative 'base'
+    #   module Coradoc::Mirror::ReverseBuilder
     #     class Figure < Base
     #       registers 'figure'
-    #
-    #       def build(node)
-    #         CoreModel::Image.new(src: node.src, ...)
-    #       end
+    #       def build(node) = CoreModel::Image.new(...)
     #     end
     #   end
     #
-    # No edits to MirrorToCoreModel or any other existing class. The
-    # registry is the single source of truth for "which type string maps
-    # to which builder" (MECE).
+    # Then add a single `require_relative` for the new file below. No edits
+    # to MirrorToCoreModel or any other existing class — the registry is
+    # the single source of truth for "which type string maps to which
+    # builder" (MECE).
     #
     # This file is the autoload target for the ReverseBuilder constant
-    # (see coradoc/mirror.rb). All built-in Builder subclasses live here
-    # so their `registers` calls run at load time and the REGISTRY is
-    # full before any caller references it. Mirror-level mark dispatch
-    # lives in MarkReverseBuilder (mark_reverse_builder.rb).
+    # (see coradoc/mirror.rb). Each Builder subclass lives in its own
+    # file under reverse_builder/; eager-requiring them here populates
+    # the REGISTRY at load time so every caller sees a full registry.
+    # Mirror-level mark dispatch lives in MarkReverseBuilder
+    # (mark_reverse_builder.rb).
     module ReverseBuilder
       # Not frozen: subclasses call `register` from their class body at
       # load time, and `registers` may fire late via autoload. Freezing
@@ -45,568 +46,51 @@ module Coradoc
         REGISTRY.keys
       end
 
-      # Base class for all reverse builders. Subclasses register one or
-      # more Mirror type strings via `registers` and implement `#build`.
-      # Shared helpers (build_content, extract_text, apply_mark, ...) are
-      # delegated to the context (a MirrorToCoreModel instance), keeping
-      # each builder focused on the per-type mapping only (DRY).
-      class Base
-        attr_reader :context
-
-        def initialize(context)
-          @context = context
-        end
-
-        def build(_node)
-          raise NotImplementedError,
-                "#{self.class} must implement #build(node)"
-        end
-
-        # Shared helpers — all delegate to the context (DRY).
-        def build_content(node) = context.build_content(node)
-        def build_inline_children(node) = context.build_inline_children(node)
-        def build_node(node)            = context.build_node(node)
-        def extract_text(node)          = context.extract_text(node)
-        def apply_mark(inner, mark)     = context.apply_mark(inner, mark)
-        def inline_content(element)     = context.inline_content(element)
-
-        class << self
-          # DSL: declare which Mirror type strings this builder handles.
-          # Multiple strings per builder are allowed (e.g. all JS
-          # SECTION_TYPES route to the same SectionElement builder).
-          def registers(*types)
-            types.each { |t| ReverseBuilder.register(t, self) }
-          end
-        end
-      end
-
-      # ── Structural ──
-
-      class Document < Base
-        registers 'doc'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::DocumentElement.new(
-            title: attrs&.title,
-            id: attrs&.id,
-            children: build_content(node)
-          )
-        end
-      end
-
-      # All JS SECTION_TYPES reverse to a generic SectionElement. Style
-      # information lives in the original AsciiDoc and is preserved only
-      # on the forward side; the reverse side collapses them.
-      class Section < Base
-        registers 'section', 'clause', 'annex', 'content_section',
-                  'abstract', 'foreword', 'introduction',
-                  'acknowledgements', 'terms', 'definitions', 'references'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::SectionElement.new(
-            title: attrs&.title,
-            level: attrs&.level,
-            id: attrs&.id,
-            children: build_content(node)
-          )
-        end
-      end
-
-      class Header < Base
-        registers 'floating_title', 'heading'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::HeaderElement.new(
-            title: attrs&.title,
-            level: attrs&.level,
-            children: build_content(node)
-          )
-        end
-      end
-
-      class Preamble < Base
-        registers 'preface'
-
-        def build(node)
-          CoreModel::PreambleElement.new(children: build_content(node))
-        end
-      end
-
-      # `sections` is a structural container only — unwrap directly into
-      # an array. MirrorToCoreModel#build_content flattens arrays.
-      class Sections < Base
-        registers 'sections'
-
-        def build(node)
-          build_content(node)
-        end
-      end
-
-      # ── Blocks ──
-
-      class Paragraph < Base
-        registers 'paragraph'
-
-        def build(node)
-          CoreModel::ParagraphBlock.new(children: build_inline_children(node))
-        end
-      end
-
-      class CodeBlock < Base
-        registers 'sourcecode'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::SourceBlock.new(
-            content: attrs&.text || extract_text(node),
-            language: attrs&.language,
-            title: attrs&.title
-          )
-        end
-      end
-
-      class Blockquote < Base
-        registers 'quote'
-
-        def build(node)
-          CoreModel::QuoteBlock.new(
-            attribution: node.attrs&.attribution,
-            children: build_content(node)
-          )
-        end
-      end
-
-      class Example < Base
-        registers 'example'
-
-        def build(node)
-          CoreModel::ExampleBlock.new(
-            title: node.attrs&.title,
-            children: build_content(node)
-          )
-        end
-      end
-
-      class Sidebar < Base
-        registers 'sidebar'
-
-        def build(node)
-          CoreModel::SidebarBlock.new(
-            title: node.attrs&.title,
-            children: build_content(node)
-          )
-        end
-      end
-
-      class OpenBlock < Base
-        registers 'open_block'
-
-        def build(node)
-          CoreModel::OpenBlock.new(children: build_content(node))
-        end
-      end
-
-      class Verse < Base
-        registers 'verse'
-
-        def build(node)
-          CoreModel::VerseBlock.new(
-            content: extract_text(node),
-            attribution: node.attrs&.attribution
-          )
-        end
-      end
-
-      class HorizontalRule < Base
-        registers 'horizontal_rule', 'thematic_break'
-
-        def build(_node)
-          CoreModel::HorizontalRuleBlock.new
-        end
-      end
-
-      class Frontmatter < Base
-        registers 'frontmatter'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::FrontmatterBlock.new(
-            schema: attrs&.schema,
-            data: FrontmatterTreeToHash.to_hash(attrs&.entries || [])
-          )
-        end
-      end
-
-      class Admonition < Base
-        registers 'admonition'
-
-        def build(node)
-          CoreModel::AnnotationBlock.new(
-            annotation_type: node.attrs&.admonition_type,
-            content: extract_text(node)
-          )
-        end
-      end
-
-      # ── Lists ──
-
-      class BulletList < Base
-        registers 'bullet_list'
-
-        def build(node)
-          items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
-          CoreModel::ListBlock.new(marker_type: 'unordered', items: items)
-        end
-      end
-
-      class OrderedList < Base
-        registers 'ordered_list'
-
-        def build(node)
-          items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
-          CoreModel::ListBlock.new(marker_type: 'ordered', items: items)
-        end
-      end
-
-      class ListItem < Base
-        registers 'list_item'
-
-        def build(node)
-          children = build_inline_children(node)
-          text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : '' }.join
-
-          CoreModel::ListItem.new(
-            content: text,
-            children: children,
-            nested_list: find_nested_list(node)
-          )
-        end
-
-        private
-
-        def find_nested_list(node)
-          node.content&.each do |child|
-            next unless child.is_a?(Node)
-            return build_node(child) if LIST_TYPES.include?(child.type)
-          end
-          nil
-        end
-      end
-
-      class DefinitionList < Base
-        registers 'dl'
-
-        def build(node)
-          terms = []
-          descriptions = []
-          node.content&.each do |child|
-            next unless child.is_a?(Node)
-
-            case child.type
-            when 'dt' then terms << build_node(child)
-            when 'dd' then descriptions << build_node(child)
-            end
-          end
-
-          items = terms.zip(descriptions).map do |term, desc|
-            CoreModel::DefinitionItem.new(
-              term: inline_content(term),
-              definitions: [inline_content(desc)]
-            )
-          end
-
-          CoreModel::DefinitionList.new(items: items)
-        end
-      end
-
-      class InlineText < Base
-        registers 'dt', 'dd'
-
-        def build(node)
-          children = build_inline_children(node)
-          text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : '' }.join
-          CoreModel::InlineElement.new(content: text)
-        end
-      end
-
-      # ── Media ──
-
-      class Image < Base
-        registers 'image'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::Image.new(
-            src: attrs&.src,
-            alt: attrs&.alt,
-            title: attrs&.title,
-            caption: attrs&.caption,
-            width: attrs&.width,
-            height: attrs&.height
-          )
-        end
-      end
-
-      # JS @metanorma/mirror `figure` wraps an image plus an optional
-      # caption. Reverse: collapse back to a single CoreModel::Image,
-      # promoting the caption child to `caption:` if present.
-      class Figure < Base
-        registers 'figure'
-
-        def build(node)
-          image_child = node.content&.find { |c| c.is_a?(Node) && c.type == 'image' }
-          return nil unless image_child
-
-          image = build_node(image_child)
-          caption = extract_caption(node)
-          image.caption = caption if caption && !image.caption
-          image
-        end
-
-        private
-
-        def extract_caption(node)
-          caption_node = node.content&.find { |c| c.is_a?(Node) && c.type == 'caption' }
-          return nil unless caption_node
-
-          extract_text(caption_node)
-        end
-      end
-
-      # Caption only appears as a Figure child. If encountered standalone,
-      # extract its text as an inline element so it isn't lost.
-      class Caption < Base
-        registers 'caption'
-
-        def build(node)
-          CoreModel::InlineElement.new(content: extract_text(node))
-        end
-      end
-
-      # Include directive: round-trips back to a CoreModel::Include link
-      # node. The text graph is preserved through mirror_json → core.
-      class Include < Base
-        registers 'include'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::Include.new(
-            target: attrs&.target,
-            options: build_options(attrs),
-            raw_options: attrs&.raw_options || ''
-          )
-        end
-
-        private
-
-        def build_options(attrs)
-          return CoreModel::IncludeOptions.new unless attrs
-
-          CoreModel::IncludeOptions.new(
-            tags: Array(attrs.tags),
-            tags_wildcard: attrs.tags == ['*'],
-            tags_inverted: attrs.tags == ['**'],
-            lines_spec: attrs.lines,
-            leveloffset: parse_leveloffset(attrs.leveloffset),
-            indent: attrs.indent,
-            file_encoding: attrs.file_encoding
-          )
-        end
-
-        def parse_leveloffset(raw)
-          return nil if raw.nil? || raw.to_s.empty?
-
-          Coradoc::CoreModel::IncludeLevelOffset.parse(raw.to_s)
-        end
-      end
-
-      # ── Tables ──
-
-      class Table < Base
-        registers 'table'
-
-        def build(node)
-          rows = []
-          node.content&.each do |child|
-            next unless child.is_a?(Node)
-            next unless %w[table_head table_body].include?(child.type)
-
-            child.content&.each do |row_node|
-              rows << build_node(row_node) if row_node.is_a?(Node)
-            end
-          end
-
-          CoreModel::Table.new(title: node.attrs&.title, rows: rows)
-        end
-      end
-
-      class TableHead < Base
-        registers 'table_head'
-
-        def build(node)
-          build_content(node).first || CoreModel::TableRow.new
-        end
-      end
-
-      class TableBody < Base
-        registers 'table_body'
-
-        def build(node)
-          build_content(node).first || CoreModel::TableRow.new
-        end
-      end
-
-      class TableRow < Base
-        registers 'table_row'
-
-        def build(node)
-          cells = build_content(node).select { |c| c.is_a?(CoreModel::TableCell) }
-          CoreModel::TableRow.new(cells: cells)
-        end
-      end
-
-      class TableCell < Base
-        registers 'table_cell'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::TableCell.new(
-            content: extract_text(node),
-            header: attrs&.header || false,
-            colspan: attrs&.colspan,
-            rowspan: attrs&.rowspan,
-            alignment: attrs&.alignment
-          )
-        end
-      end
-
-      # ── Bibliography ──
-
-      class Bibliography < Base
-        registers 'bibliography'
-
-        def build(node)
-          entries = build_content(node).select { |c| c.is_a?(CoreModel::BibliographyEntry) }
-          CoreModel::Bibliography.new(title: node.attrs&.title, entries: entries)
-        end
-      end
-
-      class BiblioEntry < Base
-        registers 'biblio_entry'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::BibliographyEntry.new(
-            anchor_name: attrs&.anchor_name,
-            document_id: attrs&.document_id,
-            ref_text: extract_text(node)
-          )
-        end
-      end
-
-      # ── Footnotes ──
-
-      # The `footnotes` block is a structural trailing container; it has
-      # no CoreModel equivalent (each entry is built separately). Returns
-      # nil so build_content filters it out.
-      class Footnotes < Base
-        registers 'footnotes'
-
-        def build(_node)
-          nil
-        end
-      end
-
-      class FootnoteEntry < Base
-        registers 'footnote_entry'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::Footnote.new(id: attrs&.id, content: extract_text(node))
-        end
-      end
-
-      # Inline footnote marker (JS `footnote_marker`). The CoreModel
-      # FootnoteReference holds the same id/ref/number triple.
-      class FootnoteMarker < Base
-        registers 'footnote_marker'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::FootnoteReference.new(
-            id: attrs&.id,
-            reference: attrs&.ref_id,
-            number: attrs&.number
-          )
-        end
-      end
-
-      # ── TOC ──
-
-      class Toc < Base
-        registers 'toc'
-
-        def build(_node)
-          CoreModel::Toc.new
-        end
-      end
-
-      class TocEntry < Base
-        registers 'toc_entry'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::TocEntry.new(id: attrs&.id, title: attrs&.title)
-        end
-      end
-
-      # ── Inline ──
-
-      class Text < Base
-        registers 'text'
-
-        def build(node)
-          text = node.text || ''
-          marks = node.marks || []
-
-          return CoreModel::TextContent.new(text: text) if marks.empty?
-
-          marks.reduce(CoreModel::TextContent.new(text: text)) do |current, mark|
-            apply_mark(current, mark)
-          end
-        end
-      end
-
-      class SoftBreak < Base
-        registers 'soft_break'
-
-        def build(_node)
-          CoreModel::LineBreakElement.new
-        end
-      end
-
-      # Catch-all for unrecognized block types emitted by the forward
-      # direction (`Node::GenericBlock`). Preserves the semantic_type so
-      # downstream consumers can dispatch on it.
-      class GenericBlock < Base
-        registers 'generic_block'
-
-        def build(node)
-          attrs = node.attrs
-          CoreModel::Block.new(
-            block_semantic_type: attrs&.semantic_type || 'generic',
-            title: attrs&.title,
-            id: attrs&.id,
-            content: extract_text(node)
-          )
-        end
-      end
-
-      LIST_TYPES = %w[bullet_list ordered_list].freeze
-      private_constant :LIST_TYPES
+      # Base must load first — every subclass inherits from it. Then
+      # eager-load each Builder so its `registers` call runs.
+      require_relative 'reverse_builder/base'
+      require_relative 'reverse_builder/document'
+      require_relative 'reverse_builder/section'
+      require_relative 'reverse_builder/header'
+      require_relative 'reverse_builder/preamble'
+      require_relative 'reverse_builder/sections'
+      require_relative 'reverse_builder/paragraph'
+      require_relative 'reverse_builder/code_block'
+      require_relative 'reverse_builder/literal_block'
+      require_relative 'reverse_builder/pass_block'
+      require_relative 'reverse_builder/stem_block'
+      require_relative 'reverse_builder/blockquote'
+      require_relative 'reverse_builder/example'
+      require_relative 'reverse_builder/sidebar'
+      require_relative 'reverse_builder/open_block'
+      require_relative 'reverse_builder/verse'
+      require_relative 'reverse_builder/horizontal_rule'
+      require_relative 'reverse_builder/frontmatter'
+      require_relative 'reverse_builder/admonition'
+      require_relative 'reverse_builder/bullet_list'
+      require_relative 'reverse_builder/ordered_list'
+      require_relative 'reverse_builder/list_item'
+      require_relative 'reverse_builder/definition_list'
+      require_relative 'reverse_builder/inline_text'
+      require_relative 'reverse_builder/image'
+      require_relative 'reverse_builder/figure'
+      require_relative 'reverse_builder/caption'
+      require_relative 'reverse_builder/include'
+      require_relative 'reverse_builder/table'
+      require_relative 'reverse_builder/table_head'
+      require_relative 'reverse_builder/table_body'
+      require_relative 'reverse_builder/table_row'
+      require_relative 'reverse_builder/table_cell'
+      require_relative 'reverse_builder/bibliography'
+      require_relative 'reverse_builder/biblio_entry'
+      require_relative 'reverse_builder/footnotes'
+      require_relative 'reverse_builder/footnote_entry'
+      require_relative 'reverse_builder/footnote_marker'
+      require_relative 'reverse_builder/toc'
+      require_relative 'reverse_builder/toc_entry'
+      require_relative 'reverse_builder/text'
+      require_relative 'reverse_builder/soft_break'
+      require_relative 'reverse_builder/generic_block'
     end
   end
 end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/admonition.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/admonition.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Admonition < Base
+        registers 'admonition'
+
+        def build(node)
+          CoreModel::AnnotationBlock.new(
+            annotation_type: node.attrs&.admonition_type,
+            content: extract_text(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/base.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/base.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      # Base class for all reverse builders. Subclasses register one or
+      # more Mirror type strings via `registers` and implement `#build`.
+      # Shared helpers (build_content, extract_text, apply_mark, ...) are
+      # delegated to the context (a MirrorToCoreModel instance), keeping
+      # each builder focused on the per-type mapping only (DRY).
+      class Base
+        attr_reader :context
+
+        def initialize(context)
+          @context = context
+        end
+
+        def build(_node)
+          raise NotImplementedError,
+                "#{self.class} must implement #build(node)"
+        end
+
+        # Shared helpers — all delegate to the context (DRY).
+        def build_content(node) = context.build_content(node)
+        def build_inline_children(node) = context.build_inline_children(node)
+        def build_node(node)            = context.build_node(node)
+        def extract_text(node)          = context.extract_text(node)
+        def apply_mark(inner, mark)     = context.apply_mark(inner, mark)
+        def inline_content(element)     = context.inline_content(element)
+
+        class << self
+          # DSL: declare which Mirror type strings this builder handles.
+          # Multiple strings per builder are allowed (e.g. all JS
+          # SECTION_TYPES route to the same SectionElement builder).
+          def registers(*types)
+            types.each { |t| ReverseBuilder.register(t, self) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/biblio_entry.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/biblio_entry.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class BiblioEntry < Base
+        registers 'biblio_entry'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::BibliographyEntry.new(
+            anchor_name: attrs&.anchor_name,
+            document_id: attrs&.document_id,
+            ref_text: extract_text(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/bibliography.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/bibliography.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Bibliography < Base
+        registers 'bibliography'
+
+        def build(node)
+          entries = build_content(node).select { |c| c.is_a?(CoreModel::BibliographyEntry) }
+          CoreModel::Bibliography.new(title: node.attrs&.title, entries: entries)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/blockquote.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/blockquote.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Blockquote < Base
+        registers 'quote'
+
+        def build(node)
+          CoreModel::QuoteBlock.new(
+            attribution: node.attrs&.attribution,
+            children: build_content(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/bullet_list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/bullet_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class BulletList < Base
+        registers 'bullet_list'
+
+        def build(node)
+          items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
+          CoreModel::ListBlock.new(marker_type: 'unordered', items: items)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/caption.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/caption.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      # Caption only appears as a Figure child. If encountered standalone,
+      # extract its text as an inline element so it isn't lost.
+      class Caption < Base
+        registers 'caption'
+
+        def build(node)
+          CoreModel::InlineElement.new(content: extract_text(node))
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/code_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/code_block.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class CodeBlock < Base
+        registers 'sourcecode'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::SourceBlock.new(
+            content: attrs&.text || extract_text(node),
+            language: attrs&.language,
+            title: attrs&.title
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/definition_list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/definition_list.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class DefinitionList < Base
+        registers 'dl'
+
+        def build(node)
+          terms = []
+          descriptions = []
+          node.content&.each do |child|
+            next unless child.is_a?(Node)
+
+            case child.type
+            when 'dt' then terms << build_node(child)
+            when 'dd' then descriptions << build_node(child)
+            end
+          end
+
+          items = terms.zip(descriptions).map do |term, desc|
+            CoreModel::DefinitionItem.new(
+              term: inline_content(term),
+              definitions: [inline_content(desc)]
+            )
+          end
+
+          CoreModel::DefinitionList.new(items: items)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/document.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/document.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Document < Base
+        registers 'doc'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::DocumentElement.new(
+            title: attrs&.title,
+            id: attrs&.id,
+            children: build_content(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/example.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/example.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Example < Base
+        registers 'example'
+
+        def build(node)
+          CoreModel::ExampleBlock.new(
+            title: node.attrs&.title,
+            children: build_content(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/figure.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/figure.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      # JS @metanorma/mirror `figure` wraps an image plus an optional
+      # caption. Reverse: collapse back to a single CoreModel::Image,
+      # promoting the caption child to `caption:` if present.
+      class Figure < Base
+        registers 'figure'
+
+        def build(node)
+          image_child = node.content&.find { |c| c.is_a?(Node) && c.type == 'image' }
+          return nil unless image_child
+
+          image = build_node(image_child)
+          caption = extract_caption(node)
+          image.caption = caption if caption && !image.caption
+          image
+        end
+
+        private
+
+        def extract_caption(node)
+          caption_node = node.content&.find { |c| c.is_a?(Node) && c.type == 'caption' }
+          return nil unless caption_node
+
+          extract_text(caption_node)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnote_entry.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnote_entry.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class FootnoteEntry < Base
+        registers 'footnote_entry'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::Footnote.new(id: attrs&.id, content: extract_text(node))
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnote_marker.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnote_marker.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      # Inline footnote marker (JS `footnote_marker`). The CoreModel
+      # FootnoteReference holds the same id/ref/number triple.
+      class FootnoteMarker < Base
+        registers 'footnote_marker'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::FootnoteReference.new(
+            id: attrs&.id,
+            reference: attrs&.ref_id,
+            number: attrs&.number
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnotes.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnotes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      # The `footnotes` block is a structural trailing container; it has
+      # no CoreModel equivalent (each entry is built separately). Returns
+      # nil so build_content filters it out.
+      class Footnotes < Base
+        registers 'footnotes'
+
+        def build(_node)
+          nil
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/frontmatter.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/frontmatter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Frontmatter < Base
+        registers 'frontmatter'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::FrontmatterBlock.new(
+            schema: attrs&.schema,
+            data: FrontmatterTreeToHash.to_hash(attrs&.entries || [])
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/generic_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/generic_block.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      # Catch-all for unrecognized block types emitted by the forward
+      # direction (`Node::GenericBlock`). Preserves the semantic_type so
+      # downstream consumers can dispatch on it.
+      class GenericBlock < Base
+        registers 'generic_block'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::Block.new(
+            block_semantic_type: attrs&.semantic_type || 'generic',
+            title: attrs&.title,
+            id: attrs&.id,
+            content: extract_text(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/header.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/header.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Header < Base
+        registers 'floating_title', 'heading'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::HeaderElement.new(
+            title: attrs&.title,
+            level: attrs&.level,
+            children: build_content(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/horizontal_rule.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/horizontal_rule.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class HorizontalRule < Base
+        registers 'horizontal_rule', 'thematic_break'
+
+        def build(_node)
+          CoreModel::HorizontalRuleBlock.new
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/image.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/image.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Image < Base
+        registers 'image'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::Image.new(
+            src: attrs&.src,
+            alt: attrs&.alt,
+            title: attrs&.title,
+            caption: attrs&.caption,
+            width: attrs&.width,
+            height: attrs&.height
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/include.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/include.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      # Include directive: round-trips back to a CoreModel::Include link
+      # node. The text graph is preserved through mirror_json → core.
+      class Include < Base
+        registers 'include'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::Include.new(
+            target: attrs&.target,
+            options: build_options(attrs),
+            raw_options: attrs&.raw_options || ''
+          )
+        end
+
+        private
+
+        def build_options(attrs)
+          return CoreModel::IncludeOptions.new unless attrs
+
+          CoreModel::IncludeOptions.new(
+            tags: Array(attrs.tags),
+            tags_wildcard: attrs.tags == ['*'],
+            tags_inverted: attrs.tags == ['**'],
+            lines_spec: attrs.lines,
+            leveloffset: parse_leveloffset(attrs.leveloffset),
+            indent: attrs.indent,
+            file_encoding: attrs.file_encoding
+          )
+        end
+
+        def parse_leveloffset(raw)
+          return nil if raw.nil? || raw.to_s.empty?
+
+          Coradoc::CoreModel::IncludeLevelOffset.parse(raw.to_s)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/inline_text.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/inline_text.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class InlineText < Base
+        registers 'dt', 'dd'
+
+        def build(node)
+          children = build_inline_children(node)
+          text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : '' }.join
+          CoreModel::InlineElement.new(content: text)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/list_item.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/list_item.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class ListItem < Base
+        registers 'list_item'
+
+        LIST_TYPES = %w[bullet_list ordered_list].freeze
+        private_constant :LIST_TYPES
+
+        def build(node)
+          children = build_inline_children(node)
+          text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : '' }.join
+
+          CoreModel::ListItem.new(
+            content: text,
+            children: children,
+            nested_list: find_nested_list(node)
+          )
+        end
+
+        private
+
+        def find_nested_list(node)
+          node.content&.each do |child|
+            next unless child.is_a?(Node)
+            return build_node(child) if LIST_TYPES.include?(child.type)
+          end
+          nil
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/literal_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/literal_block.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class LiteralBlock < Base
+        registers 'literal'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::LiteralBlock.new(
+            content: attrs&.text || extract_text(node),
+            language: attrs&.language,
+            title: attrs&.title
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/open_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/open_block.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class OpenBlock < Base
+        registers 'open_block'
+
+        def build(node)
+          CoreModel::OpenBlock.new(children: build_content(node))
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/ordered_list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/ordered_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class OrderedList < Base
+        registers 'ordered_list'
+
+        def build(node)
+          items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
+          CoreModel::ListBlock.new(marker_type: 'ordered', items: items)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/paragraph.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/paragraph.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Paragraph < Base
+        registers 'paragraph'
+
+        def build(node)
+          CoreModel::ParagraphBlock.new(children: build_inline_children(node))
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/pass_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/pass_block.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class PassBlock < Base
+        registers 'pass'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::PassBlock.new(
+            content: attrs&.text || extract_text(node),
+            language: attrs&.language,
+            title: attrs&.title
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/preamble.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/preamble.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Preamble < Base
+        registers 'preface'
+
+        def build(node)
+          CoreModel::PreambleElement.new(children: build_content(node))
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/section.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/section.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      # All JS SECTION_TYPES reverse to a generic SectionElement. Style
+      # information lives in the original AsciiDoc and is preserved only
+      # on the forward side; the reverse side collapses them.
+      class Section < Base
+        registers 'section', 'clause', 'annex', 'content_section',
+                  'abstract', 'foreword', 'introduction',
+                  'acknowledgements', 'terms', 'definitions', 'references'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::SectionElement.new(
+            title: attrs&.title,
+            level: attrs&.level,
+            id: attrs&.id,
+            children: build_content(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/sections.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/sections.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      # `sections` is a structural container only — unwrap directly into
+      # an array. MirrorToCoreModel#build_content flattens arrays.
+      class Sections < Base
+        registers 'sections'
+
+        def build(node)
+          build_content(node)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/sidebar.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/sidebar.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Sidebar < Base
+        registers 'sidebar'
+
+        def build(node)
+          CoreModel::SidebarBlock.new(
+            title: node.attrs&.title,
+            children: build_content(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/soft_break.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/soft_break.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class SoftBreak < Base
+        registers 'soft_break'
+
+        def build(_node)
+          CoreModel::LineBreakElement.new
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/stem_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/stem_block.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class StemBlock < Base
+        registers 'stem'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::StemBlock.new(
+            content: attrs&.text || extract_text(node),
+            language: attrs&.language || 'latex',
+            title: attrs&.title
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Table < Base
+        registers 'table'
+
+        def build(node)
+          rows = []
+          node.content&.each do |child|
+            next unless child.is_a?(Node)
+            next unless %w[table_head table_body].include?(child.type)
+
+            child.content&.each do |row_node|
+              rows << build_node(row_node) if row_node.is_a?(Node)
+            end
+          end
+
+          CoreModel::Table.new(title: node.attrs&.title, rows: rows)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_body.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_body.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class TableBody < Base
+        registers 'table_body'
+
+        def build(node)
+          build_content(node).first || CoreModel::TableRow.new
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_cell.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_cell.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class TableCell < Base
+        registers 'table_cell'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::TableCell.new(
+            content: extract_text(node),
+            header: attrs&.header || false,
+            colspan: attrs&.colspan,
+            rowspan: attrs&.rowspan,
+            alignment: attrs&.alignment
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_head.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_head.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class TableHead < Base
+        registers 'table_head'
+
+        def build(node)
+          build_content(node).first || CoreModel::TableRow.new
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_row.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_row.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class TableRow < Base
+        registers 'table_row'
+
+        def build(node)
+          cells = build_content(node).select { |c| c.is_a?(CoreModel::TableCell) }
+          CoreModel::TableRow.new(cells: cells)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/text.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/text.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Text < Base
+        registers 'text'
+
+        def build(node)
+          text = node.text || ''
+          marks = node.marks || []
+
+          return CoreModel::TextContent.new(text: text) if marks.empty?
+
+          marks.reduce(CoreModel::TextContent.new(text: text)) do |current, mark|
+            apply_mark(current, mark)
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/toc.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/toc.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Toc < Base
+        registers 'toc'
+
+        def build(_node)
+          CoreModel::Toc.new
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/toc_entry.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/toc_entry.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class TocEntry < Base
+        registers 'toc_entry'
+
+        def build(node)
+          attrs = node.attrs
+          CoreModel::TocEntry.new(id: attrs&.id, title: attrs&.title)
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/verse.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/verse.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Verse < Base
+        registers 'verse'
+
+        def build(node)
+          CoreModel::VerseBlock.new(
+            content: extract_text(node),
+            attribution: node.attrs&.attribution
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/code_block_variants_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/code_block_variants_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+require 'coradoc-mirror'
+
+RSpec.describe 'Code-block variants (source / literal / pass / stem)', :asciidoc do
+  def first_node_type(adoc)
+    json = JSON.parse(Coradoc.serialize(Coradoc.parse(adoc, format: :asciidoc), to: :mirror_json))
+    [json.dig('content', 0, 'type'), json.dig('content', 0, 'attrs')]
+  end
+
+  it 'source blocks emit type=sourcecode' do
+    adoc = "[source,ruby]\n----\nputs 'hi'\n----\n"
+    type, attrs = first_node_type(adoc)
+    expect(type).to eq('sourcecode')
+    expect(attrs['language']).to eq('ruby')
+  end
+
+  it 'literal blocks emit type=literal (not sourcecode)' do
+    adoc = "....\n  indented literal\n....\n"
+    expect(first_node_type(adoc).first).to eq('literal')
+  end
+
+  it 'pass blocks emit type=pass (not sourcecode)' do
+    adoc = "++++\n<p>raw html</p>\n++++\n"
+    type, attrs = first_node_type(adoc)
+    expect(type).to eq('pass')
+    expect(attrs['passthrough']).to be(true)
+  end
+
+  it '[stem] emits type=stem with language=latex' do
+    adoc = "[stem]\n++++\nx^2\n++++\n"
+    type, attrs = first_node_type(adoc)
+    expect(type).to eq('stem')
+    expect(attrs['language']).to eq('latex')
+  end
+
+  it '[latexmath] emits type=stem with language=latex' do
+    adoc = "[latexmath]\n++++\nx^2\n++++\n"
+    type, attrs = first_node_type(adoc)
+    expect(type).to eq('stem')
+    expect(attrs['language']).to eq('latex')
+  end
+
+  it '[asciimath] emits type=stem with language=asciimath' do
+    adoc = "[asciimath]\n++++\nx^2\n++++\n"
+    type, attrs = first_node_type(adoc)
+    expect(type).to eq('stem')
+    expect(attrs['language']).to eq('asciimath')
+  end
+
+  it 'preserves block content verbatim' do
+    adoc = "[stem]\n++++\nx^2 + y^2 = z^2\n++++\n"
+    json = JSON.parse(Coradoc.serialize(Coradoc.parse(adoc, format: :asciidoc), to: :mirror_json))
+    # text may be in attrs.text (partition mode) or in content[0].text
+    text = json.dig('content', 0, 'attrs', 'text') ||
+           json.dig('content', 0, 'content', 0, 'text')
+    expect(text).to eq('x^2 + y^2 = z^2')
+  end
+
+  context 'round-trip (mirror → CoreModel)' do
+    def round_trip(adoc)
+      core = Coradoc.parse(adoc, format: :asciidoc)
+      json = JSON.parse(Coradoc.serialize(core, to: :mirror_json))
+      Coradoc::Mirror.from_hash(json).then do |node|
+        Coradoc::Mirror::MirrorToCoreModel.new.call(node)
+      end
+    end
+
+    it 'literal round-trips to CoreModel::LiteralBlock' do
+      adoc = "....\ntext\n....\n"
+      core = round_trip(adoc)
+      first = core.children.first
+      expect(first).to be_a(Coradoc::CoreModel::LiteralBlock)
+    end
+
+    it 'pass round-trips to CoreModel::PassBlock' do
+      adoc = "++++\nraw\n++++\n"
+      core = round_trip(adoc)
+      first = core.children.first
+      expect(first).to be_a(Coradoc::CoreModel::PassBlock)
+    end
+
+    it 'stem round-trips to CoreModel::StemBlock with language' do
+      adoc = "[asciimath]\n++++\nx^2\n++++\n"
+      core = round_trip(adoc)
+      first = core.children.first
+      expect(first).to be_a(Coradoc::CoreModel::StemBlock)
+      expect(first.language).to eq('asciimath')
+    end
+
+    it 'source round-trips to CoreModel::SourceBlock' do
+      adoc = "[source,ruby]\n----\nputs 'hi'\n----\n"
+      core = round_trip(adoc)
+      expect(core.children.first).to be_a(Coradoc::CoreModel::SourceBlock)
+    end
+  end
+end

--- a/coradoc/lib/coradoc.rb
+++ b/coradoc/lib/coradoc.rb
@@ -43,4 +43,5 @@ module Coradoc
   autoload :DocumentManipulator, 'coradoc/document_manipulator'
   autoload :Visitor, 'coradoc/visitor'
   autoload :Serializer, 'coradoc/serializer/registry'
+  autoload :LinkRewriter, 'coradoc/link_rewriter'
 end

--- a/coradoc/lib/coradoc.rb
+++ b/coradoc/lib/coradoc.rb
@@ -44,4 +44,5 @@ module Coradoc
   autoload :Visitor, 'coradoc/visitor'
   autoload :Serializer, 'coradoc/serializer/registry'
   autoload :LinkRewriter, 'coradoc/link_rewriter'
+  autoload :RelativePath, 'coradoc/relative_path'
 end

--- a/coradoc/lib/coradoc/coradoc.rb
+++ b/coradoc/lib/coradoc/coradoc.rb
@@ -170,6 +170,33 @@ module Coradoc
       )
     end
 
+    # Rewrite every link/xref target in a parsed document.
+    #
+    # Walks the document tree and invokes the supplied rewriter for each
+    # link and cross-reference target. The original document is never
+    # mutated — a NEW document is returned.
+    #
+    # Verbatim blocks (+SourceBlock+, +ListingBlock+, +LiteralBlock+,
+    # +PassBlock+, +StemBlock+) are skipped entirely so link-shaped text
+    # inside code/math bodies is never rewritten.
+    #
+    # The rewriter responds to +#call(target:, kind:, context:)+ and
+    # returns the new target String. +kind+ is +:link+ or +:xref+; the
+    # block form is supported for one-liners.
+    #
+    # @param document [Coradoc::CoreModel::Base] parsed document
+    # @param rewriter [#call, nil] callable rewriter; ignored when a block is given
+    # @return [Coradoc::CoreModel::Base] new document with rewritten targets
+    #
+    # @example Canonicalize snake_case targets to kebab-case
+    #   doc = Coradoc.parse(adoc, format: :asciidoc)
+    #   rewritten = Coradoc.rewrite_links(doc) do |target:, kind:, **|
+    #     target.tr('_', '-')
+    #   end
+    def rewrite_links(document, rewriter: nil, &block)
+      Coradoc::LinkRewriter.rewrite(document, rewriter: rewriter, &block)
+    end
+
     # Convert document text from one format to another
     #
     # This is the main entry point for format conversion. It handles the

--- a/coradoc/lib/coradoc/core_model.rb
+++ b/coradoc/lib/coradoc/core_model.rb
@@ -83,5 +83,6 @@ module Coradoc
     autoload :Include, "#{__dir__}/core_model/include"
     autoload :IncludeOptions, "#{__dir__}/core_model/include_options"
     autoload :IncludeLevelOffset, "#{__dir__}/core_model/include_level_offset"
+    autoload :OutputArtifact, "#{__dir__}/core_model/output_artifact"
   end
 end

--- a/coradoc/lib/coradoc/core_model.rb
+++ b/coradoc/lib/coradoc/core_model.rb
@@ -70,6 +70,7 @@ module Coradoc
     autoload :SidebarBlock, "#{__dir__}/core_model/sidebar_block"
     autoload :LiteralBlock, "#{__dir__}/core_model/literal_block"
     autoload :PassBlock, "#{__dir__}/core_model/pass_block"
+    autoload :StemBlock, "#{__dir__}/core_model/stem_block"
     autoload :ListingBlock, "#{__dir__}/core_model/listing_block"
     autoload :OpenBlock, "#{__dir__}/core_model/open_block"
     autoload :VerseBlock, "#{__dir__}/core_model/verse_block"

--- a/coradoc/lib/coradoc/core_model/base.rb
+++ b/coradoc/lib/coradoc/core_model/base.rb
@@ -41,6 +41,28 @@ module Coradoc
       #   @return [Array<MetadataEntry>] additional metadata entries
       attribute :metadata_entries, MetadataEntry, collection: true
 
+      # Construct an instance and yield it for in-place mutation.
+      #
+      # This is the programmatic-construction entry point for CoreModel
+      # nodes. It calls +new+ exactly as a caller would, then yields
+      # the resulting instance for append-style construction. No new
+      # class hierarchy, no +method_missing+ — the block operates on
+      # the real model object.
+      #
+      # Per-class fluent helpers (e.g., +ListBlock#add_item+,
+      # +ListItem#add_text+) compose naturally with +build+:
+      #
+      #   list = ListBlock.build do |ul|
+      #     children.each { |c| ul.add_item { |li| li.add_link(c[:slug], text: c[:title]) } }
+      #   end
+      #
+      # Without a block, +build(**attrs)+ is identical to +new(**attrs)+.
+      def self.build(**attrs)
+        instance = new(**attrs)
+        yield instance if block_given?
+        instance
+      end
+
       # Get all metadata as a hash, or a specific metadata value by key
       # @overload metadata
       #   @return [Hash] All metadata as key-value pairs

--- a/coradoc/lib/coradoc/core_model/base.rb
+++ b/coradoc/lib/coradoc/core_model/base.rb
@@ -167,6 +167,23 @@ module Coradoc
         visitor.visit(self)
       end
 
+      # True when this node counts as "real body content" for the
+      # purposes of empty-document detection and similar structural
+      # queries. Default is true; metadata and ephemeral nodes
+      # (FrontmatterBlock, CommentBlock, CommentLine) override to
+      # false. Polymorphic dispatch keeps the predicate open for
+      # future "skip-me" types — no central walker to edit (OCP).
+      def body_content?
+        true
+      end
+
+      # True when this node is structurally present but carries no
+      # visible characters. Default is false; inline text and
+      # paragraph blocks override to inspect their text content.
+      def whitespace_only?
+        false
+      end
+
       private
 
       # List of attributes to compare for semantic equivalence

--- a/coradoc/lib/coradoc/core_model/comment_block.rb
+++ b/coradoc/lib/coradoc/core_model/comment_block.rb
@@ -7,6 +7,10 @@ module Coradoc
       def self.semantic_type
         :comment
       end
+
+      def body_content?
+        false
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/comment_line.rb
+++ b/coradoc/lib/coradoc/core_model/comment_line.rb
@@ -13,6 +13,10 @@ module Coradoc
         :comment_line
       end
 
+      def body_content?
+        false
+      end
+
       attribute :text, :string
     end
   end

--- a/coradoc/lib/coradoc/core_model/frontmatter.rb
+++ b/coradoc/lib/coradoc/core_model/frontmatter.rb
@@ -50,6 +50,10 @@ module Coradoc
         schema.nil? && (data.nil? || data.empty?)
       end
 
+      def body_content?
+        false
+      end
+
       # Sub-namespaces (Codec, SchemaResolver, FieldTransform, TextSplitter)
       # live under FrontmatterBlock and autoload lazily.
       autoload :Codec, "#{__dir__}/frontmatter/codec"

--- a/coradoc/lib/coradoc/core_model/frontmatter/codec.rb
+++ b/coradoc/lib/coradoc/core_model/frontmatter/codec.rb
@@ -10,42 +10,209 @@ module Coradoc
       # No other code in any gem may call YAML directly for frontmatter.
       # This isolates permitted-classes configuration and error handling
       # in one MECE location (DRY).
+      #
+      # Two serialization modes:
+      # - +:flat+ (default) — values rendered with their natural YAML
+      #   type. Matches what Jekyll, Hugo, VitePress, VuePress, 11ty and
+      #   most SSGs expect: +title: Foo+ / +date: 2024-01-01+.
+      # - +:typed+ — values rendered with a +value_type+ discriminator
+      #   (string/integer/date/boolean/array/null). Matches the
+      #   ProseMirror-compatible JSON shape emitted by the Mirror gem.
+      #   Useful when downstream tooling needs explicit type tags to
+      #   avoid ambiguity (e.g. ISO-date string vs Date object).
+      #
+      # The mode is a serialization concern — the FrontmatterBlock model
+      # itself stays unchanged. Both modes round-trip to the same model.
       module Codec
         PERMITTED_CLASSES = [Date, Time, DateTime, Symbol].freeze
 
+        # Native Ruby class → discriminator string. MECE — every
+        # wrap_scalar branch derives from this table.
+        DISCRIMINATOR_BY_CLASS = {
+          String => 'string',
+          Integer => 'integer',
+          Float => 'number',
+          Date => 'date',
+          Time => 'datetime',
+          DateTime => 'datetime',
+          TrueClass => 'boolean',
+          FalseClass => 'boolean',
+          NilClass => 'null'
+        }.freeze
+
+        # Discriminator → reader that pulls the typed value out of the
+        # discriminated hash. Used by extract_typed_value.
+        TYPED_VALUE_READERS = {
+          'string' => ->(h) { h['string_value'] },
+          'integer' => ->(h) { h['integer_value'] },
+          'number' => ->(h) { h['number_value'] },
+          'boolean' => ->(h) { h['boolean_value'] },
+          'date' => ->(h) { safe_parse_date(h['date_value']) },
+          'datetime' => ->(h) { safe_parse_time(h['datetime_value']) },
+          'null' => ->(_h) {}
+        }.freeze
+
+        # Discriminator → writer that builds the discriminated hash from
+        # a native value. Used by wrap_scalar.
+        TYPED_VALUE_WRITERS = {
+          'string' => ->(v) { { 'value_type' => 'string', 'string_value' => v.to_s } },
+          'integer' => ->(v) { { 'value_type' => 'integer', 'integer_value' => v } },
+          'number' => ->(v) { { 'value_type' => 'number', 'number_value' => v } },
+          'date' => ->(v) { { 'value_type' => 'date', 'date_value' => v.iso8601 } },
+          'datetime' => ->(v) { { 'value_type' => 'datetime', 'datetime_value' => v.iso8601 } },
+          'boolean' => ->(v) { { 'value_type' => 'boolean', 'boolean_value' => v } },
+          'null' => ->(_) { { 'value_type' => 'null' } }
+        }.freeze
+
         class << self
-          # Parse a YAML string into a FrontmatterBlock.
-          # Returns an empty FrontmatterBlock on malformed YAML (graceful
-          # degradation — body parsing continues).
-          def from_yaml(yaml_text)
+          # Parse YAML text into a FrontmatterBlock. Mode-agnostic —
+          # both +:flat+ and +:typed+ YAML collapse to the same model
+          # because the FrontmatterBlock stores native Ruby types.
+          # Returns an empty FrontmatterBlock on malformed YAML.
+          def from_yaml(yaml_text, mode: :flat)
             return FrontmatterBlock.new if yaml_text.nil? || yaml_text.strip.empty?
 
-            parsed = YAML.safe_load(
-              yaml_text,
-              permitted_classes: PERMITTED_CLASSES,
-              aliases: true
-            )
-            return FrontmatterBlock.new unless parsed.is_a?(Hash)
-
-            schema = parsed['$schema']
-            data = parsed.except('$schema')
-            FrontmatterBlock.new(schema: schema&.to_s, data: data)
+            build_from_loaded(load_yaml(yaml_text), mode: mode)
           rescue YAML::SyntaxError, Psych::DisallowedClass
             FrontmatterBlock.new
           end
 
+          # Build a FrontmatterBlock from a Ruby hash. Mode-agnostic.
+          def from_hash(hash, mode: :flat)
+            return FrontmatterBlock.new unless hash.is_a?(Hash)
+
+            build_from_loaded(hash, mode: mode)
+          end
+
           # Serialize a FrontmatterBlock to canonical YAML text.
           # Does NOT include leading/trailing `---` delimiters; the caller
-          # wraps the output.
-          def to_yaml(block)
+          # wraps the output. +:flat+ emits plain YAML; +:typed+ emits
+          # the discriminator shape.
+          def to_yaml(block, mode: :flat)
             return '' unless block.is_a?(FrontmatterBlock)
 
+            payload = payload_for(block, mode: mode)
+            return '' if payload.empty?
+
+            YAML.dump(payload).delete_prefix("---\n").delete_suffix("\n...")
+          end
+
+          # Return the frontmatter as a Ruby hash. +:flat+ (default)
+          # returns native-typed values (String, Integer, Date, …).
+          # +:typed+ returns the discriminator shape used by the Mirror
+          # JSON model.
+          def to_hash(block, mode: :flat)
+            return {} unless block.is_a?(FrontmatterBlock)
+
+            payload_for(block, mode: mode)
+          end
+
+          private
+
+          def load_yaml(yaml_text)
+            YAML.safe_load(
+              yaml_text,
+              permitted_classes: PERMITTED_CLASSES,
+              aliases: true
+            )
+          end
+
+          def build_from_loaded(loaded, mode:)
+            return FrontmatterBlock.new unless loaded.is_a?(Hash)
+
+            data = mode == :typed ? typed_hash_to_flat(loaded) : loaded
+            schema = data['$schema']
+            FrontmatterBlock.new(schema: schema&.to_s, data: data.except('$schema'))
+          end
+
+          def payload_for(block, mode:)
+            tree = flat_tree(block)
+            return {} if tree.empty?
+
+            mode == :typed ? flat_tree_to_typed(tree) : tree
+          end
+
+          def flat_tree(block)
             tree = {}
             tree['$schema'] = block.schema if block.schema
             tree.merge!(block.data || {})
-            return '' if tree.empty?
+            tree
+          end
 
-            YAML.dump(tree).delete_prefix("---\n").delete_suffix("\n...")
+          # Flatten a discriminator-shaped hash into native values.
+          # Inverse of +flat_tree_to_typed+.
+          def typed_hash_to_flat(typed_hash)
+            typed_hash.transform_values do |value|
+              value.is_a?(Hash) ? extract_typed_value(value) : value
+            end
+          end
+
+          def extract_typed_value(value_hash)
+            reader = TYPED_VALUE_READERS[value_hash['value_type']]
+            return reader.call(value_hash) if reader
+            return extract_array(value_hash) if value_hash['value_type'] == 'array'
+
+            value_hash['raw_value']
+          end
+
+          def extract_array(value_hash)
+            Array(value_hash['items_value']).map do |item|
+              item.is_a?(Hash) ? extract_typed_value(item) : item
+            end
+          end
+
+          def safe_parse_date(value)
+            return value if value.is_a?(Date)
+
+            Date.iso8601(value.to_s)
+          rescue Date::Error
+            value
+          end
+
+          def safe_parse_time(value)
+            return value if value.is_a?(Time) || value.is_a?(DateTime)
+
+            Time.iso8601(value.to_s)
+          rescue ArgumentError
+            value
+          end
+
+          # Wrap each native value in a discriminator-shaped hash.
+          def flat_tree_to_typed(flat)
+            flat.to_h do |key, value|
+              [key, key == '$schema' ? wrap_schema(value) : wrap_typed(value)]
+            end
+          end
+
+          def wrap_schema(value)
+            { 'value_type' => 'string', 'string_value' => value.to_s }
+          end
+
+          def wrap_typed(value)
+            case value
+            when Hash  then wrap_hash(value)
+            when Array then wrap_array(value)
+            else wrap_scalar(value)
+            end
+          end
+
+          def wrap_hash(value)
+            typed = { 'value_type' => 'map' }
+            value.each { |k, v| typed[k.to_s] = wrap_typed(v) }
+            typed
+          end
+
+          def wrap_array(value)
+            {
+              'value_type' => 'array',
+              'items_value' => value.map { |v| wrap_typed(v) }
+            }
+          end
+
+          def wrap_scalar(value)
+            discriminator = DISCRIMINATOR_BY_CLASS[value.class] || 'string'
+            writer = TYPED_VALUE_WRITERS[discriminator]
+            writer&.call(value) || wrap_schema(value)
           end
         end
       end

--- a/coradoc/lib/coradoc/core_model/frontmatter/codec.rb
+++ b/coradoc/lib/coradoc/core_model/frontmatter/codec.rb
@@ -11,100 +11,61 @@ module Coradoc
       # This isolates permitted-classes configuration and error handling
       # in one MECE location (DRY).
       #
-      # Two serialization modes:
-      # - +:flat+ (default) — values rendered with their natural YAML
-      #   type. Matches what Jekyll, Hugo, VitePress, VuePress, 11ty and
-      #   most SSGs expect: +title: Foo+ / +date: 2024-01-01+.
-      # - +:typed+ — values rendered with a +value_type+ discriminator
-      #   (string/integer/date/boolean/array/null). Matches the
-      #   ProseMirror-compatible JSON shape emitted by the Mirror gem.
-      #   Useful when downstream tooling needs explicit type tags to
-      #   avoid ambiguity (e.g. ISO-date string vs Date object).
+      # The Codec emits flat YAML — values rendered with their natural
+      # YAML type. This is what Jekyll, Hugo, VitePress, VuePress, 11ty
+      # and every SSG expects: +title: Foo+ / +date: 2024-01-01+.
+      # Round-trip fidelity for typed values (Date, Time, Symbol) is
+      # preserved by Psych's permitted-classes mechanism, not by a
+      # custom discriminator scheme.
       #
-      # The mode is a serialization concern — the FrontmatterBlock model
-      # itself stays unchanged. Both modes round-trip to the same model.
+      # For the typed-tree representation used by the coradoc-mirror JSON
+      # pipeline, see +Coradoc::Mirror::Node::FrontmatterValue+ and
+      # +Coradoc::Mirror::Handlers::Frontmatter+. The typed-tree concern
+      # lives in the mirror gem; this Codec stays focused on YAML.
       module Codec
         PERMITTED_CLASSES = [Date, Time, DateTime, Symbol].freeze
 
-        # Native Ruby class → discriminator string. MECE — every
-        # wrap_scalar branch derives from this table.
-        DISCRIMINATOR_BY_CLASS = {
-          String => 'string',
-          Integer => 'integer',
-          Float => 'number',
-          Date => 'date',
-          Time => 'datetime',
-          DateTime => 'datetime',
-          TrueClass => 'boolean',
-          FalseClass => 'boolean',
-          NilClass => 'null'
-        }.freeze
-
-        # Discriminator → reader that pulls the typed value out of the
-        # discriminated hash. Used by extract_typed_value.
-        TYPED_VALUE_READERS = {
-          'string' => ->(h) { h['string_value'] },
-          'integer' => ->(h) { h['integer_value'] },
-          'number' => ->(h) { h['number_value'] },
-          'boolean' => ->(h) { h['boolean_value'] },
-          'date' => ->(h) { safe_parse_date(h['date_value']) },
-          'datetime' => ->(h) { safe_parse_time(h['datetime_value']) },
-          'null' => ->(_h) {}
-        }.freeze
-
-        # Discriminator → writer that builds the discriminated hash from
-        # a native value. Used by wrap_scalar.
-        TYPED_VALUE_WRITERS = {
-          'string' => ->(v) { { 'value_type' => 'string', 'string_value' => v.to_s } },
-          'integer' => ->(v) { { 'value_type' => 'integer', 'integer_value' => v } },
-          'number' => ->(v) { { 'value_type' => 'number', 'number_value' => v } },
-          'date' => ->(v) { { 'value_type' => 'date', 'date_value' => v.iso8601 } },
-          'datetime' => ->(v) { { 'value_type' => 'datetime', 'datetime_value' => v.iso8601 } },
-          'boolean' => ->(v) { { 'value_type' => 'boolean', 'boolean_value' => v } },
-          'null' => ->(_) { { 'value_type' => 'null' } }
-        }.freeze
-
         class << self
-          # Parse YAML text into a FrontmatterBlock. Mode-agnostic —
-          # both +:flat+ and +:typed+ YAML collapse to the same model
-          # because the FrontmatterBlock stores native Ruby types.
-          # Returns an empty FrontmatterBlock on malformed YAML.
-          def from_yaml(yaml_text, mode: :flat)
+          # Parse YAML text into a FrontmatterBlock. Returns an empty
+          # FrontmatterBlock on malformed YAML or non-Hash payload.
+          # Logs a warning so the conversion pipeline can surface the
+          # skip rather than silently dropping user-authored content.
+          def from_yaml(yaml_text)
             return FrontmatterBlock.new if yaml_text.nil? || yaml_text.strip.empty?
 
-            build_from_loaded(load_yaml(yaml_text), mode: mode)
-          rescue YAML::SyntaxError, Psych::DisallowedClass
+            build_from_loaded(load_yaml(yaml_text))
+          rescue YAML::SyntaxError, Psych::DisallowedClass => e
+            Coradoc::Logger.warn("frontmatter parse failed: #{e.message}")
             FrontmatterBlock.new
           end
 
-          # Build a FrontmatterBlock from a Ruby hash. Mode-agnostic.
-          def from_hash(hash, mode: :flat)
+          # Build a FrontmatterBlock from a Ruby hash with native-typed
+          # values (String, Integer, Date, …). Returns an empty block
+          # for non-Hash input.
+          def from_hash(hash)
             return FrontmatterBlock.new unless hash.is_a?(Hash)
 
-            build_from_loaded(hash, mode: mode)
+            build_from_loaded(hash)
           end
 
           # Serialize a FrontmatterBlock to canonical YAML text.
-          # Does NOT include leading/trailing `---` delimiters; the caller
-          # wraps the output. +:flat+ emits plain YAML; +:typed+ emits
-          # the discriminator shape.
-          def to_yaml(block, mode: :flat)
+          # Does NOT include leading/trailing +---+ delimiters; the
+          # caller wraps the output. Returns +''+ for empty blocks.
+          def to_yaml(block)
             return '' unless block.is_a?(FrontmatterBlock)
 
-            payload = payload_for(block, mode: mode)
+            payload = flat_tree(block)
             return '' if payload.empty?
 
             YAML.dump(payload).delete_prefix("---\n").delete_suffix("\n...")
           end
 
-          # Return the frontmatter as a Ruby hash. +:flat+ (default)
-          # returns native-typed values (String, Integer, Date, …).
-          # +:typed+ returns the discriminator shape used by the Mirror
-          # JSON model.
-          def to_hash(block, mode: :flat)
+          # Return the frontmatter as a native-typed Ruby hash.
+          # +$schema+ is included when present.
+          def to_hash(block)
             return {} unless block.is_a?(FrontmatterBlock)
 
-            payload_for(block, mode: mode)
+            flat_tree(block)
           end
 
           private
@@ -117,19 +78,14 @@ module Coradoc
             )
           end
 
-          def build_from_loaded(loaded, mode:)
+          def build_from_loaded(loaded)
             return FrontmatterBlock.new unless loaded.is_a?(Hash)
 
-            data = mode == :typed ? typed_hash_to_flat(loaded) : loaded
-            schema = data['$schema']
-            FrontmatterBlock.new(schema: schema&.to_s, data: data.except('$schema'))
-          end
-
-          def payload_for(block, mode:)
-            tree = flat_tree(block)
-            return {} if tree.empty?
-
-            mode == :typed ? flat_tree_to_typed(tree) : tree
+            schema = loaded['$schema']
+            FrontmatterBlock.new(
+              schema: schema&.to_s,
+              data: loaded.except('$schema')
+            )
           end
 
           def flat_tree(block)
@@ -137,82 +93,6 @@ module Coradoc
             tree['$schema'] = block.schema if block.schema
             tree.merge!(block.data || {})
             tree
-          end
-
-          # Flatten a discriminator-shaped hash into native values.
-          # Inverse of +flat_tree_to_typed+.
-          def typed_hash_to_flat(typed_hash)
-            typed_hash.transform_values do |value|
-              value.is_a?(Hash) ? extract_typed_value(value) : value
-            end
-          end
-
-          def extract_typed_value(value_hash)
-            reader = TYPED_VALUE_READERS[value_hash['value_type']]
-            return reader.call(value_hash) if reader
-            return extract_array(value_hash) if value_hash['value_type'] == 'array'
-
-            value_hash['raw_value']
-          end
-
-          def extract_array(value_hash)
-            Array(value_hash['items_value']).map do |item|
-              item.is_a?(Hash) ? extract_typed_value(item) : item
-            end
-          end
-
-          def safe_parse_date(value)
-            return value if value.is_a?(Date)
-
-            Date.iso8601(value.to_s)
-          rescue Date::Error
-            value
-          end
-
-          def safe_parse_time(value)
-            return value if value.is_a?(Time) || value.is_a?(DateTime)
-
-            Time.iso8601(value.to_s)
-          rescue ArgumentError
-            value
-          end
-
-          # Wrap each native value in a discriminator-shaped hash.
-          def flat_tree_to_typed(flat)
-            flat.to_h do |key, value|
-              [key, key == '$schema' ? wrap_schema(value) : wrap_typed(value)]
-            end
-          end
-
-          def wrap_schema(value)
-            { 'value_type' => 'string', 'string_value' => value.to_s }
-          end
-
-          def wrap_typed(value)
-            case value
-            when Hash  then wrap_hash(value)
-            when Array then wrap_array(value)
-            else wrap_scalar(value)
-            end
-          end
-
-          def wrap_hash(value)
-            typed = { 'value_type' => 'map' }
-            value.each { |k, v| typed[k.to_s] = wrap_typed(v) }
-            typed
-          end
-
-          def wrap_array(value)
-            {
-              'value_type' => 'array',
-              'items_value' => value.map { |v| wrap_typed(v) }
-            }
-          end
-
-          def wrap_scalar(value)
-            discriminator = DISCRIMINATOR_BY_CLASS[value.class] || 'string'
-            writer = TYPED_VALUE_WRITERS[discriminator]
-            writer&.call(value) || wrap_schema(value)
           end
         end
       end

--- a/coradoc/lib/coradoc/core_model/inline_element.rb
+++ b/coradoc/lib/coradoc/core_model/inline_element.rb
@@ -24,6 +24,18 @@ module Coradoc
         self.class.format_type || format_type
       end
 
+      # Polymorphic classification used by LinkRewriter::Visitor. Returns
+      # :link / :xref when this node carries a rewrite-able target, nil
+      # otherwise. Generic InlineElement instances defer to their
+      # resolved format_type; typed subclasses override with a literal.
+      # Keeps the visitor free of class-keyed case/when (OCP).
+      def link_kind
+        case resolve_format_type
+        when 'link' then :link
+        when 'xref' then :xref
+        end
+      end
+
       FORMAT_TYPES = %w[
         bold italic monospace underline strikethrough
         subscript superscript highlight
@@ -99,11 +111,19 @@ module Coradoc
       def self.format_type
         'link'
       end
+
+      def link_kind
+        :link
+      end
     end
 
     class CrossReferenceElement < InlineElement
       def self.format_type
         'xref'
+      end
+
+      def link_kind
+        :xref
       end
     end
 

--- a/coradoc/lib/coradoc/core_model/list_block.rb
+++ b/coradoc/lib/coradoc/core_model/list_block.rb
@@ -108,6 +108,23 @@ module Coradoc
       #   @return [Array<ListItem>] collection of list items
       attribute :items, ListItem, collection: true
 
+      # -- Fluent construction helpers (paired with Base.build) --
+
+      # Append a new ListItem, built via ListItem.build. The block
+      # (if given) is yielded the new item so callers can chain
+      # +add_text+ / +add_link+ on it inline:
+      #
+      #   ListBlock.build do |ul|
+      #     children.each { |c| ul.add_item { |li| li.add_link(c[:slug], text: c[:title]) } }
+      #   end
+      #
+      # Returns self for chaining at the list level.
+      def add_item(marker: self.marker_type == 'ordered' ? '.' : '*')
+        item = ListItem.build(marker: marker) { |li| yield li if block_given? }
+        self.items = Array(items) + [item]
+        self
+      end
+
       private
 
       # Attributes to compare for semantic equivalence

--- a/coradoc/lib/coradoc/core_model/list_item.rb
+++ b/coradoc/lib/coradoc/core_model/list_item.rb
@@ -109,6 +109,27 @@ module Coradoc
         true
       end
 
+      # -- Fluent construction helpers (paired with Base.build) --
+
+      # Append a plain-text inline to this item's children. Returns
+      # self for chaining. Pairs naturally with ListItem.build:
+      #
+      #   ListItem.build do |li|
+      #     li.add_text("See ")
+      #     li.add_link("foo.adoc", text: "Foo")
+      #   end
+      def add_text(text)
+        self.children = Array(children) + [TextContent.new(text: text)]
+        self
+      end
+
+      # Append a +link:+ inline to this item's children. +text+ becomes
+      # the link's visible label; +target+ is the URL/anchor.
+      def add_link(target, text: nil)
+        self.children = Array(children) + [LinkElement.new(target: target, content: text)]
+        self
+      end
+
       private
 
       # Compare two list blocks for equivalence

--- a/coradoc/lib/coradoc/core_model/output_artifact.rb
+++ b/coradoc/lib/coradoc/core_model/output_artifact.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    # Output-side state object for host-system emitters (VitePress, Hugo,
+    # Astro, plain ERB, etc.).
+    #
+    # coradoc's source side has +IncludeResolver::Filesystem+ to resolve
+    # include targets without coupling to a storage layer. The output side
+    # has no analogous state object — until now. +OutputArtifact+ captures
+    # the three pieces of state coradoc genuinely needs to hand to a
+    # downstream emitter:
+    #
+    # - +output_key+ — site-relative key (e.g. "author/iso/ref/foo")
+    # - +frontmatter_block+ — parsed YAML frontmatter (may be empty)
+    # - +core_document+ — the canonical CoreModel document
+    #
+    # The consumer takes these and renders whatever wrapper it needs in
+    # its host system's native template language. coradoc does not know
+    # about VitePress, ERB, or Liquid. Symmetric with the source side:
+    # minimal protocol object, not an engine.
+    #
+    # A mirror-tree document is deliberately NOT bundled here. coradoc
+    # core has no runtime dependency on coradoc-mirror; consumers that
+    # target the mirror JSON pipeline pair an +OutputArtifact+ with a
+    # separately-computed +Coradoc::Mirror.transform(core)+ result.
+    class OutputArtifact < Base
+      # @!attribute output_key
+      #   @return [String, nil] site-relative key with no leading slash
+      #     and no trailing extension. SSGs map this to their URL space.
+      attribute :output_key, :string
+
+      # @!attribute frontmatter_block
+      #   @return [FrontmatterBlock, nil] parsed YAML frontmatter
+      attribute :frontmatter_block, FrontmatterBlock
+
+      # @!attribute core_document
+      #   @return [DocumentElement, nil] canonical CoreModel document
+      attribute :core_document, DocumentElement
+
+      private
+
+      def comparable_attributes
+        %i[output_key frontmatter_block core_document]
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/core_model/paragraph_block.rb
+++ b/coradoc/lib/coradoc/core_model/paragraph_block.rb
@@ -7,6 +7,10 @@ module Coradoc
       def self.semantic_type
         :paragraph
       end
+
+      def whitespace_only?
+        flat_text.strip.empty?
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model/stem_block.rb
+++ b/coradoc/lib/coradoc/core_model/stem_block.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    # STEM block — mathematical/scientific content authored in LaTeX,
+    # AsciiMath, or another STEM markup. Carries a +language+ attribute so
+    # downstream renderers know which interpreter to invoke.
+    #
+    # AsciiDoc surface forms:
+    #   [stem]\n++++\nx^2\n++++        # language: "latex" (default)
+    #   [latexmath]\n++++\nx^2\n++++   # language: "latex"
+    #   [asciimath]\n++++\nx^2\n++++   # language: "asciimath"
+    class StemBlock < Block
+      attribute :language, :string, default: -> { 'latex' }
+
+      def self.semantic_type
+        :stem
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/core_model/structural_element.rb
+++ b/coradoc/lib/coradoc/core_model/structural_element.rb
@@ -52,6 +52,38 @@ module Coradoc
         false
       end
 
+      # Override in subclasses that carry document-title semantics.
+      # HeaderElement at level 0 represents the document title (`= Title`
+      # in AsciiDoc). Consumers that walk the body — TOC builders,
+      # section numbering — skip these so the title is not counted as
+      # "section 1". Polymorphic dispatch (vs. an is_a? guard at the
+      # call site) keeps the predicate open for future subclasses.
+      def document_title?
+        false
+      end
+
+      # Children that count as body content and aren't whitespace-only.
+      # Derived from per-node {#body_content?} and {#whitespace_only?}
+      # predicates — no central walker, no is_a? switch to maintain.
+      def visible_children
+        Array(children).select(&:body_content?).reject(&:whitespace_only?)
+      end
+
+      # True when the body has no visible content anywhere in its subtree.
+      # A document with only frontmatter + comments returns true; a
+      # document with one non-whitespace paragraph returns false.
+      def empty_body?
+        return true if children.nil? || children.empty?
+
+        children.all? do |child|
+          next true unless child.body_content?
+          next true if child.whitespace_only?
+          next child.empty_body? if child.is_a?(StructuralElement)
+
+          false
+        end
+      end
+
       # Derived element_type string for backward compatibility with
       # templates and legacy consumers. Subclasses override this.
       def element_type

--- a/coradoc/lib/coradoc/core_model/structural_element.rb
+++ b/coradoc/lib/coradoc/core_model/structural_element.rb
@@ -108,6 +108,15 @@ module Coradoc
         true
       end
 
+      # A level-0 HeaderElement represents the document title (the `= Title`
+      # line in AsciiDoc, the `<h1>` in HTML). It is structurally part of
+      # the body but semantically the document's title, not a section —
+      # section numbering, TOC builders, and other section-aware logic
+      # skip these so the title is not counted as "section 1".
+      def document_title?
+        level.to_i.zero?
+      end
+
       def self.element_type_name
         'header'
       end

--- a/coradoc/lib/coradoc/core_model/text_content.rb
+++ b/coradoc/lib/coradoc/core_model/text_content.rb
@@ -17,6 +17,10 @@ module Coradoc
       def to_s
         text.to_s
       end
+
+      def whitespace_only?
+        text.to_s.strip.empty?
+      end
     end
   end
 end

--- a/coradoc/lib/coradoc/link_rewriter.rb
+++ b/coradoc/lib/coradoc/link_rewriter.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Coradoc
+  # Post-parse link/xref rewriting.
+  #
+  # Consumers that need to canonicalize link and xref targets (snake→kebab,
+  # strip +.adoc+, redirect maps, dialect translation) get a single
+  # immutable entry point: +Coradoc.rewrite_links(doc, rewriter:, &)+.
+  # The visitor walks the parsed CoreModel, invokes the supplied rewriter
+  # for every link/xref target, and returns a NEW document. Verbatim
+  # blocks (source, listing, literal, pass, stem) are skipped entirely —
+  # coradoc owns the parse and guarantees those bodies never reach the
+  # rewriter, removing the "track parser state to avoid verbatim bodies"
+  # footgun that plagues regex-based rewriting.
+  #
+  # Two-step API mirrors +Coradoc.resolve_includes+: parse produces the
+  # document, rewrite is a separate explicit step the caller controls.
+  module LinkRewriter
+    autoload :Identity, "#{__dir__}/link_rewriter/identity"
+    autoload :Visitor, "#{__dir__}/link_rewriter/visitor"
+
+    class << self
+      # Rewrite every link/xref target in +doc+.
+      #
+      # +rewriter+ responds to +#call(target:, kind:, context:)+ and returns
+      # the new target String. If a block is given it is used as the
+      # rewriter. Omitting both falls back to {Identity} (no-op) — useful
+      # for "give me a structurally identical copy" cases.
+      #
+      # Returns a NEW document; the input is never mutated.
+      def rewrite(doc, rewriter: nil, &block)
+        callable = rewriter || block || Identity.new
+        Visitor.new(callable).visit_document(doc)
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/link_rewriter/identity.rb
+++ b/coradoc/lib/coradoc/link_rewriter/identity.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module LinkRewriter
+    # Default no-op rewriter. Returns every target unchanged. Used when
+    # the caller only wants the visitor's immutable-copy guarantee.
+    class Identity
+      def call(target:, **)
+        target
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/link_rewriter/visitor.rb
+++ b/coradoc/lib/coradoc/link_rewriter/visitor.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module LinkRewriter
+    # Focused rewriting visitor for the CoreModel tree.
+    #
+    # The set of node types that carry link/xref targets is closed and
+    # small: +LinkElement+, +CrossReferenceElement+, plus generic
+    # +InlineElement+ instances whose +format_type+ is +'link'+ or
+    # +'xref'+. Encoding that classification here, in one place, is
+    # MECE — every other visitor method just delegates to the canonical
+    # "rewrite children and rebuild immutably" path.
+    #
+    # Verbatim block types are also closed: +SourceBlock+, +ListingBlock+,
+    # +LiteralBlock+, +PassBlock+, +StemBlock+. The visitor returns them
+    # unchanged so the rewriter never sees link-shaped text that is, in
+    # fact, raw code/math.
+    #
+    # Dispatch is class-based (no +respond_to?+ duck-typing). Unrecognized
+    # classes are returned unchanged — the visitor is closed by design.
+    class Visitor
+      # Verbatim block classes — content is raw, no link semantics.
+      VERBATIM_TYPES = [
+        Coradoc::CoreModel::SourceBlock,
+        Coradoc::CoreModel::ListingBlock,
+        Coradoc::CoreModel::LiteralBlock,
+        Coradoc::CoreModel::PassBlock,
+        Coradoc::CoreModel::StemBlock
+      ].freeze
+
+      # Structural/container classes that own a child collection. Each
+      # entry maps the class to the reader method that exposes its
+      # children. MECE — every "recurse into the children" case lands
+      # in this table.
+      CONTAINER_TYPES = {
+        Coradoc::CoreModel::DocumentElement => :children,
+        Coradoc::CoreModel::SectionElement => :children,
+        Coradoc::CoreModel::PreambleElement => :children,
+        Coradoc::CoreModel::HeaderElement => :children,
+        Coradoc::CoreModel::Block => :children,
+        Coradoc::CoreModel::ListBlock => :items,
+        Coradoc::CoreModel::ListItem => :children,
+        Coradoc::CoreModel::Table => :rows,
+        Coradoc::CoreModel::TableRow => :cells,
+        Coradoc::CoreModel::TableCell => :children,
+        Coradoc::CoreModel::DefinitionList => :items,
+        Coradoc::CoreModel::Toc => :entries,
+        Coradoc::CoreModel::Bibliography => :entries,
+        Coradoc::CoreModel::AnnotationBlock => :children
+      }.freeze
+
+      LINK_FORMAT_TYPES = %w[link xref].freeze
+
+      def initialize(rewriter)
+        @rewriter = rewriter
+      end
+
+      # Entry point. Always returns a NEW root node — even Identity
+      # callers can rely on object identity to confirm the rewrite ran.
+      def visit_document(document)
+        return document unless document.is_a?(Coradoc::CoreModel::Base)
+
+        result = visit_subtree(document)
+        result.equal?(document) ? document.dup : result
+      end
+
+      private
+
+      def visit_subtree(node)
+        return node if VERBATIM_TYPES.any? { |type| node.is_a?(type) }
+        return rewrite_inline(node) if node.is_a?(Coradoc::CoreModel::InlineElement)
+
+        reader = reader_for(node)
+        return node unless reader
+
+        rewrite_collection(node, reader)
+      end
+
+      # Look up the children-reader method for +node+. Returns nil for
+      # unrecognized classes (no duck-typing — the CONTAINER_TYPES
+      # table is the single source of truth).
+      def reader_for(node)
+        CONTAINER_TYPES.each do |klass, reader|
+          return reader if node.is_a?(klass)
+        end
+        nil
+      end
+
+      def rewrite_collection(node, attr_name)
+        original = node.public_send(attr_name)
+        return node if original.nil? || original.empty?
+
+        rewritten = original.map { |child| visit_subtree(child) }
+        return node if unchanged?(rewritten, original)
+
+        rebuild_with(node, attr_name => rewritten)
+      end
+
+      # Inline dispatch. Typed LinkElement / CrossReferenceElement are
+      # always candidates; generic InlineElement instances must declare a
+      # matching format_type. Other typed subclasses (Bold, Italic, …)
+      # are walked for nested inlines instead of being rewritten.
+      def rewrite_inline(inline)
+        kind = link_kind_for(inline)
+
+        rewritten_target = rewrite_target(inline, kind)
+        rewritten_nested = rewrite_nested(inline)
+
+        return inline if rewritten_target.nil? && rewritten_nested.nil?
+
+        overrides = {}
+        overrides[:target] = rewritten_target unless rewritten_target.nil?
+        overrides[:nested_elements] = rewritten_nested unless rewritten_nested.nil?
+        rebuild_with(inline, overrides)
+      end
+
+      def rewrite_target(inline, kind)
+        return nil unless kind
+
+        target = inline.target
+        return nil if target.nil? || target.empty?
+
+        new_target = @rewriter.call(
+          target: target,
+          kind: kind,
+          context: { in_verbatim: false }
+        )
+        return nil if new_target == target
+
+        new_target
+      end
+
+      def rewrite_nested(inline)
+        nested = inline.nested_elements
+        return nil if nested.nil? || nested.empty?
+
+        rewritten = nested.map { |child| visit_subtree(child) }
+        return nil if unchanged?(rewritten, nested)
+
+        rewritten
+      end
+
+      # Map a node to its link kind (:link, :xref) or nil when the node
+      # is not a rewrite target.
+      def link_kind_for(inline)
+        case inline
+        when Coradoc::CoreModel::LinkElement
+          :link
+        when Coradoc::CoreModel::CrossReferenceElement
+          :xref
+        else
+          format_type = inline.resolve_format_type
+          return nil unless LINK_FORMAT_TYPES.include?(format_type)
+
+          format_type == 'link' ? :link : :xref
+        end
+      end
+
+      def rebuild_with(node, overrides)
+        duplicate = node.dup
+        overrides.each { |key, value| duplicate.public_send("#{key}=", value) }
+        duplicate
+      end
+
+      def unchanged?(rewritten, original)
+        return false unless rewritten.length == original.length
+
+        rewritten.each_with_index.all? { |node, i| node.equal?(original[i]) }
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/link_rewriter/visitor.rb
+++ b/coradoc/lib/coradoc/link_rewriter/visitor.rb
@@ -7,9 +7,10 @@ module Coradoc
     # The set of node types that carry link/xref targets is closed and
     # small: +LinkElement+, +CrossReferenceElement+, plus generic
     # +InlineElement+ instances whose +format_type+ is +'link'+ or
-    # +'xref'+. Encoding that classification here, in one place, is
-    # MECE — every other visitor method just delegates to the canonical
-    # "rewrite children and rebuild immutably" path.
+    # +'xref'+. That classification is owned polymorphically by
+    # +InlineElement#link_kind+ — the visitor just calls it. Adding a
+    # new link-bearing subclass means overriding +link_kind+ on it,
+    # not editing a case/when here (OCP).
     #
     # Verbatim block types are also closed: +SourceBlock+, +ListingBlock+,
     # +LiteralBlock+, +PassBlock+, +StemBlock+. The visitor returns them
@@ -31,7 +32,9 @@ module Coradoc
       # Structural/container classes that own a child collection. Each
       # entry maps the class to the reader method that exposes its
       # children. MECE — every "recurse into the children" case lands
-      # in this table.
+      # in this table. Exposed as a public constant so spec helpers
+      # and other visitors can mirror the same paths without restating
+      # the dispatch (DRY).
       CONTAINER_TYPES = {
         Coradoc::CoreModel::DocumentElement => :children,
         Coradoc::CoreModel::SectionElement => :children,
@@ -48,8 +51,6 @@ module Coradoc
         Coradoc::CoreModel::Bibliography => :entries,
         Coradoc::CoreModel::AnnotationBlock => :children
       }.freeze
-
-      LINK_FORMAT_TYPES = %w[link xref].freeze
 
       def initialize(rewriter)
         @rewriter = rewriter
@@ -101,7 +102,7 @@ module Coradoc
       # matching format_type. Other typed subclasses (Bold, Italic, …)
       # are walked for nested inlines instead of being rewritten.
       def rewrite_inline(inline)
-        kind = link_kind_for(inline)
+        kind = inline.link_kind
 
         rewritten_target = rewrite_target(inline, kind)
         rewritten_nested = rewrite_nested(inline)
@@ -138,22 +139,6 @@ module Coradoc
         return nil if unchanged?(rewritten, nested)
 
         rewritten
-      end
-
-      # Map a node to its link kind (:link, :xref) or nil when the node
-      # is not a rewrite target.
-      def link_kind_for(inline)
-        case inline
-        when Coradoc::CoreModel::LinkElement
-          :link
-        when Coradoc::CoreModel::CrossReferenceElement
-          :xref
-        else
-          format_type = inline.resolve_format_type
-          return nil unless LINK_FORMAT_TYPES.include?(format_type)
-
-          format_type == 'link' ? :link : :xref
-        end
       end
 
       def rebuild_with(node, overrides)

--- a/coradoc/lib/coradoc/relative_path.rb
+++ b/coradoc/lib/coradoc/relative_path.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Coradoc
+  # Pure-function module for relative-path arithmetic across output keys.
+  #
+  # Every SSG wrapper (VitePress, Hugo, Astro) needs to compute "how many
+  # directories up do I walk to reach the site root from this output?".
+  # The answer is the segment count of the source output_key. Everything
+  # else (template, imports) is host-system-specific; this module owns
+  # only the one piece of arithmetic that is genuinely shared.
+  #
+  # No state. No class. No knowledge of any specific SSG.
+  #
+  # @example Compute a VitePress import path
+  #   Coradoc::RelativePath.from("author/iso/ref/foo", to: ".vitepress/theme")
+  #   # => "../../../.vitepress/theme"
+  module RelativePath
+    module_function
+
+    # Compute a relative path from an output_key to a site-root-relative
+    # target.
+    #
+    # @param output_key [String, nil] site-relative key for the source
+    #   page (e.g. "author/iso/ref/foo"). No leading slash, no extension.
+    # @param to [String] destination path relative to the site root.
+    # @return [String] the composed relative path.
+    def from(output_key, to:)
+      depth = output_key.to_s.count('/')
+      ('../' * depth) + to.to_s
+    end
+  end
+end

--- a/coradoc/spec/coradoc/core_model/base_build_spec.rb
+++ b/coradoc/spec/coradoc/core_model/base_build_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc'
+require 'coradoc/core_model'
+
+RSpec.describe 'CoreModel builder API (Base.build + fluent constructors)' do
+  describe 'CoreModel::Base.build' do
+    it 'returns a new instance identical to new() when no block is given' do
+      built = Coradoc::CoreModel::Base.build(id: 'x', title: 'T')
+      direct = Coradoc::CoreModel::Base.new(id: 'x', title: 'T')
+
+      expect(built.id).to eq('x')
+      expect(built.title).to eq('T')
+      expect(built).to be_a(Coradoc::CoreModel::Base)
+      expect(built.semantically_equivalent?(direct)).to be(true)
+    end
+
+    it 'yields the instance for in-place mutation' do
+      built = Coradoc::CoreModel::TextContent.build(text: 'before') do |tc|
+        tc.text = 'after'
+      end
+
+      expect(built.text).to eq('after')
+    end
+
+    it 'is inherited by every subclass' do
+      [Coradoc::CoreModel::DocumentElement,
+       Coradoc::CoreModel::ParagraphBlock,
+       Coradoc::CoreModel::ListItem,
+       Coradoc::CoreModel::ListBlock].each do |klass|
+        expect(klass.respond_to?(:build)).to be(true), "#{klass} should respond to build"
+      end
+    end
+  end
+
+  describe 'ListBlock#add_item' do
+    it 'appends a ListItem built from the block and returns self for chaining' do
+      list = Coradoc::CoreModel::ListBlock.build(marker_type: 'unordered') do |ul|
+        result = ul.add_item { |li| li.add_text('first') }
+        expect(result).to be(ul)
+        ul.add_item { |li| li.add_text('second') }
+      end
+
+      expect(list.items.map(&:content).compact).to eq([])
+      expect(list.items.length).to eq(2)
+      expect(list.items[0].children.map(&:text)).to eq(['first'])
+      expect(list.items[1].children.map(&:text)).to eq(['second'])
+    end
+
+    it 'picks a sensible default marker based on marker_type' do
+      unordered = Coradoc::CoreModel::ListBlock.build(marker_type: 'unordered') do |ul|
+        ul.add_item { |li| li.add_text('a') }
+      end
+      ordered = Coradoc::CoreModel::ListBlock.build(marker_type: 'ordered') do |ol|
+        ol.add_item { |li| li.add_text('1') }
+      end
+
+      expect(unordered.items.first.marker).to eq('*')
+      expect(ordered.items.first.marker).to eq('.')
+    end
+  end
+
+  describe 'ListItem#add_text and #add_link' do
+    it 'appends typed inline nodes to children' do
+      item = Coradoc::CoreModel::ListItem.build do |li|
+        li.add_text('See ')
+        li.add_link('foo.adoc', text: 'Foo')
+        li.add_text('.')
+      end
+
+      expect(item.children.map(&:class)).to eq([
+        Coradoc::CoreModel::TextContent,
+        Coradoc::CoreModel::LinkElement,
+        Coradoc::CoreModel::TextContent
+      ])
+      expect(item.children[0].text).to eq('See ')
+      expect(item.children[1].target).to eq('foo.adoc')
+      expect(item.children[1].content).to eq('Foo')
+    end
+  end
+
+  describe 'real-world hub-page synthesis (no source-text round-trip)' do
+    it 'builds a DocumentElement with frontmatter + intro + bulleted links' do
+      children = [
+        { slug: 'iso', title: 'ISO' },
+        { slug: 'iec', title: 'IEC' }
+      ]
+
+      frontmatter = Coradoc::CoreModel::FrontmatterBlock.new(
+        data: { 'title' => 'Author Index' }
+      )
+
+      list = Coradoc::CoreModel::ListBlock.build(marker_type: 'unordered') do |ul|
+        children.each { |c| ul.add_item { |li| li.add_link("./#{c[:slug]}/", text: c[:title]) } }
+      end
+
+      intro = Coradoc::CoreModel::ParagraphBlock.new(content: 'Author documentation.')
+
+      doc = Coradoc::CoreModel::DocumentElement.build(
+        title: 'Author Index',
+        children: [frontmatter, intro, list]
+      )
+
+      expect(doc.title).to eq('Author Index')
+      expect(doc.children.length).to eq(3)
+      expect(doc.children[0]).to be_a(Coradoc::CoreModel::FrontmatterBlock)
+      expect(doc.children[1].content).to eq('Author documentation.')
+
+      built_list = doc.children[2]
+      expect(built_list.items.length).to eq(2)
+      expect(built_list.items[0].children[0].target).to eq('./iso/')
+      expect(built_list.items[0].children[0].content).to eq('ISO')
+      expect(built_list.items[1].children[0].target).to eq('./iec/')
+    end
+  end
+end

--- a/coradoc/spec/coradoc/core_model/body_content_predicates_spec.rb
+++ b/coradoc/spec/coradoc/core_model/body_content_predicates_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc'
+require 'coradoc/core_model'
+
+RSpec.describe 'per-node body-content predicates' do
+  describe 'Base defaults' do
+    it 'returns true for body_content? on a generic node' do
+      expect(Coradoc::CoreModel::Base.new).to be_body_content
+    end
+
+    it 'returns false for whitespace_only? on a generic node' do
+      expect(Coradoc::CoreModel::Base.new).not_to be_whitespace_only
+    end
+  end
+
+  describe 'body_content? overrides' do
+    it 'returns false for CommentBlock' do
+      expect(Coradoc::CoreModel::CommentBlock.new).not_to be_body_content
+    end
+
+    it 'returns false for CommentLine' do
+      expect(Coradoc::CoreModel::CommentLine.new(text: '// note')).not_to be_body_content
+    end
+
+    it 'returns false for FrontmatterBlock' do
+      fm = Coradoc::CoreModel::FrontmatterBlock.new(data: { 'title' => 'X' })
+      expect(fm).not_to be_body_content
+    end
+
+    it 'returns true for ParagraphBlock (no override)' do
+      expect(Coradoc::CoreModel::ParagraphBlock.new(content: 'hi')).to be_body_content
+    end
+  end
+
+  describe 'whitespace_only? overrides' do
+    it 'returns true for TextContent with empty text' do
+      expect(Coradoc::CoreModel::TextContent.new(text: '')).to be_whitespace_only
+    end
+
+    it 'returns true for TextContent with only whitespace' do
+      expect(Coradoc::CoreModel::TextContent.new(text: "  \n\t ")).to be_whitespace_only
+    end
+
+    it 'returns false for TextContent with visible characters' do
+      expect(Coradoc::CoreModel::TextContent.new(text: 'word')).not_to be_whitespace_only
+    end
+
+    it 'returns true for ParagraphBlock with nil content and no children' do
+      expect(Coradoc::CoreModel::ParagraphBlock.new).to be_whitespace_only
+    end
+
+    it 'returns true for ParagraphBlock whose children are all whitespace' do
+      para = Coradoc::CoreModel::ParagraphBlock.new(
+        children: [Coradoc::CoreModel::TextContent.new(text: '  ')]
+      )
+      expect(para).to be_whitespace_only
+    end
+
+    it 'returns false for ParagraphBlock with visible content' do
+      expect(Coradoc::CoreModel::ParagraphBlock.new(content: 'Hello'))
+        .not_to be_whitespace_only
+    end
+
+    it 'returns false for ParagraphBlock with a visible-text child' do
+      para = Coradoc::CoreModel::ParagraphBlock.new(
+        children: [Coradoc::CoreModel::TextContent.new(text: 'word')]
+      )
+      expect(para).not_to be_whitespace_only
+    end
+  end
+
+  describe 'StructuralElement#visible_children' do
+    it 'selects body_content nodes and rejects whitespace-only ones' do
+      fm = Coradoc::CoreModel::FrontmatterBlock.new(data: { 'title' => 'X' })
+      comment = Coradoc::CoreModel::CommentBlock.new(lines: ['c'])
+      empty_para = Coradoc::CoreModel::ParagraphBlock.new(content: '   ')
+      real_para = Coradoc::CoreModel::ParagraphBlock.new(content: 'real body')
+
+      doc = Coradoc::CoreModel::DocumentElement.new(
+        children: [fm, comment, empty_para, real_para]
+      )
+
+      expect(doc.visible_children).to eq([real_para])
+    end
+
+    it 'returns an empty array when children is nil' do
+      expect(Coradoc::CoreModel::DocumentElement.new.visible_children).to eq([])
+    end
+  end
+
+  describe 'StructuralElement#empty_body?' do
+    it 'returns true for a document with no children' do
+      expect(Coradoc::CoreModel::DocumentElement.new).to be_empty_body
+    end
+
+    it 'returns true for a comment-only document' do
+      doc = Coradoc::CoreModel::DocumentElement.new(
+        children: [Coradoc::CoreModel::CommentBlock.new(lines: ['hidden'])]
+      )
+      expect(doc).to be_empty_body
+    end
+
+    it 'returns true for a frontmatter-only document' do
+      doc = Coradoc::CoreModel::DocumentElement.new(
+        children: [Coradoc::CoreModel::FrontmatterBlock.new(data: { 'title' => 'X' })]
+      )
+      expect(doc).to be_empty_body
+    end
+
+    it 'returns true when every paragraph is whitespace-only' do
+      doc = Coradoc::CoreModel::DocumentElement.new(
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: "  \n")]
+      )
+      expect(doc).to be_empty_body
+    end
+
+    it 'returns false when a real paragraph is present' do
+      doc = Coradoc::CoreModel::DocumentElement.new(
+        children: [
+          Coradoc::CoreModel::FrontmatterBlock.new(data: { 'title' => 'X' }),
+          Coradoc::CoreModel::CommentBlock.new(lines: ['c']),
+          Coradoc::CoreModel::ParagraphBlock.new(content: 'real body')
+        ]
+      )
+      expect(doc).not_to be_empty_body
+    end
+
+    it 'recurses into nested StructuralElements (empty section does not count)' do
+      empty_section = Coradoc::CoreModel::SectionElement.new(
+        title: 'Empty',
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: '')]
+      )
+      doc = Coradoc::CoreModel::DocumentElement.new(children: [empty_section])
+      expect(doc).to be_empty_body
+    end
+
+    it 'recurses into nested StructuralElements (section with content counts)' do
+      real_section = Coradoc::CoreModel::SectionElement.new(
+        title: 'Real',
+        children: [Coradoc::CoreModel::ParagraphBlock.new(content: 'body')]
+      )
+      doc = Coradoc::CoreModel::DocumentElement.new(children: [real_section])
+      expect(doc).not_to be_empty_body
+    end
+  end
+end

--- a/coradoc/spec/coradoc/core_model/frontmatter_block/codec_spec.rb
+++ b/coradoc/spec/coradoc/core_model/frontmatter_block/codec_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Coradoc::CoreModel::FrontmatterBlock::Codec do
 
   let(:block) { described_class.from_yaml(flat_yaml) }
 
-  describe ':flat mode (default)' do
+  describe 'flat YAML round-trip' do
     it 'round-trips flat YAML unchanged' do
       expect(described_class.to_yaml(block)).to eq("#{flat_yaml}\n")
     end
@@ -43,69 +43,37 @@ RSpec.describe Coradoc::CoreModel::FrontmatterBlock::Codec do
     end
   end
 
-  describe ':typed mode (discriminator shape)' do
-    let(:typed_yaml) { described_class.to_yaml(block, mode: :typed) }
-    let(:typed_hash) { described_class.to_hash(block, mode: :typed) }
-
-    it 'wraps string values with value_type discriminator' do
-      expect(typed_hash['title']).to eq(
-        'value_type' => 'string',
-        'string_value' => 'Foo'
-      )
+  describe 'typed value preservation via Psych permitted classes' do
+    it 'preserves Date through round-trip' do
+      block = described_class.from_yaml("due: 2024-06-15\n")
+      expect(described_class.to_hash(block)['due']).to eq(Date.new(2024, 6, 15))
     end
 
-    it 'wraps date values with value_type discriminator' do
-      expect(typed_hash['date']).to eq(
-        'value_type' => 'date',
-        'date_value' => '2024-01-01'
-      )
+    it 'preserves Time through round-trip' do
+      block = described_class.from_yaml("at: 2024-06-15T10:30:00Z\n")
+      expect(described_class.to_hash(block)['at']).to be_a(Time)
     end
 
-    it 'wraps array values with items_value discriminator' do
-      expect(typed_hash['tags']).to eq(
-        'value_type' => 'array',
-        'items_value' => [
-          { 'value_type' => 'string', 'string_value' => 'a' },
-          { 'value_type' => 'string', 'string_value' => 'b' }
-        ]
-      )
+    it 'preserves Symbol through round-trip' do
+      block = described_class.from_yaml("status: :draft\n")
+      expect(described_class.to_hash(block)['status']).to eq(:draft)
     end
 
-    it 'wraps boolean values with value_type discriminator' do
-      expect(typed_hash['draft']).to eq(
-        'value_type' => 'boolean',
-        'boolean_value' => false
-      )
+    it 'preserves Integer through round-trip' do
+      block = described_class.from_yaml("count: 42\n")
+      expect(described_class.to_hash(block)['count']).to eq(42)
     end
 
-    it 'emits typed YAML with the discriminator fields' do
-      expect(typed_yaml).to include('value_type: string')
-      expect(typed_yaml).to include('string_value: Foo')
-      expect(typed_yaml).to include('value_type: date')
-      expect(typed_yaml).to include('value_type: array')
-      expect(typed_yaml).to include('value_type: boolean')
+    it 'preserves Boolean through round-trip' do
+      block = described_class.from_yaml("draft: false\n")
+      expect(described_class.to_hash(block)['draft']).to eq(false)
     end
 
-    it 'round-trips :typed YAML back to the same block (mode-agnostic model)' do
-      back = described_class.from_yaml(typed_yaml, mode: :typed)
-      expect(described_class.to_hash(back)).to eq(described_class.to_hash(block))
-    end
-
-    it 'round-trips :typed hash through from_hash(mode: :typed)' do
-      back = described_class.from_hash(typed_hash, mode: :typed)
-      expect(described_class.to_hash(back)).to eq(described_class.to_hash(block))
-    end
-  end
-
-  describe 'mode equivalence' do
-    it 'both modes share the same underlying FrontmatterBlock' do
-      # Mode is purely a serialization concern — the model is mode-agnostic.
-      expect(described_class.to_hash(block, mode: :flat)).to eq(
-        'title' => 'Foo',
-        'date' => Date.new(2024, 1, 1),
-        'tags' => %w[a b],
-        'draft' => false
-      )
+    it 'preserves nil through round-trip' do
+      block = described_class.from_yaml("missing:\n")
+      hash = described_class.to_hash(block)
+      expect(hash.key?('missing')).to be(true)
+      expect(hash['missing']).to be_nil
     end
   end
 
@@ -140,8 +108,17 @@ RSpec.describe Coradoc::CoreModel::FrontmatterBlock::Codec do
       expect(block.empty?).to be(true)
     end
 
-    it 'returns an empty block on malformed YAML' do
-      block = described_class.from_yaml("title: [unterminated")
+    it 'warns and returns an empty block on malformed YAML' do
+      allow(Coradoc::Logger).to receive(:warn)
+      block = described_class.from_yaml('title: [unterminated')
+      expect(Coradoc::Logger).to have_received(:warn).with(/frontmatter parse failed/)
+      expect(block.empty?).to be(true)
+    end
+
+    it 'warns and returns an empty block on disallowed YAML class' do
+      allow(Coradoc::Logger).to receive(:warn)
+      block = described_class.from_yaml('foo: !ruby/object:Object {}')
+      expect(Coradoc::Logger).to have_received(:warn).with(/frontmatter parse failed/)
       expect(block.empty?).to be(true)
     end
 
@@ -165,7 +142,7 @@ RSpec.describe Coradoc::CoreModel::FrontmatterBlock::Codec do
         author: Jane
       YAML
       block = described_class.from_yaml(yaml)
-      hash = described_class.to_hash(block, mode: :flat)
+      hash = described_class.to_hash(block)
 
       expect(hash['title']).to eq('My Post')
       expect(hash['description']).to eq('A short summary')
@@ -174,17 +151,33 @@ RSpec.describe Coradoc::CoreModel::FrontmatterBlock::Codec do
     end
   end
 
-  describe 'integer and null values' do
-    it 'wraps integer and null values correctly in typed mode' do
-      yaml = "count: 42\nmissing:\n"
+  describe 'nested structures' do
+    it 'preserves nested Hash values' do
+      yaml = <<~YAML.strip
+        author:
+          name: Jane
+          email: jane@example.com
+      YAML
       block = described_class.from_yaml(yaml)
-      typed = described_class.to_hash(block, mode: :typed)
-
-      expect(typed['count']).to eq(
-        'value_type' => 'integer',
-        'integer_value' => 42
+      hash = described_class.to_hash(block)
+      expect(hash['author']).to eq(
+        'name' => 'Jane',
+        'email' => 'jane@example.com'
       )
-      expect(typed['missing']).to eq('value_type' => 'null')
+    end
+
+    it 'preserves Array of Hashes' do
+      yaml = <<~YAML.strip
+        authors:
+        - name: Jane
+        - name: Carlos
+      YAML
+      block = described_class.from_yaml(yaml)
+      hash = described_class.to_hash(block)
+      expect(hash['authors']).to eq([
+        { 'name' => 'Jane' },
+        { 'name' => 'Carlos' }
+      ])
     end
   end
 end

--- a/coradoc/spec/coradoc/core_model/frontmatter_block/codec_spec.rb
+++ b/coradoc/spec/coradoc/core_model/frontmatter_block/codec_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'date'
+
+RSpec.describe Coradoc::CoreModel::FrontmatterBlock::Codec do
+  let(:flat_yaml) do
+    <<~YAML.strip
+      title: Foo
+      date: 2024-01-01
+      tags:
+      - a
+      - b
+      draft: false
+    YAML
+  end
+
+  let(:block) { described_class.from_yaml(flat_yaml) }
+
+  describe ':flat mode (default)' do
+    it 'round-trips flat YAML unchanged' do
+      expect(described_class.to_yaml(block)).to eq("#{flat_yaml}\n")
+    end
+
+    it 'exposes a native-typed hash via to_hash' do
+      hash = described_class.to_hash(block)
+      expect(hash['title']).to eq('Foo')
+      expect(hash['date']).to eq(Date.new(2024, 1, 1))
+      expect(hash['tags']).to eq(%w[a b])
+      expect(hash['draft']).to be(false)
+    end
+
+    it 'round-trips through from_hash/to_hash' do
+      hash = described_class.to_hash(block)
+      back = described_class.from_hash(hash)
+      expect(described_class.to_hash(back)).to eq(hash)
+    end
+
+    it 'round-trips through to_yaml/from_yaml' do
+      yaml = described_class.to_yaml(block)
+      back = described_class.from_yaml(yaml)
+      expect(described_class.to_yaml(back)).to eq(yaml)
+    end
+  end
+
+  describe ':typed mode (discriminator shape)' do
+    let(:typed_yaml) { described_class.to_yaml(block, mode: :typed) }
+    let(:typed_hash) { described_class.to_hash(block, mode: :typed) }
+
+    it 'wraps string values with value_type discriminator' do
+      expect(typed_hash['title']).to eq(
+        'value_type' => 'string',
+        'string_value' => 'Foo'
+      )
+    end
+
+    it 'wraps date values with value_type discriminator' do
+      expect(typed_hash['date']).to eq(
+        'value_type' => 'date',
+        'date_value' => '2024-01-01'
+      )
+    end
+
+    it 'wraps array values with items_value discriminator' do
+      expect(typed_hash['tags']).to eq(
+        'value_type' => 'array',
+        'items_value' => [
+          { 'value_type' => 'string', 'string_value' => 'a' },
+          { 'value_type' => 'string', 'string_value' => 'b' }
+        ]
+      )
+    end
+
+    it 'wraps boolean values with value_type discriminator' do
+      expect(typed_hash['draft']).to eq(
+        'value_type' => 'boolean',
+        'boolean_value' => false
+      )
+    end
+
+    it 'emits typed YAML with the discriminator fields' do
+      expect(typed_yaml).to include('value_type: string')
+      expect(typed_yaml).to include('string_value: Foo')
+      expect(typed_yaml).to include('value_type: date')
+      expect(typed_yaml).to include('value_type: array')
+      expect(typed_yaml).to include('value_type: boolean')
+    end
+
+    it 'round-trips :typed YAML back to the same block (mode-agnostic model)' do
+      back = described_class.from_yaml(typed_yaml, mode: :typed)
+      expect(described_class.to_hash(back)).to eq(described_class.to_hash(block))
+    end
+
+    it 'round-trips :typed hash through from_hash(mode: :typed)' do
+      back = described_class.from_hash(typed_hash, mode: :typed)
+      expect(described_class.to_hash(back)).to eq(described_class.to_hash(block))
+    end
+  end
+
+  describe 'mode equivalence' do
+    it 'both modes share the same underlying FrontmatterBlock' do
+      # Mode is purely a serialization concern — the model is mode-agnostic.
+      expect(described_class.to_hash(block, mode: :flat)).to eq(
+        'title' => 'Foo',
+        'date' => Date.new(2024, 1, 1),
+        'tags' => %w[a b],
+        'draft' => false
+      )
+    end
+  end
+
+  describe '$schema promotion' do
+    it 'promotes $schema to the block attribute, not data' do
+      yaml = "$schema: https://example.com/schema.json\ntitle: Bar\n"
+      block = described_class.from_yaml(yaml)
+      expect(block.schema).to eq('https://example.com/schema.json')
+      expect(block.data).not_to have_key('$schema')
+    end
+
+    it 'serializes $schema back to the top of the YAML' do
+      block = described_class.from_yaml(
+        "$schema: https://example.com/schema.json\ntitle: Bar\n"
+      )
+      yaml = described_class.to_yaml(block)
+      # Psych quotes `$schema` because `$` is reserved at the start of a
+      # YAML scalar — the quoted form is canonical.
+      expect(yaml.lines.first).to start_with('"$schema":')
+    end
+  end
+
+  describe 'malformed input handling' do
+    it 'returns an empty block on nil' do
+      block = described_class.from_yaml(nil)
+      expect(block).to be_a(Coradoc::CoreModel::FrontmatterBlock)
+      expect(block.empty?).to be(true)
+    end
+
+    it 'returns an empty block on empty string' do
+      block = described_class.from_yaml('   ')
+      expect(block.empty?).to be(true)
+    end
+
+    it 'returns an empty block on malformed YAML' do
+      block = described_class.from_yaml("title: [unterminated")
+      expect(block.empty?).to be(true)
+    end
+
+    it 'returns empty hash for non-FrontmatterBlock input' do
+      expect(described_class.to_hash(Object.new)).to eq({})
+      expect(described_class.to_yaml(Object.new)).to eq('')
+    end
+
+    it 'returns empty hash from from_hash with non-Hash input' do
+      block = described_class.from_hash('not a hash')
+      expect(block.empty?).to be(true)
+    end
+  end
+
+  describe 'VitePress-shaped frontmatter (real-world SSG acceptance)' do
+    it 'matches what flat YAML SSGs expect' do
+      yaml = <<~YAML.strip
+        title: My Post
+        description: A short summary
+        date: 2024-06-15
+        author: Jane
+      YAML
+      block = described_class.from_yaml(yaml)
+      hash = described_class.to_hash(block, mode: :flat)
+
+      expect(hash['title']).to eq('My Post')
+      expect(hash['description']).to eq('A short summary')
+      expect(hash['date']).to eq(Date.new(2024, 6, 15))
+      expect(hash['author']).to eq('Jane')
+    end
+  end
+
+  describe 'integer and null values' do
+    it 'wraps integer and null values correctly in typed mode' do
+      yaml = "count: 42\nmissing:\n"
+      block = described_class.from_yaml(yaml)
+      typed = described_class.to_hash(block, mode: :typed)
+
+      expect(typed['count']).to eq(
+        'value_type' => 'integer',
+        'integer_value' => 42
+      )
+      expect(typed['missing']).to eq('value_type' => 'null')
+    end
+  end
+end

--- a/coradoc/spec/coradoc/core_model/output_artifact_spec.rb
+++ b/coradoc/spec/coradoc/core_model/output_artifact_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc'
+require 'coradoc/core_model'
+
+RSpec.describe Coradoc::CoreModel::OutputArtifact do
+  let(:frontmatter) do
+    Coradoc::CoreModel::FrontmatterBlock.new(data: { 'title' => 'Foo' })
+  end
+  let(:core_document) do
+    Coradoc::CoreModel::DocumentElement.new(title: 'Foo')
+  end
+
+  it 'round-trips its three typed attributes' do
+    artifact = described_class.new(
+      output_key: 'author/iso/ref/foo',
+      frontmatter_block: frontmatter,
+      core_document: core_document
+    )
+
+    expect(artifact.output_key).to eq('author/iso/ref/foo')
+    expect(artifact.frontmatter_block).to eq(frontmatter)
+    expect(artifact.core_document).to eq(core_document)
+  end
+
+  it 'accepts a nil for every attribute (consumer is still bootstrapping)' do
+    artifact = described_class.new
+
+    expect(artifact.output_key).to be_nil
+    expect(artifact.frontmatter_block).to be_nil
+    expect(artifact.core_document).to be_nil
+  end
+
+  it 'compares semantically on the three attributes' do
+    a = described_class.new(output_key: 'a/b', core_document: core_document)
+    b = described_class.new(output_key: 'a/b', core_document: core_document)
+
+    expect(a.semantically_equivalent?(b)).to be(true)
+  end
+
+  it 'distinguishes by output_key' do
+    a = described_class.new(output_key: 'a/b')
+    b = described_class.new(output_key: 'a/c')
+
+    expect(a.semantically_equivalent?(b)).to be(false)
+  end
+
+  it 'inherits Base.build for fluent construction' do
+    artifact = described_class.build(output_key: 'x/y') do |a|
+      a.frontmatter_block = frontmatter
+    end
+
+    expect(artifact.output_key).to eq('x/y')
+    expect(artifact.frontmatter_block).to eq(frontmatter)
+  end
+end

--- a/coradoc/spec/coradoc/link_rewriter/rewrite_spec.rb
+++ b/coradoc/spec/coradoc/link_rewriter/rewrite_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc'
+require 'coradoc/asciidoc'
+
+RSpec.describe Coradoc::LinkRewriter do
+  let(:adoc) do
+    <<~ADOC
+      = Doc
+
+      See link:foo_bar.adoc[Foo] and <<section_two>>.
+
+      [source,ruby]
+      ----
+      # link:do_not_touch.adoc inside source
+      url = "xref:also_do_not_touch"
+      ----
+    ADOC
+  end
+
+  let(:document) { Coradoc.parse(adoc, format: :asciidoc) }
+
+  describe '.rewrite with Identity (default)' do
+    it 'returns a structurally equal document' do
+      rewritten = described_class.rewrite(document)
+
+      expect(rewritten.children.map(&:class)).to eq(document.children.map(&:class))
+      expect(rewritten.semantically_equivalent?(document)).to be true
+    end
+
+    it 'returns a NEW object, never the same instance' do
+      rewritten = described_class.rewrite(document)
+
+      expect(rewritten).not_to be(document)
+    end
+  end
+
+  describe '.rewrite with a block' do
+    it 'rewrites link targets via the block' do
+      rewritten = described_class.rewrite(document) do |target:, **|
+        target.tr('_', '-')
+      end
+
+      paragraph = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      link = find_link(paragraph)
+      expect(link.target).to eq('foo-bar.adoc')
+    end
+
+    it 'rewrites xref targets via the block' do
+      rewritten = described_class.rewrite(document) do |target:, kind:, **|
+        next target unless kind == :xref
+
+        "renamed-#{target}"
+      end
+
+      paragraph = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      xref = find_xref(paragraph)
+      expect(xref.target).to eq('renamed-section_two')
+    end
+
+    it 'does NOT rewrite link-shaped text inside verbatim source blocks' do
+      rewritten = described_class.rewrite(document) do |target:, **|
+        target.tr('_', '-')
+      end
+
+      source = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::SourceBlock) }
+      expect(source.content).to include('link:do_not_touch.adoc')
+      expect(source.content).to include('xref:also_do_not_touch')
+    end
+
+    it 'preserves the original document (immutability)' do
+      original_paragraph = document.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      original_link_target = find_link(original_paragraph).target
+
+      described_class.rewrite(document) { |target:, **| target.tr('_', '-') }
+
+      expect(find_link(original_paragraph).target).to eq(original_link_target)
+    end
+  end
+
+  describe '.rewrite with a callable object' do
+    it 'uses the callable when no block is given' do
+      rewriter = Class.new do
+        def call(target:, **)
+          "prefix:#{target}"
+        end
+      end.new
+
+      rewritten = described_class.rewrite(document, rewriter: rewriter)
+
+      paragraph = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      link = find_link(paragraph)
+      expect(link.target).to eq('prefix:foo_bar.adoc')
+    end
+  end
+
+  describe 'verbatim block coverage' do
+    it 'skips literal blocks' do
+      literal_adoc = <<~ADOC
+        = Doc
+
+        link:visible.adoc[Visible]
+
+        ....
+        link:invisible_literal.adoc[Inside Literal]
+        ....
+      ADOC
+      doc = Coradoc.parse(literal_adoc, format: :asciidoc)
+
+      rewritten = described_class.rewrite(doc) { |target:, **| "rewritten-#{target}" }
+
+      literal = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::LiteralBlock) }
+      expect(literal.content).to include('link:invisible_literal.adoc')
+    end
+
+    it 'skips pass-through blocks' do
+      pass_adoc = <<~ADOC
+        = Doc
+
+        link:visible.adoc[Visible]
+
+        ++++
+        link:invisible_pass.adoc[Inside Pass]
+        ++++
+      ADOC
+      doc = Coradoc.parse(pass_adoc, format: :asciidoc)
+
+      rewritten = described_class.rewrite(doc) { |target:, **| "rewritten-#{target}" }
+
+      pass = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::PassBlock) }
+      expect(pass.content).to include('link:invisible_pass.adoc')
+    end
+  end
+
+  describe 'Coradoc.rewrite_links facade' do
+    it 'exposes the API at the top level' do
+      rewritten = Coradoc.rewrite_links(document) { |target:, **| target.tr('_', '-') }
+
+      paragraph = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      link = find_link(paragraph)
+      expect(link.target).to eq('foo-bar.adoc')
+    end
+  end
+
+  def find_link(paragraph)
+    return nil unless paragraph
+
+    flatten_inlines(paragraph).find { |n| n.is_a?(Coradoc::CoreModel::LinkElement) }
+  end
+
+  def find_xref(paragraph)
+    return nil unless paragraph
+
+    flatten_inlines(paragraph).find { |n| n.is_a?(Coradoc::CoreModel::CrossReferenceElement) }
+  end
+
+  def flatten_inlines(node, acc = [])
+    children = nil
+    nested = nil
+
+    case node
+    when Coradoc::CoreModel::InlineElement
+      nested = node.nested_elements
+    when Coradoc::CoreModel::DocumentElement,
+         Coradoc::CoreModel::SectionElement,
+         Coradoc::CoreModel::ParagraphBlock,
+         Coradoc::CoreModel::Block
+      children = node.children
+    end
+
+    Array(children).each { |child| collect_inline(child, acc) }
+    Array(nested).each { |child| collect_inline(child, acc) }
+    acc
+  end
+
+  def collect_inline(child, acc)
+    return unless child.is_a?(Coradoc::CoreModel::Base)
+
+    acc << child
+    flatten_inlines(child, acc)
+  end
+end

--- a/coradoc/spec/coradoc/link_rewriter/rewrite_spec.rb
+++ b/coradoc/spec/coradoc/link_rewriter/rewrite_spec.rb
@@ -4,6 +4,12 @@ require 'spec_helper'
 require 'coradoc'
 require 'coradoc/asciidoc'
 
+# References the visitor's dispatch table so the spec helper recurses
+# through exactly the same paths the visitor does. Subclasses (e.g.
+# ParagraphBlock < Block) are matched by +is_a?+, mirroring the
+# visitor — see +container_reader_for+ below.
+CONTAINER_TYPES = Coradoc::LinkRewriter::Visitor::CONTAINER_TYPES
+
 RSpec.describe Coradoc::LinkRewriter do
   let(:adoc) do
     <<~ADOC
@@ -131,6 +137,75 @@ RSpec.describe Coradoc::LinkRewriter do
       pass = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::PassBlock) }
       expect(pass.content).to include('link:invisible_pass.adoc')
     end
+
+    it 'skips listing blocks' do
+      # The adoc parser emits SourceBlock for `----`, not ListingBlock.
+      # Construct one directly to verify the visitor's VERBATIM_TYPES
+      # coverage is closed: any ListingBlock, regardless of how it was
+      # built, must be skipped.
+      listing = Coradoc::CoreModel::ListingBlock.new(
+        content: 'link:invisible_listing.adoc[Inside Listing]'
+      )
+      doc = Coradoc::CoreModel::DocumentElement.new(children: [listing])
+
+      rewritten = described_class.rewrite(doc) { |target:, **| "rewritten-#{target}" }
+
+      expect(rewritten.children.first.content).to include('link:invisible_listing.adoc')
+    end
+
+    it 'skips stem blocks' do
+      stem_adoc = <<~ADOC
+        = Doc
+
+        link:visible.adoc[Visible]
+
+        [stem,latexmath]
+        ++++
+        link:invisible_stem.adoc[Inside Stem]
+        ++++
+      ADOC
+      doc = Coradoc.parse(stem_adoc, format: :asciidoc)
+
+      rewritten = described_class.rewrite(doc) { |target:, **| "rewritten-#{target}" }
+
+      stem = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::StemBlock) }
+      expect(stem.content).to include('link:invisible_stem.adoc')
+    end
+  end
+
+  describe 'nested containers' do
+    it 'rewrites links nested inside list items' do
+      list_adoc = <<~ADOC
+        = Doc
+
+        * See link:foo.adoc[Foo]
+        * And link:bar.adoc[Bar]
+      ADOC
+      doc = Coradoc.parse(list_adoc, format: :asciidoc)
+
+      rewritten = described_class.rewrite(doc) { |target:, **| "renamed-#{target}" }
+
+      list = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      targets = flatten_inlines(list).select { |n| n.is_a?(Coradoc::CoreModel::LinkElement) }.map(&:target)
+      expect(targets).to contain_exactly('renamed-foo.adoc', 'renamed-bar.adoc')
+    end
+
+    it 'rewrites links nested inside table cells' do
+      table_adoc = <<~ADOC
+        = Doc
+
+        |===
+        | See link:cell_a.adoc[A] | And link:cell_b.adoc[B]
+        |===
+      ADOC
+      doc = Coradoc.parse(table_adoc, format: :asciidoc)
+
+      rewritten = described_class.rewrite(doc) { |target:, **| "tc-#{target}" }
+
+      table = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::Table) }
+      targets = flatten_inlines(table).select { |n| n.is_a?(Coradoc::CoreModel::LinkElement) }.map(&:target)
+      expect(targets).to contain_exactly('tc-cell_a.adoc', 'tc-cell_b.adoc')
+    end
   end
 
   describe 'Coradoc.rewrite_links facade' do
@@ -140,6 +215,35 @@ RSpec.describe Coradoc::LinkRewriter do
       paragraph = rewritten.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
       link = find_link(paragraph)
       expect(link.target).to eq('foo-bar.adoc')
+    end
+  end
+
+  describe 'polymorphic link classification (OCP for new inline types)' do
+    # The visitor delegates classification to InlineElement#link_kind
+    # rather than a class-keyed case/when. Adding a new link-bearing
+    # subclass means overriding +link_kind+ on it, not editing the
+    # visitor. These specs lock that contract in place.
+
+    it 'classifies LinkElement as :link' do
+      node = Coradoc::CoreModel::LinkElement.new(target: 'foo.adoc')
+      expect(node.link_kind).to eq(:link)
+    end
+
+    it 'classifies CrossReferenceElement as :xref' do
+      node = Coradoc::CoreModel::CrossReferenceElement.new(target: 'sec')
+      expect(node.link_kind).to eq(:xref)
+    end
+
+    it 'classifies generic InlineElement by its format_type' do
+      as_link = Coradoc::CoreModel::InlineElement.new(format_type: 'link', target: 'l.adoc')
+      as_xref = Coradoc::CoreModel::InlineElement.new(format_type: 'xref', target: 'sec')
+      expect(as_link.link_kind).to eq(:link)
+      expect(as_xref.link_kind).to eq(:xref)
+    end
+
+    it 'returns nil for non-link inlines' do
+      bold = Coradoc::CoreModel::BoldElement.new
+      expect(bold.link_kind).to be_nil
     end
   end
 
@@ -155,29 +259,33 @@ RSpec.describe Coradoc::LinkRewriter do
     flatten_inlines(paragraph).find { |n| n.is_a?(Coradoc::CoreModel::CrossReferenceElement) }
   end
 
+  # Walks a CoreModel subtree collecting every node in pre-order. The
+  # CONTAINER_TYPES table is shared with LinkRewriter::Visitor so the
+  # spec helper recurses through the same paths the visitor does —
+  # no drift when a container type is added (DRY).
   def flatten_inlines(node, acc = [])
-    children = nil
-    nested = nil
-
-    case node
-    when Coradoc::CoreModel::InlineElement
-      nested = node.nested_elements
-    when Coradoc::CoreModel::DocumentElement,
-         Coradoc::CoreModel::SectionElement,
-         Coradoc::CoreModel::ParagraphBlock,
-         Coradoc::CoreModel::Block
-      children = node.children
-    end
-
-    Array(children).each { |child| collect_inline(child, acc) }
-    Array(nested).each { |child| collect_inline(child, acc) }
+    acc << node if node.is_a?(Coradoc::CoreModel::Base)
+    each_child(node) { |child| flatten_inlines(child, acc) }
     acc
   end
 
-  def collect_inline(child, acc)
-    return unless child.is_a?(Coradoc::CoreModel::Base)
+  def each_child(node, &blk)
+    return unless node.is_a?(Coradoc::CoreModel::Base)
 
-    acc << child
-    flatten_inlines(child, acc)
+    nested = node.nested_elements if node.is_a?(Coradoc::CoreModel::InlineElement)
+    Array(nested).each(&blk)
+
+    reader = container_reader_for(node)
+    Array(node.public_send(reader)).each(&blk) if reader
+  end
+
+  # Mirrors Visitor#reader_for exactly — first is_a? match wins. This
+  # catches subclasses (ParagraphBlock < Block, etc.) via the same
+  # dispatch the visitor uses.
+  def container_reader_for(node)
+    CONTAINER_TYPES.each do |klass, reader|
+      return reader if node.is_a?(klass)
+    end
+    nil
   end
 end

--- a/coradoc/spec/coradoc/relative_path_spec.rb
+++ b/coradoc/spec/coradoc/relative_path_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc'
+
+RSpec.describe Coradoc::RelativePath do
+  describe '.from' do
+    it 'returns the target unchanged when output_key has no slashes' do
+      expect(described_class.from('foo', to: '.vitepress/theme'))
+        .to eq('.vitepress/theme')
+    end
+
+    it 'walks up one directory per segment in the output_key' do
+      expect(described_class.from('author/iso/ref/foo', to: '.vitepress/theme'))
+        .to eq('../../../.vitepress/theme')
+    end
+
+    it 'walks up only the right number of directories for one-segment keys' do
+      expect(described_class.from('author/foo', to: '.vitepress/theme'))
+        .to eq('../.vitepress/theme')
+    end
+
+    it 'returns the target unchanged when output_key is nil' do
+      expect(described_class.from(nil, to: '.vitepress/theme'))
+        .to eq('.vitepress/theme')
+    end
+
+    it 'composes the VitePress-shaped import path from the proposal' do
+      # The real-world import line from FEATURE-template-renderer-with-filesystem.md
+      import = described_class.from('author/iso/ref/foo',
+                                    to: '.vitepress/theme/components/ProseMirrorContent.vue')
+      expect(import)
+        .to eq('../../../.vitepress/theme/components/ProseMirrorContent.vue')
+    end
+
+    it 'composes a JSON import path that includes the output_key itself' do
+      output_key = 'author/iso/ref/document-attributes'
+      json_import = described_class.from(
+        output_key,
+        to: ".vitepress/mirror-json/#{output_key}.json"
+      )
+      expect(json_import)
+        .to eq('../../../.vitepress/mirror-json/author/iso/ref/document-attributes.json')
+    end
+
+    it 'is a pure function: same inputs, same output (no state)' do
+      expect(described_class.from('a/b/c', to: 'x')).to eq('../../x')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Programmatic-construction and query API for CoreModel, plus three audit fixes that surfaced while reviewing the link-rewriter and frontmatter pipeline.

**New API surface:**
- `CoreModel::Base.build(**, &block)` yield-self constructor, inherited by every model
- `ListItem#add_text` / `#add_link`, `ListBlock#add_item` fluent helpers (compose with `build`)
- Per-node `body_content?` / `whitespace_only?` predicates; `StructuralElement#visible_children` + `#empty_body?` derived from them (no central walker)
- `CoreModel::OutputArtifact` (output_key + frontmatter_block + core_document) — output-side companion to `IncludeResolver::Filesystem`
- `Coradoc::RelativePath.from(output_key, to:)` pure function for SSG import-path arithmetic

**Audit fixes:**
- `InlineElement#link_kind` polymorphic dispatch replaces central `LINK_FORMAT_TYPES` switch in the link rewriter (OCP)
- AsciiDoc `transform_stem_block` threads `language_override:` as a keyword arg instead of post-mutating `block.language`
- `FrontmatterBlock::Codec.from_yaml` warns via `Coradoc::Logger.warn` on malformed YAML instead of returning a silent empty block

**Design notes:**
- `ListItem` / `ListBlock` fluent helpers use writer-based accumulation (`self.x = Array(x) + [item]`) because lutaml-model collection getters don't persist `<<` across calls.
- `OutputArtifact` ships with three attributes, not four. The original proposal's `mirror_document` attribute was dropped because `coradoc` core has no runtime dependency on `coradoc-mirror`; consumers pair an `OutputArtifact` with a separately-computed `Mirror.transform(core)` result. The full reasoning is in `FEATURE-template-renderer-with-filesystem.md`.

## Test plan

- [x] `coradoc/spec/coradoc/core_model/base_build_spec.rb` — 7 examples (Base.build + fluent helpers)
- [x] `coradoc/spec/coradoc/core_model/body_content_predicates_spec.rb` — 22 examples (per-node predicates + derived helpers)
- [x] `coradoc/spec/coradoc/core_model/output_artifact_spec.rb` — 5 examples
- [x] `coradoc/spec/coradoc/relative_path_spec.rb` — 7 examples
- [x] `coradoc/spec/coradoc/link_rewriter/rewrite_spec.rb` — polymorphic dispatch specs
- [x] `coradoc/spec/coradoc/core_model/frontmatter_block/codec_spec.rb` — warn-on-malformed specs
- [x] `bundle exec rake spec_all` — coradoc / coradoc-adoc / coradoc-html / coradoc-markdown all green; coradoc-docx has 10 pre-existing failures unrelated to this PR (verified by stashing changes and rerunning)