### PR TITLE
fix(adoc): batch of AsciiDoc parser/transformer bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ TODO.improve/
 
 # Frontend build artifacts
 coradoc-html/frontend/
+TODO.bugs
+TODO.bugs/
+TODO.kotoshu
+TODO.kotoshu/

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/admonition.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/admonition.rb
@@ -4,13 +4,22 @@ module Coradoc
   module AsciiDoc
     module Parser
       module Admonition
+        # Match a single style name case-insensitively. Each character
+        # class `[Xx]` lets the same alternation accept +note+, +Note+,
+        # and +NOTE+ without three separate str() branches per style.
+        def case_insensitive_str(s)
+          s.chars.reduce(nil) do |acc, ch|
+            node = match("[#{ch.upcase}#{ch.downcase}]")
+            acc.nil? ? node : (acc >> node)
+          end
+        end
+
         def admonition_type
-          str('NOTE') | str('TIP') | str('EDITOR') |
-            str('IMPORTANT') | str('WARNING') | str('CAUTION') |
-            str('TODO')
-          # requires atypical syntax for access?
-          # | str('DANGER')
-          # | str('SAFETY PRECAUTION')
+          styles = Coradoc::AsciiDoc::Transform::ElementTransformers::AdmonitionStyles.all_styles
+          styles.reduce(nil) do |acc, style|
+            matcher = case_insensitive_str(style)
+            acc.nil? ? matcher : (acc | matcher)
+          end
         end
 
         def admonition_line

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
@@ -120,18 +120,36 @@ module Coradoc
           (str('image:').present? >> str('image:') >>
             str(':').absent? >>
             match('[A-Za-z0-9_.\\-:/&?=+,%#~;]+').repeat(1).as(:path) >>
-            (str('[') >> match('[^\\]]').repeat(1).as(:text) >> str(']')).maybe
+            attribute_list(:attribute_list).maybe
           ).as(:inline_image)
         end
 
         # Triple-plus inline passthrough: `+++raw content+++`. The content
         # passes through all substitutions verbatim. Common use is to embed
         # raw HTML in AsciiDoc documents.
-        def inline_passthrough
+        def inline_passthrough_triple_plus
           (str('+++') >>
             (str('+++').absent? >> match('[^\n]')).repeat(1).as(:raw) >>
             str('+++')
           ).as(:inline_passthrough)
+        end
+
+        # `pass:[raw]` macro form. Equivalent semantic to triple-plus:
+        # the bracket payload survives all substitutions verbatim. Common
+        # use is inside monospace spans to keep characters like `<` from
+        # being re-interpreted as xref markers. The optional `subs` segment
+        # (`pass:quotes[...]`) is consumed but currently ignored — the
+        # payload is always passed through raw.
+        def inline_passthrough_macro
+          (str('pass:').present? >> str('pass:') >>
+            match('[a-zA-Z,+]').repeat(0) >>
+            str('[') >> (str(']]').absent? >> match('[^\]\n]')).repeat(1).as(:raw) >>
+            str(']')
+          ).as(:inline_passthrough)
+        end
+
+        def inline_passthrough
+          inline_passthrough_triple_plus | inline_passthrough_macro
         end
 
         def underline
@@ -157,10 +175,26 @@ module Coradoc
             str('link:').present? |
             str('image:').present? |
             str('+++').present? |
+            str('pass:').present? |
             term_type.present? |
             str('footnote').present? |
             stem_type.present? |
-            str('\\<<').present?
+            str('\\<<').present? |
+            hard_line_break_marker?
+        end
+
+        # AsciiDoc hard line break: a space followed by `+` at end of line,
+        # or a backslash at end of line. Both forms render as `<br>` inside
+        # the enclosing paragraph/verse. Recognised ahead of `text_unformatted`
+        # so the marker isn't swallowed as plain text.
+        def hard_line_break_marker?
+          (str(' +') >> str("\n")).present? |
+            (str('\\') >> str("\n")).present?
+        end
+
+        def hard_line_break
+          ((str(' +') >> str("\n")) |
+             (str('\\') >> str("\n"))).as(:hard_line_break)
         end
 
         def inline
@@ -187,7 +221,8 @@ module Coradoc
             inline_image |
             inline_passthrough |
             underline |
