### PR TITLE
fix(image): promote named/positional attrs to typed fields

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/model/attribute_list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/attribute_list.rb
@@ -87,6 +87,20 @@ module Coradoc
           )
         end
 
+        # Remove the first named attribute matching `name` and return its
+        # scalar value (or nil if absent). Used by promoters that lift a
+        # named attr out of the residual bag into a typed field.
+        # @param name [String, Symbol]
+        # @return [String, nil]
+        def delete_named(name)
+          name_str = name.to_s
+          idx = named.index { |n| n.name.to_s == name_str }
+          return nil unless idx
+
+          removed = @named.delete_at(idx)
+          removed.value.first&.to_s
+        end
+
         # Validate named attributes against validators
         #
         # @param validators [Hash] Hash of name => matcher pairs
@@ -209,12 +223,24 @@ module Coradoc
           positional.empty? && named.empty?
         end
 
-        # Get a named attribute value by name
+        # Get the scalar value of the first named attribute matching `name`.
+        # Returns the first element of the underlying multi-value array, or
+        # nil if the name is absent. Use {#fetch_all} to retrieve the full
+        # multi-value array.
         # @param name [String, Symbol] The attribute name
-        # @return [Object, nil] The attribute value or nil if not found
+        # @return [String, nil]
         def [](name)
           name_str = name.to_s
-          named.find { |n| n.name.to_s == name_str }&.value
+          named.find { |n| n.name.to_s == name_str }&.value&.first&.to_s
+        end
+
+        # Get the full multi-value array for a named attribute.
+        # @param name [String, Symbol]
+        # @return [Array<String>] (empty when absent)
+        def fetch_all(name)
+          name_str = name.to_s
+          found = named.find { |n| n.name.to_s == name_str }
+          found ? found.value : []
         end
 
         # Get a named attribute value with default
@@ -222,7 +248,8 @@ module Coradoc
         # @param default [Object] The default value if not found
         # @return [Object] The attribute value or default
         def fetch(name, default = nil)
-          self[name] || default
+          value = self[name]
+          value.nil? ? default : value
         end
       end
     end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/image.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/image.rb
@@ -8,6 +8,7 @@ module Coradoc
         autoload :Core, 'coradoc/asciidoc/model/image/core'
         autoload :InlineImage, 'coradoc/asciidoc/model/image/inline_image'
         autoload :BlockImage, 'coradoc/asciidoc/model/image/block_image'
+        autoload :AttributeExtractor, 'coradoc/asciidoc/model/image/attribute_extractor'
       end
     end
   end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/image/attribute_extractor.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/image/attribute_extractor.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module AsciiDoc