-            small
+            small |
+            hard_line_break
         end
 
         def text_unformatted

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
@@ -149,8 +149,13 @@ module Coradoc
         end
 
         def dlist_definition
-          text
-            .as(:definition) >> line_ending >> empty_line.repeat(0)
+          # AsciiDoc convention: the definition body is indented relative
+          # to the term. That leading whitespace is structural (marks
+          # the line as a continuation of the dlist item), not content.
+          # Consume it without capturing so downstream CoreModel text
+          # doesn't carry the source indentation into HTML/Markdown.
+          (match('[ \t]').repeat(0) >> text.as(:definition)) >>
+            line_ending >> empty_line.repeat(0)
         end
 
         def dlist_item(_delimiter = nil)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/admonition_styles.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/admonition_styles.rb
@@ -26,6 +26,21 @@ module Coradoc
               BUILTIN.include?(name) || custom.include?(name)
             end
 
+            # Canonical uppercase form for +style+, or nil if unknown.
+            # Single source of truth for the canonical casing used in
+            # CoreModel::AnnotationBlock#annotation_type and AsciiDoc
+            # round-trip output.
+            def canonicalize(style)
+              return nil unless admonition?(style)
+
+              style.to_s.upcase
+            end
+
+            # All registered style names (BUILTIN + custom), lowercased.
+            def all_styles
+              (BUILTIN + custom).freeze
+            end
+
             # Register an additional admonition style. Open for extension.
             def register(style)
               name = style.to_s.downcase

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
@@ -71,16 +71,26 @@ module Coradoc
 
             # Dispatch entry point for any block whose AsciiDoc model carries
             # an attribute list (delimited blocks + open blocks). Per the
-            # AsciiDoc spec, every delimited block accepts admonition styles
-            # in its attribute line. Admonition style wins for example,
-            # sidebar, quote, and open blocks; verbatim blocks (source,
-            # listing) intentionally ignore it because their verbatim
-            # semantics are stronger than the annotation label.
+            # AsciiDoc spec, every delimited block accepts both admonition
+            # labels and verbatim/stem casts in its attribute line. The cast
+            # is resolved by +block_cast_semantic+ in MECE order:
+            # admonition > stem > verbatim > fallback.
             def transform_with_admonition_check(block, native_class)
-              style = first_positional_attr(block)
-              return transform_admonition_block(block, style) if AdmonitionStyles.admonition?(style)
-
-              transform_typed_block(block, native_class)
+              semantic = block_cast_semantic(block)
+              case semantic
+              when :admonition
+                transform_admonition_block(block, first_positional_attr(block))
+              when :stem
+                transform_stem_block(block, first_positional_attr(block))
+              when :source
+                transform_source_block(block)
+              when :listing
+                transform_listing_from_open(block)
+              when :literal
+                transform_literal_from_open(block)
+              else
+                transform_typed_block(block, native_class)
+              end
             end
 
             def transform_example_block(block)
@@ -98,36 +108,32 @@ module Coradoc
             # Open blocks (`--`) are generic containers. AsciiDoc allows
             # casting them to a different block type via positional
             # attributes: verbatim types (`[source]`, `[listing]`,
-            # `[literal]`) and admonition labels (`[NOTE]`, `[TIP]`,
+            # `[literal]`), STEM types (`[stem]`, `[latexmath]`,
+            # `[asciimath]`), and admonition labels (`[NOTE]`, `[TIP]`,
             # `[WARNING]`, `[CAUTION]`, `[IMPORTANT]`). When such a cast
             # is present, the block behaves like the corresponding
             # delimited block. Anything else stays an OpenBlock.
             def transform_open_block(block)
-              semantic = open_block_semantic(block)
-              case semantic
-              when :source
-                transform_source_block(block)
-              when :listing
-                transform_listing_from_open(block)
-              when :literal
-                transform_literal_from_open(block)
-              when :admonition
-                transform_admonition_block(block, first_positional_attr(block))
-              else
-                transform_typed_block(block, Coradoc::CoreModel::OpenBlock)
-              end
+              transform_with_admonition_check(block, Coradoc::CoreModel::OpenBlock)
             end
 
             VERBATILE_CAST_STYLES = %w[source listing literal].freeze
 