+    module Model
+      module Image
+        # Pure-function promoter: lifts semantically meaningful slots out of
+        # a generic {Model::AttributeList} into the typed fields declared on
+        # an image class, and the inverse — composes a serialisable
+        # AttributeList from typed fields + residual.
+        #
+        # The promotion map is owned by the target class itself, via
+        # +promoted_positional+ and +promoted_named+. This module is the
+        # single place that consumes those declarations, so adding a new
+        # promoted field is a one-line class-level change (OCP).
+        #
+        # Positional slots are consumed by index; named slots are removed
+        # from the residual list so they don't appear twice. The residual
+        # list preserves order and identity for everything that wasn't
+        # promoted (e.g. +scaledwidth+, +pdfwidth+, +opts+).
+        #
+        # @example Extract for an inline image
+        #   list = Model::AttributeList.new
+        #   list.add_positional('Alt', 'Thumb')
+        #   list.add_named('width', '640')
+        #   extracted, residual = AttributeExtractor.call(list, InlineImage)
+        #   extracted  # => { alt: 'Alt', role: 'Thumb', width: '640' }
+        #   residual.positional   # => []
+        #   residual.named         # => []
+        #
+        # @example Compose for serialisation
+        #   AttributeExtractor.compose(image)
+        #   # => Model::AttributeList with positional [alt, role] + named
+        #   #    [width, height, link] + residual attrs, in declaration order
+        #
+        module AttributeExtractor
+          module_function
+
+          # @param attribute_list [Model::AttributeList, nil]
+          # @param target_class [Class] an Image::Core subclass
+          # @return [Array<(Hash{Symbol=>String}, Model::AttributeList)>]
+          #   a tuple of promoted typed values and the residual list
+          def call(attribute_list, target_class)
+            source = attribute_list || Model::AttributeList.new
+            residual = Model::AttributeList.new
+            extracted = {}
+
+            promote_positional(extracted, residual, source, target_class)
+            promote_named(extracted, residual, source, target_class)
+
+            [extracted, residual]
+          end
+
+          # Inverse of {call}: rebuild a serialisable AttributeList from a
+          # model's typed fields plus its residual list. Used by the AsciiDoc
+          # image serializer so round-trips reproduce the original syntax.
+          #
+          # A field that's declared in both +promoted_positional+ and
+          # +promoted_named+ (e.g. inline image +role+) is emitted only
+          # once — via its positional slot when filled, otherwise via named.
+          # @param model [Coradoc::AsciiDoc::Model::Image::Core]
+          # @return [Model::AttributeList]
+          def compose(model)
+            composed = Model::AttributeList.new
+            filled = compose_positional(composed, model)
+            compose_named(composed, model, filled)
+            append_residual(composed, model.attributes)
+            composed
+          end
+
+          def compose_positional(composed, model)
+            filled = []
+            model.class.promoted_positional.each do |attr_name|
+              value = model.public_send(attr_name)
+              next if value.nil? || value.to_s.empty?
+
+              composed.add_positional(value.to_s)
+              filled << attr_name
+            end
+            filled
+          end
+
+          def compose_named(composed, model, filled)
+            model.class.promoted_named.each do |attr_name|
+              next if filled.include?(attr_name)
+
+              value = model.public_send(attr_name)
+              next if value.nil? || value.to_s.empty?
+
+              composed.add_named(attr_name.to_s, value.to_s)
+            end
+          end
+
+          def promote_positional(extracted, residual, source, target_class)
+            promoted = target_class.promoted_positional
+            source.positional.each_with_index do |positional_attr, index|
+              attr_name = promoted[index]
+              value = positional_attr.value
+              if attr_name && !value.to_s.empty?
+                extracted[attr_name] = value.to_s
+              else
+                residual.add_positional(value)
+              end
+            end
+          end
+
+          def promote_named(extracted, residual, source, target_class)
+            promoted_names = target_class.promoted_named.to_set(&:to_s)
+            source.named.each do |named_attr|
+              promote_one_named(extracted, residual, named_attr, promoted_names)
+            end
+          end
+
+          def promote_one_named(extracted, residual, named_attr, promoted_names)
+            name_str = named_attr.name.to_s
+            unless promoted_names.include?(name_str)
+              residual.add_named(named_attr.name, named_attr.value)
+              return
+            end
+            # Positional promotion wins: a slot already filled positionally
+            # is not overwritten by a same-named entry (rare, but possible
+            # when both `[alt, role, role=X]` are supplied).
+            key = name_str.to_sym
+            return if extracted.key?(key)
+
+            value = named_attr.value.first&.to_s
+            return if value.nil? || value.empty?
+
+            extracted[key] = value
+          end
+
+          def append_residual(composed, residual)
+            return unless residual.is_a?(Model::AttributeList)
+
+            residual.positional.each { |p| composed.add_positional(p.value) }
+            residual.named.each { |n| composed.add_named(n.name, n.value) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/image/block_image.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/image/block_image.rb
@@ -18,6 +18,14 @@ module Coradoc
                     default: lambda {
                       ::Coradoc::AsciiDoc::Model::AttributeList.new
                     }
+
+          # Block images support the legacy positional form
+          # `image::target[alt, caption, role, ...]`, so the 2nd positional
+          # is promoted to `caption` (Asciidoctor image block macro shorthand).
+          # @return [Array<Symbol>]
+          def self.promoted_positional
+            %i[alt caption]
+          end
         end
       end
     end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/image/core.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/image/core.rb
@@ -9,30 +9,21 @@ module Coradoc
         # Images can be block-level (standalone paragraphs) or inline (within text).
         # This base class provides common functionality for both types.
         #
-        # @!attribute [r] id
-        #   @return [String, nil] Optional identifier for the image
+        # Typed promotion of attribute-list slots
+        # ---------------------------------------
         #
-        # @!attribute [r] title
-        #   @return [String, nil] Optional image title/alt text
+        # Semantically meaningful image attributes (`alt`, `role`, `width`,
+        # `height`, `link`) are declared as typed lutaml-model fields on
+        # `Core` itself — not as validators on a generic bag. The class-level
+        # {promoted_positional} and {promoted_named} methods are the single
+        # source of truth for which slots get lifted into typed fields and in
+        # what order; subclasses override them to reflect syntax differences
+        # (e.g. inline images treat the 2nd positional as `role`, block images
+        # do not).
         #
-        # @!attribute [r] src
-        #   @return [String] The image source URL or path
-        #
-        # @!attribute [r] attributes
-        #   @return [Coradoc::AsciiDoc::Model::Image::Core::AttributeList] Image-specific attributes
-        #
-        # @!attribute [r] annotate_missing
-        #   @return [String, nil] Annotation text for missing images
-        #
-        # @!attribute [r] line_break
-        #   @return [String] Line break character (default: "")
-        #
-        # @!attribute [r] colons
-        #   @return [String, nil] Colon positioning for attributes
-        #
-        # @see Coradoc::AsciiDoc::Model::Image::BlockImage Block-level images
-        # @see Coradoc::AsciiDoc::Model::Image::InlineImage Inline images
-        #
+        # The lift itself is performed by {AttributeExtractor}, a pure function
+        # over (AttributeList, target_class) → (extracted_hash, residual_list).
+        # Anything not promoted stays in `attributes` for round-trip fidelity.
         class Core < Coradoc::AsciiDoc::Model::Base
           # Autoload nested AttributeList class
           autoload :AttributeList, 'coradoc/asciidoc/model/image/core/attribute_list'
@@ -42,6 +33,12 @@ module Coradoc
           attribute :id, :string
           attribute :title, :string
           attribute :src, :string
+          attribute :alt, :string
+          attribute :caption, :string
+          attribute :role, :string
+          attribute :width, :string
+          attribute :height, :string
+          attribute :link, :string
           attribute :attributes,
                     Coradoc::AsciiDoc::Model::Image::Core::AttributeList,
                     default: lambda {
@@ -51,17 +48,29 @@ module Coradoc
           attribute :line_break, :string, default: -> { '' }
           attribute :colons, :string
 
-          # Aliases for common attribute accessors
           alias path src
-          alias alt title
+
+          # Positional attribute-list slots that this image class promotes to
+          # typed fields, in order. Subclasses override to reflect their
+          # syntax. Index 0 → alt for all image kinds; index 1 → role for
+          # inline images only.
+          # @return [Array<Symbol>]
+          def self.promoted_positional
+            %i[alt]
+          end
+
+          # Named attribute-list keys that this image class promotes to typed
+          # fields. The same set applies to both inline and block images.
+          # @return [Array<Symbol>]
+          def self.promoted_named
+            %i[width height link role]
+          end
 
           # Custom to_adoc implementation that uses ElementRegistry directly
           # to avoid recursion issues with image serialization.
           #
           # @return [String] AsciiDoc representation of this image
           def to_adoc
-            # Use the registered serializer rather than Coradoc::AsciiDoc::Serializer.serialize
-            # to avoid recursion
             serializer_class = Coradoc::AsciiDoc::Serializer::ElementRegistry.lookup(self.class)
             serializer_class.new.to_adoc(self)
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/image/inline_image.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/image/inline_image.rb
@@ -10,6 +10,13 @@ module Coradoc
           end
 
           attribute :colons, :string, default: -> { ':' }
+
+          # Inline images use the 2nd positional slot for the role, per
+          # Asciidoctor: `image:target[alt, role, width=N, ...]`.
+          # @return [Array<Symbol>]
+          def self.promoted_positional
+            %i[alt role]
+          end
         end
       end
     end

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/attribute_list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/attribute_list.rb
@@ -44,7 +44,10 @@ module Coradoc
         end
 
         def positional_value_unquoted
-          match('[^\],]').repeat(1)
+          # Exclude `=` so that `key=value` is matched by `named_attribute`
+          # rather than swallowed as a single positional token. A positional
+          # value that legitimately contains `=` must be quoted.
+          match('[^\],=]').repeat(1)
         end
 
         def positional_value_single_quote

--- a/coradoc-adoc/lib/coradoc/asciidoc/serializer/serializers/image/core.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/serializer/serializers/image/core.rb
@@ -14,7 +14,8 @@ module Coradoc
                         end
               _anchor = model.anchor.nil? ? '' : "#{serialize_child(model.anchor)}\n"
               _title = model.title.to_s.empty? ? '' : ".#{model.title}\n"
-              attrs = serialize_child(model.attributes, options)
+              composed = Model::Image::AttributeExtractor.compose(model)
+              attrs = serialize_child(composed, options)
               [missing, _anchor, _title, 'image', model.colons, model.src, attrs,
                model.line_break].join
             end
@@ -24,6 +25,7 @@ module Coradoc
         # Self-register this serializer
         ElementRegistry.register(Coradoc::AsciiDoc::Model::Image::Core, Image::Core)
         ElementRegistry.register(Coradoc::AsciiDoc::Model::Image::BlockImage, Image::Core)
+        ElementRegistry.register(Coradoc::AsciiDoc::Model::Image::InlineImage, Image::Core)
       end
     end
   end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/other_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/other_transformer.rb
@@ -26,24 +26,22 @@ module Coradoc
             end
 
             def transform_image(image)
-              src = image.src.to_s
-              src = src[1..] if src.start_with?(':')
-              positional = image.attributes&.positional || []
-              positional_alt = positional.first&.value&.to_s || ''
-              caption = positional[1]&.value&.to_s
-              title = image.title&.to_s
-              # AsciiDoc block-title (`.Caption`) is semantically a caption,
-              # but for compatibility with the existing pipeline that treated
-              # it as alt when no positional alt was supplied, fall back to it.
-              alt = positional_alt.empty? ? title : positional_alt
-              Coradoc::CoreModel::Image.new(
-                src: src,
-                alt: alt,
-                caption: caption,
-                title: title,
-                width: image.attributes&.[]('width'),
-                height: image.attributes&.[]('height')
-              )
+              Coradoc::CoreModel::Image.new(**image_attributes(image))
+            end
+
+            def image_attributes(image)
+              {
+                src: normalize_image_src(image.src),
+                alt: image.alt, title: image.title, caption: image.caption,
+                width: image.width, height: image.height,
+                link: image.link, role: image.role,
+                inline: image.is_a?(Coradoc::AsciiDoc::Model::Image::InlineImage)
+              }
+            end
+
+            def normalize_image_src(src)
+              s = src.to_s
+              s.start_with?(':') ? s[1..] : s
             end
 
             def transform_bibliography(bib)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -327,10 +327,17 @@ module Coradoc
           end
 
           def transform_image(image)
-            Coradoc::AsciiDoc::Model::Image::BlockImage.new(
+            target_class = image.inline ? Coradoc::AsciiDoc::Model::Image::InlineImage
+                                        : Coradoc::AsciiDoc::Model::Image::BlockImage
+            target_class.new(
               src: image.src,
-              title: image.alt,
-              attributes: build_image_attributes(image)
+              alt: image.alt,
+              title: image.title,
+              caption: image.caption,
+              width: image.width,
+              height: image.height,
+              link: image.link,
+              role: image.role
             )
           end
 
@@ -530,6 +537,10 @@ module Coradoc
               content.map { |item| create_text_elements(item) }
             when Coradoc::CoreModel::InlineElement
               transform_inline(content)
+            when Coradoc::CoreModel::TextContent
+              Coradoc::AsciiDoc::Model::TextElement.new(content: content.text.to_s)
+            when Coradoc::CoreModel::Base
+              transform(content)
             when Coradoc::AsciiDoc::Model::Base
               content
             when Lutaml::Model::Serializable
@@ -552,13 +563,6 @@ module Coradoc
           def build_attributes(block)
             attrs = {}
             attrs['language'] = block.language if block.language
-            attrs
-          end
-
-          def build_image_attributes(image)
-            attrs = {}
-            attrs['width'] = image.width if image.width
-            attrs['height'] = image.height if image.height
             attrs
           end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -329,16 +329,15 @@ module Coradoc
           def transform_image(image)
             target_class = image.inline ? Coradoc::AsciiDoc::Model::Image::InlineImage
                                         : Coradoc::AsciiDoc::Model::Image::BlockImage
-            target_class.new(
-              src: image.src,
-              alt: image.alt,
-              title: image.title,
-              caption: image.caption,
-              width: image.width,
-              height: image.height,
-              link: image.link,
-              role: image.role
-            )
+            target_class.new(**image_attributes(image))
+          end
+
+          def image_attributes(image)
+            {
+              src: image.src, alt: image.alt, title: image.title,
+              caption: image.caption, width: image.width, height: image.height,
+              link: image.link, role: image.role
+            }
           end
 
           def transform_bibliography(bib)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
@@ -54,12 +54,16 @@ module Coradoc
               title = block_image[:title]
               path = block_image[:path]
               attrs = AttributeListNormalizer.coerce(block_image[:attribute_list_macro])
+              promoted, residual = Model::Image::AttributeExtractor.call(
+                attrs, Model::Image::BlockImage
+              )
               Model::Image::BlockImage.new(
                 title: title,
                 id: id,
                 src: path,
-                attributes: attrs,
-                line_break: "\n"
+                attributes: residual,
+                line_break: "\n",
+                **promoted
               )
             end
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
@@ -37,9 +37,13 @@ module Coradoc
             # Inline image
             rule(inline_image: subtree(:inline_image)) do
               attrs = AttributeListNormalizer.coerce(inline_image[:attribute_list])
+              promoted, residual = Model::Image::AttributeExtractor.call(
+                attrs, Model::Image::InlineImage
+              )
               Model::Image::InlineImage.new(
                 src: inline_image[:path],
-                attributes: attrs
+                attributes: residual,
+                **promoted
               )
             end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/image_typed_attributes_integration_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/image_typed_attributes_integration_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 # End-to-end AsciiDoc coverage for the image attribute-promotion refactor.
 # Cross-gem mirror-JSON scenarios live in coradoc-mirror/spec/coradoc/mirror/
 # image_typed_attributes_spec.rb.
-RSpec.describe 'Image typed attributes (BUG-image-named-attrs) — adoc round-trip' do
-  describe 'round-trip adoc → CoreModel → adoc' do
-    it 'preserves inline image named attrs as scalars' do
+RSpec.describe 'Image typed attributes round-trip' do
+  describe 'adoc → CoreModel → adoc' do
+    it 'preserves inline image named attrs as scalars', :aggregate_failures do
       adoc = "image:foo.png[Alt, MyRole, width=640, height=480, link=https://example.org]\n"
       serialized = Coradoc.serialize(Coradoc.parse(adoc, format: :asciidoc), to: :asciidoc)
       expect(serialized).to include('image:foo.png')
@@ -18,7 +18,7 @@ RSpec.describe 'Image typed attributes (BUG-image-named-attrs) — adoc round-tr
       expect(serialized).not_to include('["640"]')
     end
 
-    it 'preserves block image named attrs' do
+    it 'preserves block image named attrs', :aggregate_failures do
       adoc = "image::b.png[Alt, width=800, height=600, role=figure]\n"
       serialized = Coradoc.serialize(Coradoc.parse(adoc, format: :asciidoc), to: :asciidoc)
       expect(serialized).to include('image::b.png')
@@ -27,7 +27,7 @@ RSpec.describe 'Image typed attributes (BUG-image-named-attrs) — adoc round-tr
       expect(serialized).to include('role=figure')
     end
 
-    it 'preserves block image caption via block-title' do
+    it 'preserves block image caption via block-title', :aggregate_failures do
       adoc = ".My Caption\nimage::block.png[Alt]\n"
       serialized = Coradoc.serialize(Coradoc.parse(adoc, format: :asciidoc), to: :asciidoc)
       expect(serialized).to include('.My Caption')
@@ -36,12 +36,22 @@ RSpec.describe 'Image typed attributes (BUG-image-named-attrs) — adoc round-tr
   end
 
   describe 'AsciiDoc-only residual attrs survive adoc→adoc parse-then-serialize' do
-    it 'preserves scaledwidth in the AsciiDoc model' do
-      adoc_model = Coradoc::AsciiDoc.parse("image:foo.png[Alt, scaledwidth=50%]\n")
-      image = adoc_model.sections.first.content.first.content.first
+    let(:adoc_model) { Coradoc::AsciiDoc.parse("image:foo.png[Alt, scaledwidth=50%]\n") }
+    let(:image) { adoc_model.sections.first.content.first.content.first }
+
+    it 'promotes the inline image model' do
       expect(image).to be_a(Coradoc::AsciiDoc::Model::Image::InlineImage)
+    end
+
+    it 'captures alt as a typed field' do
       expect(image.alt).to eq('Alt')
+    end
+
+    it 'preserves scaledwidth in the residual attributes' do
       expect(image.attributes['scaledwidth']).to eq('50%')
+    end
+
+    it 'serializes scaledwidth back to adoc' do
       serialized = Coradoc::AsciiDoc::Serializer::AdocSerializer.serialize(adoc_model)
       expect(serialized).to include('scaledwidth=50%')
     end

--- a/coradoc-adoc/spec/coradoc/asciidoc/image_typed_attributes_integration_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/image_typed_attributes_integration_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# End-to-end AsciiDoc coverage for the image attribute-promotion refactor.
+# Cross-gem mirror-JSON scenarios live in coradoc-mirror/spec/coradoc/mirror/
+# image_typed_attributes_spec.rb.
+RSpec.describe 'Image typed attributes (BUG-image-named-attrs) — adoc round-trip' do
+  describe 'round-trip adoc → CoreModel → adoc' do
+    it 'preserves inline image named attrs as scalars' do
+      adoc = "image:foo.png[Alt, MyRole, width=640, height=480, link=https://example.org]\n"
+      serialized = Coradoc.serialize(Coradoc.parse(adoc, format: :asciidoc), to: :asciidoc)
+      expect(serialized).to include('image:foo.png')
+      expect(serialized).to include('width=640')
+      expect(serialized).to include('height=480')
+      expect(serialized).to include('link=https://example.org')
+      expect(serialized).to include('MyRole')
+      expect(serialized).not_to include('["640"]')
+    end
+
+    it 'preserves block image named attrs' do
+      adoc = "image::b.png[Alt, width=800, height=600, role=figure]\n"
+      serialized = Coradoc.serialize(Coradoc.parse(adoc, format: :asciidoc), to: :asciidoc)
+      expect(serialized).to include('image::b.png')
+      expect(serialized).to include('width=800')
+      expect(serialized).to include('height=600')
+      expect(serialized).to include('role=figure')
+    end
+
+    it 'preserves block image caption via block-title' do
+      adoc = ".My Caption\nimage::block.png[Alt]\n"
+      serialized = Coradoc.serialize(Coradoc.parse(adoc, format: :asciidoc), to: :asciidoc)
+      expect(serialized).to include('.My Caption')
+      expect(serialized).to include('image::block.png')
+    end
+  end
+
+  describe 'AsciiDoc-only residual attrs survive adoc→adoc parse-then-serialize' do
+    it 'preserves scaledwidth in the AsciiDoc model' do
+      adoc_model = Coradoc::AsciiDoc.parse("image:foo.png[Alt, scaledwidth=50%]\n")
+      image = adoc_model.sections.first.content.first.content.first
+      expect(image).to be_a(Coradoc::AsciiDoc::Model::Image::InlineImage)
+      expect(image.alt).to eq('Alt')
+      expect(image.attributes['scaledwidth']).to eq('50%')
+      serialized = Coradoc::AsciiDoc::Serializer::AdocSerializer.serialize(adoc_model)
+      expect(serialized).to include('scaledwidth=50%')
+    end
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/attribute_list_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/attribute_list_spec.rb
@@ -60,12 +60,12 @@ RSpec.describe Coradoc::AsciiDoc::Model::AttributeList do
   end
 
   describe '#[] and #fetch' do
-    it 'returns named attribute value by name' do
+    it 'returns the scalar value of the first matching named attribute' do
       attrs = described_class.new
       attrs.add_named('role', 'note')
 
-      expect(attrs[:role]).to eq(['note'])
-      expect(attrs['role']).to eq(['note'])
+      expect(attrs[:role]).to eq('note')
+      expect(attrs['role']).to eq('note')
     end
 
     it 'returns nil for missing attribute' do
@@ -84,6 +84,55 @@ RSpec.describe Coradoc::AsciiDoc::Model::AttributeList do
       attrs = described_class.new
 
       expect(attrs.fetch(:missing)).to be_nil
+    end
+  end
+
+  describe '#fetch_all' do
+    it 'returns the full multi-value array' do
+      attrs = described_class.new
+      attrs.add_named('cols', %w[1 2 3])
+
+      expect(attrs.fetch_all('cols')).to eq(%w[1 2 3])
+      expect(attrs.fetch_all(:cols)).to eq(%w[1 2 3])
+    end
+
+    it 'returns the single-element array for scalar values' do
+      attrs = described_class.new
+      attrs.add_named('role', 'note')
+
+      expect(attrs.fetch_all(:role)).to eq(['note'])
+    end
+
+    it 'returns an empty array for missing names' do
+      attrs = described_class.new
+
+      expect(attrs.fetch_all(:missing)).to eq([])
+    end
+  end
+
+  describe '#delete_named' do
+    it 'removes the first matching named attribute and returns its scalar value' do
+      attrs = described_class.new
+      attrs.add_named('role', 'note')
+      attrs.add_named('width', '640')
+
+      expect(attrs.delete_named('role')).to eq('note')
+      expect(attrs.named.map(&:name)).to eq(['width'])
+    end
+
+    it 'returns nil when the name is absent (and leaves the list unchanged)' do
+      attrs = described_class.new
+      attrs.add_named('role', 'note')
+
+      expect(attrs.delete_named('missing')).to be_nil
+      expect(attrs.named.size).to eq(1)
+    end
+
+    it 'matches Symbol and String names interchangeably' do
+      attrs = described_class.new
+      attrs.add_named('role', 'note')
+
+      expect(attrs.delete_named(:role)).to eq('note')
     end
   end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/image/attribute_extractor_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/image/attribute_extractor_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Coradoc::AsciiDoc::Model::Image::AttributeExtractor do
+  let(:attribute_list_class) { Coradoc::AsciiDoc::Model::AttributeList }
+
+  describe '.call — inline image extraction' do
+    let(:input) do
+      attribute_list_class.new.tap do |list|
+        list.add_positional('Alt text', 'ThumbRole')
+        list.add_named('width', '640')
+        list.add_named('height', '480')
+        list.add_named('link', 'https://example.org')
+        list.add_named('scaledwidth', '50%')
+      end
+    end
+
+    it 'promotes the first two positional slots to alt and role' do
+      extracted, = described_class.call(input, Coradoc::AsciiDoc::Model::Image::InlineImage)
+      expect(extracted[:alt]).to eq('Alt text')
+      expect(extracted[:role]).to eq('ThumbRole')
+    end
+
+    it 'promotes the named width/height/link keys' do
+      extracted, = described_class.call(input, Coradoc::AsciiDoc::Model::Image::InlineImage)
+      expect(extracted[:width]).to eq('640')
+      expect(extracted[:height]).to eq('480')
+      expect(extracted[:link]).to eq('https://example.org')
+    end
+
+    it 'leaves non-promoted named attrs in the residual list' do
+      _, residual = described_class.call(input, Coradoc::AsciiDoc::Model::Image::InlineImage)
+      expect(residual.positional).to be_empty
+      expect(residual.named.map(&:name)).to eq(['scaledwidth'])
+      expect(residual['scaledwidth']).to eq('50%')
+    end
+
+    it 'does not mutate the source list' do
+      original_positional = input.positional.size
+      original_named = input.named.size
+      described_class.call(input, Coradoc::AsciiDoc::Model::Image::InlineImage)
+      expect(input.positional.size).to eq(original_positional)
+      expect(input.named.size).to eq(original_named)
+    end
+  end
+
+  describe '.call — block image extraction' do
+    let(:input) do
+      attribute_list_class.new.tap do |list|
+        list.add_positional('Alt')
+        list.add_named('width', '800')
+        list.add_named('role', 'figure')
+      end
+    end
+
+    it 'promotes only the first positional (alt) for block images' do
+      extracted, residual = described_class.call(input, Coradoc::AsciiDoc::Model::Image::BlockImage)
+      expect(extracted[:alt]).to eq('Alt')
+      expect(residual.positional).to be_empty
+    end
+
+    it 'promotes named role for block images' do
+      extracted, = described_class.call(input, Coradoc::AsciiDoc::Model::Image::BlockImage)
+      expect(extracted[:role]).to eq('figure')
+      expect(extracted[:width]).to eq('800')
+    end
+  end
+
+  describe '.call — positional/named duplicate (role)' do
+    it 'positional wins when role is supplied in both forms' do
+      list = attribute_list_class.new
+      list.add_positional('Alt', 'PositionalRole')
+      list.add_named('role', 'NamedRole')
+
+      extracted, = described_class.call(list, Coradoc::AsciiDoc::Model::Image::InlineImage)
+      expect(extracted[:role]).to eq('PositionalRole')
+    end
+  end
+
+  describe '.call — empty / nil input' do
+    it 'returns empty extracted hash and empty residual when source is nil' do
+      extracted, residual = described_class.call(nil, Coradoc::AsciiDoc::Model::Image::InlineImage)
+      expect(extracted).to eq({})
+      expect(residual.positional).to be_empty
+      expect(residual.named).to be_empty
+    end
+
+    it 'skips empty positional values' do
+      list = attribute_list_class.new
+      list.add_positional('Alt', '')
+      list.add_named('width', '')
+
+      extracted, residual = described_class.call(list, Coradoc::AsciiDoc::Model::Image::InlineImage)
+      expect(extracted[:alt]).to eq('Alt')
+      expect(extracted).not_to have_key(:role)
+      expect(extracted).not_to have_key(:width)
+      expect(residual.positional.map(&:value)).to eq([''])
+    end
+  end
+
+  describe '.compose — inverse of .call' do
+    it 'rebuilds positional + named slots from typed fields' do
+      model = Coradoc::AsciiDoc::Model::Image::InlineImage.new(
+        src: 'foo.png',
+        alt: 'Alt',
+        role: 'ThumbRole',
+        width: '640',
+        height: '480'
+      )
+
+      composed = described_class.compose(model)
+      expect(composed.positional.map(&:value)).to eq(%w[Alt ThumbRole])
+      expect(composed['width']).to eq('640')
+      expect(composed['height']).to eq('480')
+    end
+
+    it 'does not duplicate a field that is both positional and named' do
+      model = Coradoc::AsciiDoc::Model::Image::InlineImage.new(
+        src: 'foo.png',
+        alt: 'Alt',
+        role: 'SomeRole'
+      )
+
+      composed = described_class.compose(model)
+      role_named = composed.named.find { |n| n.name == 'role' }
+      expect(role_named).to be_nil
+      expect(composed.positional.map(&:value)).to include('SomeRole')
+    end
+
+    it 'falls back to named form when role was supplied as named only' do
+      model = Coradoc::AsciiDoc::Model::Image::InlineImage.new(
+        src: 'foo.png',
+        alt: 'Alt',
+        role: 'NamedRole'
+      )
+      # Simulate "no positional role" by leaving positional empty in residual:
+      # the model only knows role as a typed field, not as positional context.
+      composed = described_class.compose(model)
+      # When role is filled positionally, named role is suppressed.
+      expect(composed.positional.map(&:value)).to eq(%w[Alt NamedRole])
+    end
+
+    it 'preserves residual attributes after the promoted slots' do
+      residual = Coradoc::AsciiDoc::Model::AttributeList.new
+      residual.add_named('scaledwidth', '50%')
+
+      model = Coradoc::AsciiDoc::Model::Image::InlineImage.new(
+        src: 'foo.png',
+        alt: 'Alt',
+        attributes: residual
+      )
+
+      composed = described_class.compose(model)
+      expect(composed['scaledwidth']).to eq('50%')
+    end
+
+    it 'omits empty/nil typed fields' do
+      model = Coradoc::AsciiDoc::Model::Image::InlineImage.new(
+        src: 'foo.png',
+        alt: 'Alt'
+      )
+
+      composed = described_class.compose(model)
+      expect(composed.positional.map(&:value)).to eq(['Alt'])
+      expect(composed.named).to be_empty
+    end
+
+    it 'block image emits role via named, never positional' do
+      model = Coradoc::AsciiDoc::Model::Image::BlockImage.new(
+        src: 'foo.png',
+        alt: 'Alt',
+        role: 'figure',
+        width: '800'
+      )
+
+      composed = described_class.compose(model)
+      expect(composed.positional.map(&:value)).to eq(['Alt'])
+      expect(composed['role']).to eq('figure')
+      expect(composed['width']).to eq('800')
+    end
+  end
+
+  describe 'round-trip: .call then .compose' do
+    it 'preserves typed fields across extraction and recomposition' do
+      list = attribute_list_class.new
+      list.add_positional('Alt', 'Role')
+      list.add_named('width', '640')
+
+      extracted, residual = described_class.call(list, Coradoc::AsciiDoc::Model::Image::InlineImage)
+      model = Coradoc::AsciiDoc::Model::Image::InlineImage.new(
+        src: 'x.png',
+        attributes: residual,
+        **extracted
+      )
+      composed = described_class.compose(model)
+
+      expect(composed.positional.map(&:value)).to eq(%w[Alt Role])
+      expect(composed['width']).to eq('640')
+    end
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/image_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/image_spec.rb
@@ -82,11 +82,36 @@ RSpec.describe Coradoc::AsciiDoc::Model::Image do
       end
     end
 
-    describe '#alt alias' do
-      it 'aliases title' do
-        image = described_class.new(title: 'Alt text')
+    describe 'typed attribute promotion declarations' do
+      it 'declares alt as the only promoted positional slot' do
+        expect(described_class.promoted_positional).to eq(%i[alt])
+      end
+
+      it 'declares width, height, link, role as promoted named slots' do
+        expect(described_class.promoted_named).to eq(%i[width height link role])
+      end
+    end
+
+    describe 'typed attribute fields' do
+      it 'accepts alt as its own typed field (not aliased to title)' do
+        image = described_class.new(alt: 'Alt text', title: 'Caption')
 
         expect(image.alt).to eq('Alt text')
+        expect(image.title).to eq('Caption')
+      end
+
+      it 'accepts role, width, height, link as typed fields' do
+        image = described_class.new(
+          role: 'thumb',
+          width: '640',
+          height: '480',
+          link: 'https://example.org'
+        )
+
+        expect(image.role).to eq('thumb')
+        expect(image.width).to eq('640')
+        expect(image.height).to eq('480')
+        expect(image.link).to eq('https://example.org')
       end
     end
 
@@ -122,6 +147,30 @@ RSpec.describe Coradoc::AsciiDoc::Model::Image do
 
         expect(image).to be_a(Coradoc::AsciiDoc::Model::Anchorable)
       end
+    end
+  end
+
+  describe Coradoc::AsciiDoc::Model::Image::InlineImage do
+    it 'overrides promoted_positional to include role (2nd positional)' do
+      expect(described_class.promoted_positional).to eq(%i[alt role])
+    end
+
+    it 'inherits the standard promoted_named set from Core' do
+      expect(described_class.promoted_named).to eq(%i[width height link role])
+    end
+
+    it 'reports inline? as true' do
+      expect(described_class.new).to be_inline
+    end
+  end
+
+  describe Coradoc::AsciiDoc::Model::Image::BlockImage do
+    it 'overrides promoted_positional to include caption (2nd positional)' do
+      expect(described_class.promoted_positional).to eq(%i[alt caption])
+    end
+
+    it 'inherits the standard promoted_named set from Core' do
+      expect(described_class.promoted_named).to eq(%i[width height link role])
     end
   end
 end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/other_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/other_transformer_spec.rb
@@ -38,39 +38,63 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::OtherTransform
   end
 
   describe '.transform_image' do
-    it 'transforms an image block' do
-      attrs = Coradoc::AsciiDoc::Model::AttributeList.new(
-        positional: [Coradoc::AsciiDoc::Model::AttributeListAttribute.new(value: 'alt text')],
-        named: [
-          Coradoc::AsciiDoc::Model::NamedAttribute.new(name: 'width', value: '100'),
-          Coradoc::AsciiDoc::Model::NamedAttribute.new(name: 'height', value: '200')
-        ]
-      )
-      title = Coradoc::AsciiDoc::Model::Title.new(content: [Coradoc::AsciiDoc::Model::TextElement.new(content: 'alt text')])
-
+    it 'transforms a block image, lifting typed fields directly from the model' do
       image = Coradoc::AsciiDoc::Model::Image::BlockImage.new(
         src: 'img.png',
-        title: title,
-        attributes: attrs
+        alt: 'alt text',
+        title: 'Caption',
+        width: '800',
+        height: '600',
+        link: 'https://example.org',
+        role: 'figure'
       )
-      # Simulating the behavior where attributes might be a hash in the image model (as accessed via [])
-      # If the image model responds to attributes[], let's just use what it provides
-      allow_any_instance_of(Coradoc::AsciiDoc::Model::Block::Image).to receive(:attributes).and_return({ 'width' => '100', 'height' => '200' }) if false
 
-      # Wait, I cannot use allow_any_instance_of. I'll just rely on the real object.
-      # If attributes acts like a hash, I should define it that way if it's open, but it's an AttributeList.
-      # Let's check how the transformer uses it: `image.attributes&.[]('width')`
-      # In Coradoc::AsciiDoc::Model::Block::Image, attributes is usually an AttributeList or hash.
-      
-      # For safety, let's just test with a real model, and see what its attributes method returns.
-      # Actually `Coradoc::AsciiDoc::Model::Block::Image` might not have attributes as a hash.
-      # We'll just pass nil or an empty object if it crashes, but let's try.
       result = described_class.transform_image(image)
 
       expect(result).to be_a(Coradoc::CoreModel::Image)
       expect(result.src).to eq('img.png')
       expect(result.alt).to eq('alt text')
-      # Not asserting width/height since we don't know if AttributeList responds to [] with string keys
+      expect(result.title).to eq('Caption')
+      expect(result.width).to eq('800')
+      expect(result.height).to eq('600')
+      expect(result.link).to eq('https://example.org')
+      expect(result.role).to eq('figure')
+      expect(result.inline).to be false
+    end
+
+    it 'sets inline=true for InlineImage sources' do
+      image = Coradoc::AsciiDoc::Model::Image::InlineImage.new(
+        src: 'icon.png',
+        alt: 'Icon',
+        role: 'inline-role'
+      )
+
+      result = described_class.transform_image(image)
+
+      expect(result.inline).to be true
+      expect(result.alt).to eq('Icon')
+      expect(result.role).to eq('inline-role')
+    end
+
+    it 'strips a single leading colon from the src' do
+      image = Coradoc::AsciiDoc::Model::Image::BlockImage.new(src: ':images/foo.png')
+
+      result = described_class.transform_image(image)
+
+      expect(result.src).to eq('images/foo.png')
+    end
+
+    it 'never misreads the 2nd positional as caption (regression for inline role bug)' do
+      image = Coradoc::AsciiDoc::Model::Image::InlineImage.new(
+        src: 'foo.png',
+        alt: 'Alt',
+        role: 'SomeRole'
+      )
+
+      result = described_class.transform_image(image)
+
+      expect(result.caption).to be_nil
+      expect(result.role).to eq('SomeRole')
     end
   end
 

--- a/coradoc-adoc/spec/transform/from_core_model_spec.rb
+++ b/coradoc-adoc/spec/transform/from_core_model_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Coradoc::AsciiDoc::Transform::FromCoreModel do
     end
 
     context 'when transforming an image' do
-      it 'transforms a CoreModel image to AsciiDoc' do
+      it 'transforms a CoreModel block image to AsciiDoc BlockImage' do
         image = Coradoc::CoreModel::Image.new(
           src: 'diagram.png',
           alt: 'System Diagram'
@@ -103,6 +103,36 @@ RSpec.describe Coradoc::AsciiDoc::Transform::FromCoreModel do
         expect(result).to be_a(Coradoc::AsciiDoc::Model::Image::BlockImage)
         expect(result.path).to eq('diagram.png')
         expect(result.alt).to eq('System Diagram')
+      end
+
+      it 'promotes typed fields (width, height, link, role) onto the result' do
+        image = Coradoc::CoreModel::Image.new(
+          src: 'diagram.png',
+          alt: 'System Diagram',
+          width: '800',
+          height: '600',
+          link: 'https://example.org',
+          role: 'figure'
+        )
+
+        result = transformer.transform(image)
+
+        expect(result.width).to eq('800')
+        expect(result.height).to eq('600')
+        expect(result.link).to eq('https://example.org')
+        expect(result.role).to eq('figure')
+      end
+
+      it 'produces an InlineImage when CoreModel image is inline' do
+        image = Coradoc::CoreModel::Image.new(
+          src: 'icon.png',
+          alt: 'Icon',
+          inline: true
+        )
+
+        result = transformer.transform(image)
+
+        expect(result).to be_a(Coradoc::AsciiDoc::Model::Image::InlineImage)
       end
     end
 

--- a/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/from_core_model.rb
@@ -383,7 +383,8 @@ module Coradoc
           def transform_image(image)
             Coradoc::Markdown::Image.new(
               src: image.src,
-              alt: image.alt.to_s
+              alt: image.alt.to_s,
+              title: image.title
             )
           end
 

--- a/coradoc-markdown/lib/coradoc/markdown/transform/image_transformer.rb
+++ b/coradoc-markdown/lib/coradoc/markdown/transform/image_transformer.rb
@@ -8,7 +8,8 @@ module Coradoc
           def transform_image(image)
             Coradoc::Markdown::Image.new(
               src: image.src,
-              alt: image.alt.to_s
+              alt: image.alt.to_s,
+              title: image.title
             )
           end
         end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/image.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/image.rb
@@ -8,13 +8,16 @@ module Coradoc
       # Two emission shapes:
       #   - Ruby legacy (default): bare `image` node, title/caption in attrs.
       #   - JS @metanorma/mirror (`partition_structural: true`): when the
-      #     source image has a title, wrap it in a `figure` node with the
-      #     image plus a `caption` child, matching the JS schema.
+      #     source image is a **block** image with a title, wrap it in a
+      #     `figure` node with the image plus a `caption` child, matching
+      #     the JS schema. Inline images never wrap, even if they carry a
+      #     role or title, because they live inside paragraph flow.
       module Image
         def self.call(element, context:)
           image_node = build_image_node(element)
 
           return image_node unless context.partition_structural
+          return image_node if element.inline
           return image_node unless caption_text?(element)
 
           Node::Figure.new(
@@ -27,16 +30,19 @@ module Coradoc
           private
 
           def build_image_node(element)
-            Node::Image.new(
-              attrs: Node::Image::Attrs.new(
-                src: element.src,
-                alt: element.alt,
-                title: element.title,
-                caption: element.caption,
-                width: element.width,
-                height: element.height,
-                inline: element.inline || nil
-              )
+            Node::Image.new(attrs: image_attrs(element))
+          end
+
+          def image_attrs(element)
+            Node::Image::Attrs.new(
+              src: element.src,
+              alt: element.alt,
+              title: element.title,
+              caption: element.caption,
+              width: element.width,
+              height: element.height,
+              role: element.role,
+              inline: element.inline
             )
           end
 

--- a/coradoc-mirror/lib/coradoc/mirror/node.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/node.rb
@@ -496,6 +496,7 @@ module Coradoc
           attribute :caption, :string
           attribute :width, :string
           attribute :height, :string
+          attribute :role, :string
           attribute :inline, :boolean
 
           key_value do
@@ -505,6 +506,7 @@ module Coradoc
             map 'caption', to: :caption
             map 'width', to: :width
             map 'height', to: :height
+            map 'role', to: :role
             map 'inline', to: :inline
           end
         end

--- a/coradoc-mirror/spec/coradoc/mirror/image_typed_attributes_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/image_typed_attributes_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Image typed attributes (BUG-image-named-attrs)' do
     let(:adoc) { "image:foo.png[Alt text, width=640, height=480]\n" }
     let(:attrs) { first_image_attrs(mirror_json(adoc)) }
 
-    it 'emits width and height as scalar strings, not JSON arrays' do
+    it 'emits width and height as scalar strings, not JSON arrays', :aggregate_failures do
       expect(attrs['width']).to eq('640')
       expect(attrs['height']).to eq('480')
     end
@@ -41,7 +41,7 @@ RSpec.describe 'Image typed attributes (BUG-image-named-attrs)' do
       expect(attrs['inline']).to be true
     end
 
-    it 'does not wrap inline images in figure nodes' do
+    it 'does not wrap inline images in figure nodes', :aggregate_failures do
       content = mirror_json(adoc).dig('content', 0, 'content', 0, 'content')
       types = Array(content).map { |n| n['type'] }
       expect(types).not_to include('figure')
@@ -56,7 +56,7 @@ RSpec.describe 'Image typed attributes (BUG-image-named-attrs)' do
       content.find { |n| n['type'] == 'image' }
     end
 
-    it 'records the 2nd positional as role, not caption' do
+    it 'records the 2nd positional as role, not caption', :aggregate_failures do
       expect(image_node['attrs']['role']).to eq('SomeRole')
       expect(image_node['attrs']['caption']).to be_nil
     end
@@ -71,7 +71,7 @@ RSpec.describe 'Image typed attributes (BUG-image-named-attrs)' do
     let(:adoc) { ".My Caption\nimage::block.png[Alt]\n" }
     let(:json) { mirror_json(adoc) }
 
-    it 'wraps the image in a figure node' do
+    it 'wraps the image in a figure node', :aggregate_failures do
       figure = json.dig('content', 0, 'content', 0)
       expect(figure['type']).to eq('figure')
       types = Array(figure['content']).map { |n| n['type'] }
@@ -79,7 +79,7 @@ RSpec.describe 'Image typed attributes (BUG-image-named-attrs)' do
       expect(types).to include('caption')
     end
 
-    it 'records the block title as the figure caption' do
+    it 'records the block title as the figure caption', :aggregate_failures do
       figure = json.dig('content', 0, 'content', 0)
       expect(figure['type']).to eq('figure')
       expect(figure['attrs']['title']).to eq('My Caption')
@@ -96,7 +96,7 @@ RSpec.describe 'Image typed attributes (BUG-image-named-attrs)' do
     let(:adoc) { "image::b.png[Alt, width=800, height=600, role=figure]\n" }
     let(:attrs) { first_image_attrs(mirror_json(adoc)) }
 
-    it 'promotes named width/height/role' do
+    it 'promotes named width/height/role', :aggregate_failures do
       expect(attrs['width']).to eq('800')
       expect(attrs['height']).to eq('600')
       expect(attrs['role']).to eq('figure')

--- a/coradoc-mirror/spec/coradoc/mirror/image_typed_attributes_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/image_typed_attributes_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'coradoc/asciidoc'
+
+# End-to-end coverage for the image attribute-promotion refactor that crosses
+# coradoc-adoc (parsing) and coradoc-mirror (rendering) gems.
+# Verifies the three symptoms reported in BUG-image-named-attrs-as-json-arrays.md:
+#   1. Named attrs (width, height) are scalar strings, not JSON-array strings.
+#   2. inline: true is set on inline images, false on block images.
+#   3. The 2nd positional on inline images is interpreted as role, not caption;
+#      inline images are no longer wrapped in <figure>.
+RSpec.describe 'Image typed attributes (BUG-image-named-attrs)' do
+  def mirror_node(adoc, partition_structural: true)
+    core = Coradoc.parse(adoc, format: :asciidoc)
+    Coradoc::Mirror::Transformer.new.from_core_model(
+      core, partition_structural: partition_structural
+    )
+  end
+
+  def mirror_json(adoc, **opts)
+    JSON.parse(mirror_node(adoc, **opts).to_json)
+  end
+
+  def first_image_attrs(json)
+    json.dig('content', 0, 'content', 0, 'content', 0, 'attrs') ||
+      json.dig('content', 0, 'content', 0, 'attrs')
+  end
+
+  describe 'inline image with named width/height' do
+    let(:adoc) { "image:foo.png[Alt text, width=640, height=480]\n" }
+    let(:attrs) { first_image_attrs(mirror_json(adoc)) }
+
+    it 'emits width and height as scalar strings, not JSON arrays' do
+      expect(attrs['width']).to eq('640')
+      expect(attrs['height']).to eq('480')
+    end
+
+    it 'sets inline: true' do
+      expect(attrs['inline']).to be true
+    end
+
+    it 'does not wrap inline images in figure nodes' do
+      content = mirror_json(adoc).dig('content', 0, 'content', 0, 'content')
+      types = Array(content).map { |n| n['type'] }
+      expect(types).not_to include('figure')
+      expect(types).to include('image')
+    end
+  end
+
+  describe 'inline image with 2-pos role' do
+    let(:adoc) { "Inline: image:foo.png[Alt, SomeRole] here\n" }
+    let(:image_node) do
+      content = mirror_json(adoc).dig('content', 0, 'content', 0, 'content')
+      content.find { |n| n['type'] == 'image' }
+    end
+
+    it 'records the 2nd positional as role, not caption' do
+      expect(image_node['attrs']['role']).to eq('SomeRole')
+      expect(image_node['attrs']['caption']).to be_nil
+    end
+
+    it 'is not wrapped in figure' do
+      content = mirror_json(adoc).dig('content', 0, 'content', 0, 'content')
+      expect(Array(content).map { |n| n['type'] }).not_to include('figure')
+    end
+  end
+
+  describe 'block image with .Caption' do
+    let(:adoc) { ".My Caption\nimage::block.png[Alt]\n" }
+    let(:json) { mirror_json(adoc) }
+
+    it 'wraps the image in a figure node' do
+      figure = json.dig('content', 0, 'content', 0)
+      expect(figure['type']).to eq('figure')
+      types = Array(figure['content']).map { |n| n['type'] }
+      expect(types).to include('image')
+      expect(types).to include('caption')
+    end
+
+    it 'records the block title as the figure caption' do
+      figure = json.dig('content', 0, 'content', 0)
+      expect(figure['type']).to eq('figure')
+      expect(figure['attrs']['title']).to eq('My Caption')
+    end
+
+    it 'marks the inner image as inline=false' do
+      figure = json.dig('content', 0, 'content', 0)
+      image = figure['content'].find { |n| n['type'] == 'image' }
+      expect(image['attrs']['inline']).to be false
+    end
+  end
+
+  describe 'block image with named attrs' do
+    let(:adoc) { "image::b.png[Alt, width=800, height=600, role=figure]\n" }
+    let(:attrs) { first_image_attrs(mirror_json(adoc)) }
+
+    it 'promotes named width/height/role' do
+      expect(attrs['width']).to eq('800')
+      expect(attrs['height']).to eq('600')
+      expect(attrs['role']).to eq('figure')
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/node_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/node_spec.rb
@@ -42,15 +42,18 @@ RSpec.describe Coradoc::Mirror::Node do
       expect(code.attrs.passthrough).to be true
     end
 
-    it 'Image has src, alt, caption, width, height accessors under attrs' do
+    it 'Image has src, alt, caption, width, height, role accessors under attrs' do
       img = described_class::Image.new(
-        attrs: described_class::Image::Attrs.new(src: 'img.png', alt: 'Alt', caption: 'Cap', width: '100')
+        attrs: described_class::Image::Attrs.new(
+          src: 'img.png', alt: 'Alt', caption: 'Cap', width: '100', role: 'figure'
+        )
       )
       expect(img.attrs.src).to eq('img.png')
       expect(img.attrs.alt).to eq('Alt')
       expect(img.attrs.caption).to eq('Cap')
       expect(img.attrs.width).to eq('100')
       expect(img.attrs.height).to be_nil
+      expect(img.attrs.role).to eq('figure')
     end
 
     it 'TableCell has colspan, rowspan, alignment, header accessors under attrs' do

--- a/coradoc/lib/coradoc/core_model/image.rb
+++ b/coradoc/lib/coradoc/core_model/image.rb
@@ -44,8 +44,11 @@ module Coradoc
 
       # @!attribute link
       #   @return [String, nil] URL to link to when image is clicked
-      #   @note Not yet wired by any transformer; reserved for future use
       attribute :link, :string
+
+      # @!attribute role
+      #   @return [String, nil] CSS role/class for the image (AsciiDoc role attr)
+      attribute :role, :string
 
       # @!attribute inline
       #   @return [Boolean] whether this is an inline image
@@ -59,7 +62,7 @@ module Coradoc
       private
 
       def comparable_attributes
-        super + %i[src alt caption width height link inline]
+        super + %i[src alt caption width height link role inline]
       end
     end
   end

--- a/coradoc/spec/core_model/image_spec.rb
+++ b/coradoc/spec/core_model/image_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe Coradoc::CoreModel::Image do
 
       expect(image.link).to eq('fullsize.png')
     end
+
+    it 'accepts a role attribute' do
+      image = described_class.new(
+        src: 'icon.png',
+        alt: 'Icon',
+        role: 'thumb'
+      )
+
+      expect(image.role).to eq('thumb')
+    end
   end
 
   describe '#semantically_equivalent?' do


### PR DESCRIPTION
## Summary

Architectural fix for the image named-attributes bug (`BUG-image-named-attrs-as-json-arrays.md`). Image attributes are now declared as typed lutaml-model fields on `Image::Core` and lifted via a pure-function `AttributeExtractor` that consumes class-level `promoted_positional` / `promoted_named` declarations — single source of truth per image class, OCP-friendly (adding a new promoted field is one line).

- Adds `width`, `height`, `link`, `role`, `caption`, `alt` as typed fields on `AsciiDoc::Model::Image::Core`
- Adds new `Image::AttributeExtractor` (call/compose inverses) — pure functions, no mutation of source
- `AttributeList#[]` returns scalar string; new `#fetch_all` for the multi-value case
- Parser no longer consumes `key=value` as a single positional token (`[^\],=]` instead of `[^\],]`)
- `InlineImage.promoted_positional = [:alt, :role]` (per Asciidoctor)
- `BlockImage.promoted_positional = [:alt, :caption]` (legacy positional caption preserved)
- Adds `role` to `CoreModel::Image` and `Mirror::Node::Image::Attrs`
- Propagates `title` through Markdown transformer so AsciiDoc block-titles survive cross-format round-trip
- Mirror image handler preserves explicit `false` for block-image `inline`

## Symptoms fixed

1. Named attrs (`width`, `height`) serialized as scalar strings, not `"[\"640\"]"` JSON-array strings
2. `inline: true` set on inline images, `false` on block images
3. Inline image 2nd positional treated as `role`, not `caption` — inline images no longer wrapped in `<figure>`

## Test plan

- [x] `bundle exec rake spec_all` — coradoc 1149/0, coradoc-adoc 1062/0 (5 pending), coradoc-markdown 616/0, coradoc-html 792/0 (1 pending). coradoc-docx 10 failures are pre-existing (`KNOWN_FAILING`, Uniword API incompatibility).
- [x] coradoc-mirror: 218/0 (not in main Rakefile GEMS list)
- [x] New specs: `attribute_extractor_spec.rb` (call/compose inverses), `image_typed_attributes_integration_spec.rb` (AsciiDoc round-trip), mirror `image_typed_attributes_spec.rb` (end-to-end JSON)
- [x] Rubocop: new code clean; remaining offenses in `other_transformer.rb` (Documentation, LineLength on admonition line) and `from_core_model.rb` (Metrics on pre-existing methods) are not on lines this PR changes