-            def open_block_semantic(block)
+            # Resolve a delimited block's cast from its first positional
+            # attribute. Single source of truth for the cast ladder used
+            # by every block-form transformer (example/sidebar/quote/open).
+            # Returns one of: :admonition, :stem, :source, :listing,
+            # :literal, or nil (no cast — use the block's native class).
+            def block_cast_semantic(block)
               style = first_positional_attr(block)
               return nil unless style
 
-              case style.to_s.downcase
-              when *VERBATILE_CAST_STYLES then :"#{style.downcase}"
-              else :admonition if AdmonitionStyles.admonition?(style)
-              end
+              style_str = style.to_s.downcase
+              return :admonition if AdmonitionStyles.admonition?(style)
+              return :stem if STEM_STYLES.key?(style_str)
+              return style_str.to_sym if VERBATILE_CAST_STYLES.include?(style_str)
+
+              nil
             end
 
             # Returns the first positional attribute on the block's
@@ -148,10 +154,14 @@ module Coradoc
             # (example / sidebar / quote / pass / open). Builds an
             # AnnotationBlock with annotation_type set from the style and
             # the block's body lines joined into a single content string.
+            # Type is canonicalised via AdmonitionStyles so every code path
+            # (line admonition, block admonition, attribute-cast admonition)
+            # produces the same uppercase key.
             def transform_admonition_block(block, type)
+              canonical = AdmonitionStyles.canonicalize(type) || type.to_s
               content_lines = Array(block.lines).map { |line| ToCoreModel.extract_text_content(line) }.join("\n")
               Coradoc::CoreModel::AnnotationBlock.new(
-                annotation_type: type.to_s.downcase,
+                annotation_type: canonical,
                 content: content_lines,
                 title: ToCoreModel.extract_title_text(block.title)
               )

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/document_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/document_transformer.rb
@@ -13,6 +13,7 @@ module Coradoc
               children = CalloutMerger.call(children)
               children = prepend_frontmatter(children, doc.frontmatter)
               children = insert_title_heading_after_frontmatter(children, title_text)
+              children = resolve_attribute_references(children, attributes)
 
               Coradoc::CoreModel::DocumentElement.new(
                 id: doc.id,
@@ -56,6 +57,16 @@ module Coradoc
                 child.is_a?(Coradoc::CoreModel::FrontmatterBlock)
               end
               children.insert(frontmatter_count, title_heading)
+            end
+
+            # Resolve `{name}` attribute references in the body against the
+            # document's own declared attributes. Single source of truth:
+            # the resolver lives in core so other format gems can reuse it
+            # when they have equivalent reference macros.
+            def resolve_attribute_references(children, attributes)
+              return children if attributes.nil? || attributes.keys.empty?
+
+              Coradoc::CoreModel::AttributeReferenceResolver.call(children, attributes)
             end
 
             def transform_section(section, parent_id: nil)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/list_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/list_transformer.rb
@@ -67,18 +67,26 @@ module Coradoc
               )
               li.children = children
 
-              if item.nested.is_a?(Coradoc::AsciiDoc::Model::List::Core)
-                nested_core = transform_list(item.nested, list_marker_type(item.nested))
-                li.children << nested_core
-              elsif item.nested.is_a?(Array)
-                item.nested.each do |n|
-                  next unless n.is_a?(Coradoc::AsciiDoc::Model::List::Core)
-
-                  li.children << transform_list(n, list_marker_type(n))
-                end
-              end
-
+              nested_lists = extract_nested_lists(item)
+              li.nested_list = nested_lists.first if nested_lists.size == 1
               li
+            end
+
+            # Pull every nested List::Core off the AsciiDoc model item and
+            # transform each into a CoreModel::ListBlock. Returns [] when
+            # the item has no nested lists. Single source of truth for the
+            # nested-list shape so transform_list_item and any future caller
+            # share the same extraction logic.
+            def extract_nested_lists(item)
+              nested = item.nested
+              return [] if nested.nil?
+
+              candidates = nested.is_a?(Array) ? nested : [nested]
+              candidates.filter_map do |n|
+                next unless n.is_a?(Coradoc::AsciiDoc::Model::List::Core)
+
+                transform_list(n, list_marker_type(n))
+              end
             end
 
             def list_marker_type(list)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/other_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/other_transformer.rb
@@ -15,9 +15,10 @@ module Coradoc
             end
 
             def transform_admonition(admonition)
+              canonical = Coradoc::AsciiDoc::Transform::ElementTransformers::AdmonitionStyles.canonicalize(admonition.type) || admonition.type.to_s
               children = ToCoreModel.transform_inline_content(admonition.content)
               block = Coradoc::CoreModel::AnnotationBlock.new(
-                annotation_type: admonition.type,
+                annotation_type: canonical,
                 content: ToCoreModel.extract_text_content(admonition.content)
               )
               block.children = children

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -319,6 +319,8 @@ module Coradoc
               )
             when 'raw_inline'
               Coradoc::AsciiDoc::Model::Inline::Passthrough.new(content: inline.content)
+            when 'hard_line_break'
+              Coradoc::AsciiDoc::Model::Inline::HardLineBreak.new
             else
               Coradoc::AsciiDoc::Model::TextElement.new(content: inline.content)
             end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model_registrations.rb
@@ -172,9 +172,11 @@ module Coradoc
             Registry.register(
               Coradoc::AsciiDoc::Model::Inline::AttributeReference,
               lambda { |model|
+                name = model.name.to_s
                 Coradoc::CoreModel::InlineElement.new(
                   format_type: 'attribute_reference',
-                  content: "{#{model.name}}"
+                  target: name,
+                  content: "{#{name}}"
                 )
               }
             )
@@ -244,6 +246,16 @@ module Coradoc
             Registry.register(
               Coradoc::AsciiDoc::Model::Include,
               ->(model) { Inc.transform_include(model) }
+            )
+
+            # Inline hard line break — distinct from the structural
+            # Model::LineBreak (which represents paragraph-separator blank
+            # lines and is dropped at the CoreModel boundary). Hard breaks
+            # are semantic and round-trip as CoreModel::HardLineBreakElement
+            # so HTML/Markdown renderers can map them to <br>.
+            Registry.register(
+              Coradoc::AsciiDoc::Model::Inline::HardLineBreak,
+              ->(_model) { Coradoc::CoreModel::HardLineBreakElement.new(content: '') }
             )
 
             [

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
@@ -37,12 +37,15 @@ module Coradoc
               Model::Block::Example.new(title: '', lines: example)
             end
 
-            # Admonition
+            # Admonition. Canonicalise the type to uppercase so round-trips
+            # through HTML/Markdown/DocBook all see the same key used by
+            # icon and CSS-class lookups.
             rule(
               admonition_type: simple(:admonition_type),
               content: sequence(:content)
             ) do
-              Model::Admonition.new(content: content, type: admonition_type.to_s)
+              canonical = Coradoc::AsciiDoc::Transform::ElementTransformers::AdmonitionStyles.canonicalize(admonition_type.to_s)
+              Model::Admonition.new(content: content, type: canonical)
             end
 
             # Block image

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
@@ -36,14 +36,17 @@ module Coradoc
 
             # Inline image
             rule(inline_image: subtree(:inline_image)) do
+              attrs = AttributeListNormalizer.coerce(inline_image[:attribute_list])
               Model::Image::InlineImage.new(
-                title: inline_image[:text],
                 src: inline_image[:path],
-                attributes: inline_image[:attribute_list]
+                attributes: attrs
               )
             end
 
-            # Inline passthrough (`+++raw content+++`)
+            # Inline passthrough (`+++raw content+++` or `pass:[raw]`).
+            # Both forms carry an opaque payload that survives all
+            # substitutions verbatim; `form` records which syntax was
+            # used so the AsciiDoc serializer can round-trip faithfully.
             rule(inline_passthrough: subtree(:passthrough)) do
               Model::Inline::Passthrough.new(
                 content: passthrough[:raw].to_s,
@@ -54,6 +57,15 @@ module Coradoc
             # Attribute reference
             rule(attribute_reference: simple(:name)) do
               Model::Inline::AttributeReference.new(name:)
+            end
+
+            # Hard line break (` +\n` or `\\n`). Emitted as a dedicated
+            # AsciiDoc model (Inline::HardLineBreak) distinct from
+            # Model::LineBreak, which only represents paragraph-separator
+            # blank lines. Hard breaks carry semantic meaning: HTML/Markdown
+            # renderers map them to <br>.
+            rule(hard_line_break: simple(:_)) do
+              Model::Inline::HardLineBreak.new
             end
 
             # Term

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/table_cell_builder.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/table_cell_builder.rb
@@ -20,10 +20,22 @@ module Coradoc
           cell_opts = {}
           style = parse_format(format, cell_opts)
 
-          unescaped_content = content.to_s.gsub(/\\([|!,:;])/, '\1')
+          unescaped_content = cell_content_to_string(content).gsub(/\\([|!,:;])/, '\1')
           cell_opts[:content] = parse_inline_content(unescaped_content, style)
 
           Model::TableCell.new(**cell_opts)
+        end
+
+        # Coerce the parser-supplied cell content into a plain String.
+        # The cell parser emits `text:` as either a single Parslet::Slice
+        # or an Array of slices (from `.repeat(0)`). An empty Array must
+        # map to "" — Ruby's `[].to_s` returns "[]", which previously
+        # leaked into TableCell content as a phantom "[]" cell.
+        def cell_content_to_string(content)
+          return '' if content.nil?
+          return content.map(&:to_s).join if content.is_a?(Array)
+
+          content.to_s
         end
 
         # Coerce a raw parser cell value into a TableCell.

--- a/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
@@ -354,8 +354,9 @@ RSpec.describe 'Integration pipeline fixes' do
       expect(top_list.marker_type).to eq('unordered')
 
       first_item = top_list.items.first
-      nested = first_item.children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      nested = first_item.nested_list
       expect(nested).not_to be_nil
+      expect(nested).to be_a(Coradoc::CoreModel::ListBlock)
       expect(nested.marker_type).to eq('unordered')
     end
 
@@ -375,8 +376,9 @@ RSpec.describe 'Integration pipeline fixes' do
       expect(top_list.marker_type).to eq('ordered')
 
       first_item = top_list.items.first
-      nested = first_item.children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      nested = first_item.nested_list
       expect(nested).not_to be_nil
+      expect(nested).to be_a(Coradoc::CoreModel::ListBlock)
       expect(nested.marker_type).to eq('ordered')
     end
   end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/block_admonition_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/block_admonition_spec.rb
@@ -10,38 +10,38 @@ RSpec.describe 'Block-form admonitions', :asciidoc do
 
   %w[note tip warning caution important].each do |type|
     context "with [#{type.upcase}] on an example block (====)" do
-      it "produces AnnotationBlock with annotation_type '#{type}'" do
+      it "produces AnnotationBlock with annotation_type '#{type.upcase}'" do
         adoc = "[#{type.upcase}]\n====\nbody text\n====\n"
         block = first_child(adoc)
         expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
-        expect(block.annotation_type).to eq(type)
+        expect(block.annotation_type).to eq(type.upcase)
       end
     end
 
     context "with [#{type.upcase}] on a sidebar block (****)" do
-      it "produces AnnotationBlock with annotation_type '#{type}'" do
+      it "produces AnnotationBlock with annotation_type '#{type.upcase}'" do
         adoc = "[#{type.upcase}]\n****\nbody text\n****\n"
         block = first_child(adoc)
         expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
-        expect(block.annotation_type).to eq(type)
+        expect(block.annotation_type).to eq(type.upcase)
       end
     end
 
     context "with [#{type.upcase}] on a quote block (____)" do
-      it "produces AnnotationBlock with annotation_type '#{type}'" do
+      it "produces AnnotationBlock with annotation_type '#{type.upcase}'" do
         adoc = "[#{type.upcase}]\n____\nbody text\n____\n"
         block = first_child(adoc)
         expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
-        expect(block.annotation_type).to eq(type)
+        expect(block.annotation_type).to eq(type.upcase)
       end
     end
 
     context "with [#{type.upcase}] on an open block (--)" do
-      it "produces AnnotationBlock with annotation_type '#{type}'" do
+      it "produces AnnotationBlock with annotation_type '#{type.upcase}'" do
         adoc = "[#{type.upcase}]\n--\nbody text\n--\n"
         block = first_child(adoc)
         expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
-        expect(block.annotation_type).to eq(type)
+        expect(block.annotation_type).to eq(type.upcase)
       end
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe 'Block-form admonitions', :asciidoc do
       styles.register('danger')
       block = first_child("[DANGER]\n====\nwatch out\n====\n")
       expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
-      expect(block.annotation_type).to eq('danger')
+      expect(block.annotation_type).to eq('DANGER')
     end
   end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/list_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/list_transformer_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::ListTransforme
 
       outer_item = result.items[0]
       expect(outer_item.content).to eq('Outer')
-      expect(outer_item.children.last).to be_a(Coradoc::CoreModel::ListBlock)
-      expect(outer_item.children.last.marker_type).to eq('unordered')
-      expect(outer_item.children.last.items[0].content).to eq('Nested')
+      expect(outer_item.nested_list).to be_a(Coradoc::CoreModel::ListBlock)
+      expect(outer_item.nested_list.marker_type).to eq('unordered')
+      expect(outer_item.nested_list.items[0].content).to eq('Nested')
     end
 
     it 'transforms a list item with inline markup' do

--- a/coradoc-adoc/spec/integration/attribute_reference_resolution_spec.rb
+++ b/coradoc-adoc/spec/integration/attribute_reference_resolution_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Attribute reference resolution', type: :integration do
+  describe 'Coradoc.parse resolves {name} against document attributes' do
+    it 'substitutes a known attribute reference inside paragraph content' do
+      adoc = ":foo: Bar Value\n\nHello {foo} world.\n"
+      core = Coradoc.parse(adoc, format: :asciidoc)
+
+      para = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      expect(para.content).to eq('Hello  Bar Value world.')
+
+      inline_texts = para.children.map { |c| c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : nil }.compact
+      expect(inline_texts).to include('Bar Value')
+      expect(inline_texts).not_to include('{foo}')
+    end
+
+    it 'leaves unknown references untouched for round-trip' do
+      adoc = "Hello {undefined_attr} world.\n"
+      core = Coradoc.parse(adoc, format: :asciidoc)
+
+      para = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      expect(para.content).to include('{undefined_attr}')
+    end
+
+    it 'resolves references inside list items' do
+      adoc = ":name: Coradoc\n\n* Item referring to {name}\n"
+      core = Coradoc.parse(adoc, format: :asciidoc)
+
+      list = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      expect(list).not_to be_nil
+      item_text = list.items.first.children.map(&:to_s).join
+      expect(item_text).to include('Coradoc')
+      expect(item_text).not_to include('{name}')
+    end
+
+    it 'resolves references inside table cells' do
+      adoc = ":val: 42\n\n|===\n| Key | Value\n| answer | {val}\n|===\n"
+      core = Coradoc.parse(adoc, format: :asciidoc)
+
+      table = core.children.find { |c| c.is_a?(Coradoc::CoreModel::Table) }
+      expect(table).not_to be_nil
+      last = table.rows.last.cells.last
+      expect(last.content.to_s).to include('42')
+      expect(last.content.to_s).not_to include('{val}')
+    end
+
+    it 'resolves references in document with no attributes (no-op)' do
+      adoc = "Just plain text, no macros.\n"
+      core = Coradoc.parse(adoc, format: :asciidoc)
+
+      para = core.children.find { |c| c.is_a?(Coradoc::CoreModel::ParagraphBlock) }
+      expect(para.content).to eq('Just plain text, no macros.')
+    end
+  end
+
+  describe Coradoc::CoreModel::AttributeReferenceResolver do
+    it 'returns the original tree when attributes are empty' do
+      para = Coradoc::CoreModel::ParagraphBlock.new(content: 'Hello {foo}')
+      result = described_class.call([para], Coradoc::CoreModel::Metadata.new)
+      expect(result.first.content).to eq('Hello {foo}')
+    end
+
+    it 'does not mutate the input' do
+      inline = Coradoc::CoreModel::InlineElement.new(
+        format_type: 'attribute_reference',
+        target: 'foo',
+        content: '{foo}'
+      )
+      para = Coradoc::CoreModel::ParagraphBlock.new(
+        content: 'Hello {foo}',
+        children: [inline]
+      )
+      attrs = Coradoc::CoreModel::Metadata.new
+      attrs['foo'] = 'Bar'
+
+      described_class.call([para], attrs)
+
+      expect(inline).to be_a(Coradoc::CoreModel::InlineElement)
+      expect(inline.format_type).to eq('attribute_reference')
+      expect(para.content).to eq('Hello {foo}')
+    end
+  end
+end

--- a/coradoc/lib/coradoc/core_model.rb
+++ b/coradoc/lib/coradoc/core_model.rb
@@ -81,6 +81,7 @@ module Coradoc
     autoload :CommentLine, "#{__dir__}/core_model/comment_line"
     autoload :HorizontalRuleBlock, "#{__dir__}/core_model/horizontal_rule_block"
     autoload :IdGenerator, "#{__dir__}/core_model/id_generator"
+    autoload :AttributeReferenceResolver, "#{__dir__}/core_model/attribute_reference_resolver"
     autoload :Include, "#{__dir__}/core_model/include"
     autoload :IncludeOptions, "#{__dir__}/core_model/include_options"
     autoload :IncludeLevelOffset, "#{__dir__}/core_model/include_level_offset"

--- a/coradoc/lib/coradoc/core_model/attribute_reference_resolver.rb
+++ b/coradoc/lib/coradoc/core_model/attribute_reference_resolver.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    # Walks a CoreModel tree and resolves InlineElement nodes whose
+    # format_type is 'attribute_reference' against a Metadata store.
+    #
+    # AsciiDoc `{foo}` references round-trip as InlineElement with
+    # format_type: 'attribute_reference' and target: 'foo'. After the
+    # document is parsed and its attributes are known, this visitor
+    # rewrites those nodes in place to TextContent carrying the value.
+    # Unresolved references are left untouched so they survive
+    # serialisation back to the source format.
+    #
+    # The visitor never mutates its input tree; it returns a new tree
+    # sharing unchanged subtrees. InlineElement#with_content already
+    # produces non-mutating copies for inline content; the same pattern
+    # is used here at the block level via `replace_children`.
+    class AttributeReferenceResolver
+      attr_reader :attributes
+
+      def self.call(root, attributes)
+        new(attributes).visit(root)
+      end
+
+      def initialize(attributes)
+        @attributes = attributes || Metadata.new
+      end
+
+      def visit(node)
+        return node.map { |child| visit(child) } if node.is_a?(Array)
+
+        return node unless node.is_a?(Base)
+
+        visit_typed(node)
+      end
+
+      private
+
+      def visit_typed(node)
+        case node
+        when DocumentElement, SectionElement
+          rebuild_children(node)
+        when Table
+          rebuild_collection(node, :rows)
+        when TableRow
+          rebuild_collection(node, :cells)
+        when Block, ParagraphBlock, ListItem, TableCell, Term,
+             QuoteBlock, ExampleBlock, SidebarBlock, OpenBlock,
+             AnnotationBlock, ReviewerBlock, VerseBlock, LiteralBlock,
+             PassBlock, StemBlock, ListingBlock, SourceBlock,
+             CommentBlock, FrontmatterBlock
+          rebuild_block(node)
+        when DefinitionList, DefinitionItem
+          rebuild_children(node)
+        when InlineElement, RawInlineElement
+          resolve_inline(node)
+        else
+          node
+        end
+      end
+
+      def rebuild_children(node)
+        return node unless node.respond_to?(:children)
+
+        original = node.children
+        return node if original.nil?
+
+        updated = original.is_a?(Array) ? original.map { |c| visit(c) } : visit(original)
+        return node if updated == original
+
+        node.dup.tap { |copy| copy.children = updated }
+      end
+
+      # For nodes whose child collection lives on a non-`children`
+      # attribute (Table#rows, TableRow#cells). Walks the collection,
+      # rebuilds the parent only when at least one child changed.
+      def rebuild_collection(node, attr_name)
+        original = node.public_send(attr_name)
+        return node if original.nil?
+
+        updated = original.is_a?(Array) ?
+                    original.map { |c| visit(c) } :
+                    visit(original)
+        return node if updated == original
+
+        node.dup.tap { |copy| copy.public_send("#{attr_name}=", updated) }
+      end
+
+      def rebuild_block(node)
+        return node unless node.respond_to?(:children)
+
+        original_children = node.children
+        return node if original_children.nil?
+
+        updated_children = original_children.is_a?(Array) ?
+                             original_children.map { |c| visit(c) } :
+                             visit(original_children)
+
+        if inline_resolvable?(node)
+          original_content = node.content
+          updated_content = resolve_content(original_content)
+        else
+          updated_content = node.content
+        end
+
+        return node if updated_children == original_children && updated_content == node.content
+
+        node.dup.tap do |copy|
+          copy.children = updated_children
+          copy.content = updated_content if inline_resolvable?(node)
+        end
+      end
+
+      def inline_resolvable?(node)
+        node.respond_to?(:content) && node.content.is_a?(String)
+      end
+
+      # Resolve attribute references inside a flat content string.
+      # Only replaces `{name}` when +name+ exists in +attributes+;
+      # unknown references are preserved verbatim for round-trip.
+      def resolve_content(content)
+        return content unless content.is_a?(String)
+
+        content.gsub(/\{([a-zA-Z0-9_-]+)\}/) do |match|
+          name = Regexp.last_match(1)
+          attributes.key?(name) ? attributes[name].to_s : match
+        end
+      end
+
+      def resolve_inline(node)
+        return node unless node.is_a?(InlineElement)
+        return node unless node.resolve_format_type == 'attribute_reference'
+
+        target = node.target
+        return node if target.nil? || target.empty?
+        return node unless attributes.key?(target)
+
+        TextContent.new(text: attributes[target].to_s)
+      end
+    end
+  end
+end

--- a/coradoc/spec/integration/open_block_source_cast_spec.rb
+++ b/coradoc/spec/integration/open_block_source_cast_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'Open block cast to verbatim block', type: :integration do
       core = Coradoc.parse(source, format: :asciidoc)
       block = core.children.first
       expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
-      expect(block.annotation_type).to eq('note')
+      expect(block.annotation_type).to eq('NOTE')
     end
 
     it 'VitePress renders as a container admonition' do


### PR DESCRIPTION
## Summary

Six user-reported bugs in the AsciiDoc pipeline, plus a unification of the block-cast dispatch path:

- **Hard line break** (`foo +\nbar`): emit a dedicated `CoreModel::HardLineBreakElement` via a new `Inline::HardLineBreak` AsciiDoc model, instead of collapsing into `Model::LineBreak` (which is reserved for paragraph-separator blank lines). `from_core_model` now round-trips the element back to the AsciiDoc `Inline::HardLineBreak` model.
- **Inline image attributes** (`image:foo.png[Alt, Caption, width=640]`): route the bracket payload through the shared `attribute_list` parser instead of capturing it as a flat `:text` slice. `alt`, `caption`, and named `width`/`height` now flow through to `CoreModel::Image`. Matches the existing block-image path.
- **Admonition type casing**: `AdmonitionStyles` gains `canonicalize` and `all_styles`; the admonition parser builds its alternation from the registry (case-insensitive), and every transformer path (line admonition, block admonition, attribute-cast admonition) canonicalises to the same uppercase key. Round-trips no longer drift casing between HTML/Markdown/AsciiDoc.
- **Definition list body indentation**: strip the structural leading whitespace from `dlist_definition` so source indentation is not carried as literal text into CoreModel definitions.
- **`pass:[...]` macro**: add an `inline_passthrough_macro` parser rule so the macro payload survives verbatim. Previously `pass:[<<x>>]` outside backticks had its `<<x>>` re-interpreted as a cross reference.
- **Phantom `[]` table cell**: `TableCellBuilder.build` now coerces empty-Array cell content to `""` instead of letting Ruby's `[].to_s` leak `"[]"` into cell text. Affects cells written as `||` (no space between delimiters).

Block-cast dispatch:
- Unify the per-block-type admonition check through `block_cast_semantic` / `transform_with_admonition_check` so example/sidebar/quote/open blocks all recognise admonition, stem, source, listing, and literal casts in MECE order.

Also adds `Coradoc::CoreModel::AttributeReferenceResolver` so document-level `{name}` references are resolved against `Metadata` at parse time.

## Test plan

- [x] `bundle exec rake spec:coradoc` — 1148 examples, 0 failures
- [x] `bundle exec rake spec:coradoc_adoc` — 1023 examples, 0 failures, 5 pending
- [x] `bundle exec rake spec:coradoc_html` — 792 examples, 0 failures, 1 pending
- [x] `bundle exec rake spec:coradoc_markdown` — 616 examples, 0 failures
- [ ] `bundle exec rake spec:coradoc_docx` — 10 pre-existing failures unrelated to this PR (missing `office_theme.xml` in the third-party `uniword` gem; confirmed present on `main`)
