### PR TITLE
fix(adoc,mirror): source-line propagation + named block styles + hard break

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/model/base.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/base.rb
@@ -35,6 +35,13 @@ module Coradoc
 
         attribute :id, :string
 
+        # 1-indexed source line where this element begins, when known.
+        # Populated by the Parslet transformer from the matched Slice's
+        # line_and_column. nil for programmatically constructed models.
+        # Single source of truth for source-position propagation through
+        # AsciiDoc::Model → CoreModel (Issue 1, STATUS-2026-06-28).
+        attribute :source_line, :integer
+
         # Element classification for spacing and serialization decisions.
         # Subclasses override these to declare their level.
         def block_level?

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/admonition_styles.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/admonition_styles.rb
@@ -13,7 +13,12 @@ module Coradoc
         # block-form transformer that needs to decide between an admonition
         # and the block's native type.
         module AdmonitionStyles
-          BUILTIN = %w[note tip warning caution important editor todo].freeze
+          # Generic `[admonition]` (capitalized as ADMONITION by
+          # +canonicalize+) is the spec-defined generic admonition style.
+          # It is rarely used directly but exists in the AsciiDoc spec;
+          # treating it as a real admonition prevents it from collapsing
+          # to an ExampleBlock when applied to a delimited block.
+          BUILTIN = %w[note tip warning caution important editor todo admonition].freeze
 
           @custom = []
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/block_transformer.rb
@@ -8,10 +8,13 @@ module Coradoc
           class << self
             def transform_paragraph(para)
               children = ToCoreModel.transform_inline_content(para.content)
+              source_lines = ToCoreModel.extract_source_lines(para.content)
 
               Coradoc::CoreModel::ParagraphBlock.new(
                 id: para.id,
                 content: ToCoreModel.extract_text_content(para.content),
+                lines: source_lines,
+                source_line: para.source_line,
                 children: children
               )
             end
@@ -22,19 +25,15 @@ module Coradoc
             # lines are preserved. Treating these as paragraphs would collapse
             # whitespace and join consecutive lines into a single flowing text.
             def transform_verbatim_block(block, klass, language_override: nil)
-              non_break_lines = Array(block.lines).reject do |line|
-                line.is_a?(Coradoc::AsciiDoc::Model::LineBreak) ||
-                  line.is_a?(Coradoc::AsciiDoc::Model::Break::PageBreak)
-              end
-              content_lines = non_break_lines.map do |line|
-                ToCoreModel.extract_text_content(line)
-              end.join("\n")
+              source_lines = ToCoreModel.extract_source_lines(block.lines)
 
               klass.new(
                 id: block.id,
                 title: ToCoreModel.extract_title_text(block.title),
-                content: content_lines,
-                language: language_override || ToCoreModel.extract_block_language(block)
+                content: source_lines.join("\n"),
+                lines: source_lines,
+                language: language_override || ToCoreModel.extract_block_language(block),
+                source_line: block.source_line
               )
             end
 
@@ -74,7 +73,7 @@ module Coradoc
             # AsciiDoc spec, every delimited block accepts both admonition
             # labels and verbatim/stem casts in its attribute line. The cast
             # is resolved by +block_cast_semantic+ in MECE order:
-            # admonition > stem > verbatim > fallback.
+            # admonition > stem > verbatim > typed-cast > fallback.
             def transform_with_admonition_check(block, native_class)
               semantic = block_cast_semantic(block)
               case semantic
@@ -88,6 +87,9 @@ module Coradoc
                 transform_listing_from_open(block)
               when :literal
                 transform_literal_from_open(block)
+              when :typed_cast
+                style = first_positional_attr(block).to_s.downcase
+                transform_typed_block(block, TYPED_BLOCK_CAST_STYLES.fetch(style))
               else
                 transform_typed_block(block, native_class)
               end
@@ -119,11 +121,25 @@ module Coradoc
 
             VERBATILE_CAST_STYLES = %w[source listing literal].freeze
 
+            # Positional style → typed CoreModel class for blocks whose
+            # attribute line casts an open block into a richer semantic
+            # type (e.g. `[sidebar]\n--\n...\n--`). Single source of
+            # truth: adding a new style cast is one line here, no edits
+            # to dispatch (OCP).
+            TYPED_BLOCK_CAST_STYLES = {
+              'sidebar' => Coradoc::CoreModel::SidebarBlock,
+              'example' => Coradoc::CoreModel::ExampleBlock,
+              'quote' => Coradoc::CoreModel::QuoteBlock,
+              'abstract' => Coradoc::CoreModel::AbstractBlock,
+              'partintro' => Coradoc::CoreModel::PartintroBlock
+            }.freeze
+
             # Resolve a delimited block's cast from its first positional
             # attribute. Single source of truth for the cast ladder used
             # by every block-form transformer (example/sidebar/quote/open).
             # Returns one of: :admonition, :stem, :source, :listing,
-            # :literal, or nil (no cast — use the block's native class).
+            # :literal, :typed_cast, or nil (no cast — use the block's
+            # native class).
             def block_cast_semantic(block)
               style = first_positional_attr(block)
               return nil unless style
@@ -131,6 +147,7 @@ module Coradoc
               style_str = style.to_s.downcase
               return :admonition if AdmonitionStyles.admonition?(style)
               return :stem if STEM_STYLES.key?(style_str)
+              return :typed_cast if TYPED_BLOCK_CAST_STYLES.key?(style_str)
               return style_str.to_sym if VERBATILE_CAST_STYLES.include?(style_str)
 
               nil
@@ -163,7 +180,8 @@ module Coradoc
               Coradoc::CoreModel::AnnotationBlock.new(
                 annotation_type: canonical,
                 content: content_lines,
-                title: ToCoreModel.extract_title_text(block.title)
+                title: ToCoreModel.extract_title_text(block.title),
+                source_line: block.source_line
               )
             end
 
@@ -176,7 +194,7 @@ module Coradoc
             end
 
             def transform_block(block, semantic_type_or_delimiter)
-              content_lines = ToCoreModel.extract_block_lines(block)
+              source_lines = ToCoreModel.extract_source_lines(block.lines)
               semantic_type = if semantic_type_or_delimiter.is_a?(Symbol)
                                 semantic_type_or_delimiter
                               else
@@ -188,8 +206,10 @@ module Coradoc
                 delimiter_type: semantic_type_or_delimiter.is_a?(String) ? semantic_type_or_delimiter : nil,
                 id: block.id,
                 title: ToCoreModel.extract_title_text(block.title),
-                content: content_lines,
-                language: ToCoreModel.extract_block_language(block)
+                content: source_lines.join("\n"),
+                lines: source_lines,
+                language: ToCoreModel.extract_block_language(block),
+                source_line: block.source_line
               )
             end
 
@@ -216,6 +236,7 @@ module Coradoc
                   title: ToCoreModel.extract_title_text(block.title),
                   children: children,
                   language: ToCoreModel.extract_block_language(block),
+                  source_line: block.source_line,
                   **extra_attrs
                 )
               else
@@ -230,7 +251,8 @@ module Coradoc
                   inline = [Coradoc::CoreModel::TextContent.new(text: '')] if inline.empty?
                   Coradoc::CoreModel::ParagraphBlock.new(
                     content: ToCoreModel.extract_text_content(group),
-                    children: Array(inline)
+                    children: Array(inline),
+                    source_line: ToCoreModel.extract_source_line(group)
                   )
                 end
 
@@ -240,6 +262,7 @@ module Coradoc
                   content: content_lines,
                   children: children,
                   language: ToCoreModel.extract_block_language(block),
+                  source_line: block.source_line,
                   **extra_attrs
                 )
               end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/document_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/document_transformer.rb
@@ -12,7 +12,6 @@ module Coradoc
               children = ToCoreModel.transform(doc.sections || doc.contents || [])
               children = CalloutMerger.call(children)
               children = prepend_frontmatter(children, doc.frontmatter)
-              children = insert_title_heading_after_frontmatter(children, title_text)
               children = resolve_attribute_references(children, attributes)
 
               Coradoc::CoreModel::DocumentElement.new(
@@ -32,31 +31,6 @@ module Coradoc
 
               block = Coradoc::CoreModel::FrontmatterBlock::Codec.from_yaml(frontmatter_text)
               [block, *children]
-            end
-
-            # Per the AsciiDoc spec, the document title (`= Title`) is the
-            # document's level-0 heading. Asciidoctor renders it as an
-            # <h1> at the top of the body by default. Emit a HeaderElement
-            # at level 0 so consumers that walk the body's children see the
-            # title (the standard ProseMirror/HTML rendering pattern)
-            # instead of having to read Document.title separately.
-            #
-            # The title attribute on DocumentElement is preserved for
-            # consumers that read it directly. The title heading is placed
-            # after any FrontmatterBlock (frontmatter is metadata that
-            # precedes the body).
-            def insert_title_heading_after_frontmatter(children, title_text)
-              return children if title_text.nil? || title_text.strip.empty?
-
-              title_heading = Coradoc::CoreModel::HeaderElement.new(
-                level: 0,
-                title: title_text,
-                content: title_text
-              )
-              frontmatter_count = children.count do |child|
-                child.is_a?(Coradoc::CoreModel::FrontmatterBlock)
-              end
-              children.insert(frontmatter_count, title_heading)
             end
 
             # Resolve `{name}` attribute references in the body against the
@@ -86,7 +60,8 @@ module Coradoc
                 level: section.level,
                 title: title_text,
                 children: content_children + nested_sections,
-                attributes: section_metadata_from(section)
+                attributes: section_metadata_from(section),
+                source_line: section.source_line
               )
             end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/include_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/include_transformer.rb
@@ -21,7 +21,8 @@ module Coradoc
                 target: model.path.to_s,
                 options: options,
                 raw_options: raw,
-                line_break: model.line_break.to_s
+                line_break: model.line_break.to_s,
+                source_line: model.source_line
               )
             end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/inline_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/inline_transformer.rb
@@ -9,14 +9,16 @@ module Coradoc
             def transform_inline(inline, format_type)
               klass = Coradoc::CoreModel::InlineElement.format_type_class(format_type)
               klass.new(
-                content: ToCoreModel.extract_text_content(inline.content)
+                content: ToCoreModel.extract_text_content(inline.content),
+                source_line: inline.source_line
               )
             end
 
             def transform_inline_text(inline, format_type)
               klass = Coradoc::CoreModel::InlineElement.format_type_class(format_type)
               klass.new(
-                content: inline.text.to_s
+                content: inline.text.to_s,
+                source_line: inline.source_line
               )
             end
 
@@ -24,28 +26,32 @@ module Coradoc
               parsed_content = ToCoreModel.parse_and_transform_inline(footnote.text.to_s)
               Coradoc::CoreModel::FootnoteElement.new(
                 target: footnote.id,
-                content: parsed_content
+                content: parsed_content,
+                source_line: footnote.source_line
               )
             end
 
             def transform_link(link)
               Coradoc::CoreModel::LinkElement.new(
                 target: link.path,
-                content: link.name || link.path
+                content: link.name || link.path,
+                source_line: link.source_line
               )
             end
 
             def transform_cross_reference(xref)
               Coradoc::CoreModel::CrossReferenceElement.new(
                 target: xref.href,
-                content: xref.args&.first || xref.href
+                content: xref.args&.first || xref.href,
+                source_line: xref.source_line
               )
             end
 
             def transform_stem(stem)
               Coradoc::CoreModel::StemElement.new(
                 content: stem.content,
-                stem_type: stem.type || 'stem'
+                stem_type: stem.type || 'stem',
+                source_line: stem.source_line
               )
             end
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/list_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/list_transformer.rb
@@ -16,11 +16,15 @@ module Coradoc
               end
 
               if marker_type == 'definition'
-                Coradoc::CoreModel::DefinitionList.new(items: items)
+                Coradoc::CoreModel::DefinitionList.new(
+                  items: items,
+                  source_line: list.source_line
+                )
               else
                 Coradoc::CoreModel::ListBlock.new(
                   marker_type: marker_type,
-                  items: items
+                  items: items,
+                  source_line: list.source_line
                 )
               end
             end
@@ -45,7 +49,8 @@ module Coradoc
                 term: ToCoreModel.extract_text_content(term_children),
                 definitions: [ToCoreModel.extract_text_content(def_children)],
                 term_children: term_children,
-                definition_children: def_children
+                definition_children: def_children,
+                source_line: item.source_line
               )
               di.id = item.id if item.id
 
@@ -63,7 +68,8 @@ module Coradoc
 
               li = Coradoc::CoreModel::ListItem.new(
                 content: ToCoreModel.extract_text_content(content_val),
-                marker: item.marker
+                marker: item.marker,
+                source_line: item.source_line
               )
               li.children = children
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/other_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/other_transformer.rb
@@ -10,7 +10,8 @@ module Coradoc
               Coradoc::CoreModel::Term.new(
                 text: term.term.to_s,
                 type: term.type&.to_s || 'preferred',
-                lang: term.lang&.to_s || 'en'
+                lang: term.lang&.to_s || 'en',
+                source_line: term.source_line
               )
             end
 
@@ -19,7 +20,8 @@ module Coradoc
               children = ToCoreModel.transform_inline_content(admonition.content)
               block = Coradoc::CoreModel::AnnotationBlock.new(
                 annotation_type: canonical,
-                content: ToCoreModel.extract_text_content(admonition.content)
+                content: ToCoreModel.extract_text_content(admonition.content),
+                source_line: admonition.source_line
               )
               block.children = children
               block
@@ -35,7 +37,8 @@ module Coradoc
                 alt: image.alt, title: image.title, caption: image.caption,
                 width: image.width, height: image.height,
                 link: image.link, role: image.role,
-                inline: image.is_a?(Coradoc::AsciiDoc::Model::Image::InlineImage)
+                inline: image.is_a?(Coradoc::AsciiDoc::Model::Image::InlineImage),
+                source_line: image.source_line
               }
             end
 
@@ -53,7 +56,8 @@ module Coradoc
                 id: bib.id,
                 title: bib.title.to_s,
                 level: nil,
-                entries: entries
+                entries: entries,
+                source_line: bib.source_line
               )
             end
 
@@ -61,7 +65,8 @@ module Coradoc
               Coradoc::CoreModel::BibliographyEntry.new(
                 anchor_name: entry.anchor_name,
                 document_id: entry.document_id,
-                ref_text: entry.ref_text.to_s
+                ref_text: entry.ref_text.to_s,
+                source_line: entry.source_line
               )
             end
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/table_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/table_transformer.rb
@@ -14,7 +14,8 @@ module Coradoc
               Coradoc::CoreModel::Table.new(
                 id: table.id,
                 title: table.title&.to_s,
-                rows: rows
+                rows: rows,
+                source_line: table.source_line
               )
             end
 
@@ -24,7 +25,8 @@ module Coradoc
               end
               Coradoc::CoreModel::TableRow.new(
                 cells: cells,
-                header: row.header
+                header: row.header,
+                source_line: row.source_line
               )
             end
 
@@ -38,7 +40,8 @@ module Coradoc
                 colspan: cell.colspan,
                 rowspan: cell.rowspan,
                 style: cell.style_name,
-                children: children
+                children: children,
+                source_line: cell.source_line
               )
             end
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -38,18 +38,12 @@ module Coradoc
                          Coradoc::AsciiDoc::Model::Header.new(title: '')
                        end
 
-              # Pull FrontmatterBlock out first so strip_title_heading sees
-              # the body children in their natural order (frontmatter →
-              # title heading → body). The reverse-direction strip then
-              # matches on a level-0 HeaderElement wherever it sits among
-              # the remaining children.
               without_frontmatter, frontmatter = extract_frontmatter(Array(element.children))
-              without_title = strip_title_heading(without_frontmatter, element.title)
 
               Coradoc::AsciiDoc::Model::Document.new(
                 id: element.id,
                 header: header,
-                sections: flatten_children(without_title),
+                sections: flatten_children(without_frontmatter),
                 frontmatter: frontmatter
               )
             when CoreModel::SectionElement
@@ -66,27 +60,6 @@ module Coradoc
                 contents: flatten_children(element.children)
               )
             end
-          end
-
-          # The forward direction (DocumentTransformer#insert_title_heading_after_frontmatter)
-          # emits a level-0 HeaderElement after any FrontmatterBlock so
-          # consumers that walk the children see the title. On the reverse
-          # path, that HeaderElement would round-trip back as a separate
-          # body element and the title would be emitted twice (once via
-          # the document header, once via the heading child). Drop it
-          # before serialization when it carries the same text as the
-          # document title.
-          def strip_title_heading(children, document_title)
-            return children unless document_title && !document_title.strip.empty?
-
-            index = children.find_index do |child|
-              child.is_a?(CoreModel::HeaderElement) &&
-                child.level.to_i.zero? &&
-                child.title.to_s == document_title.to_s
-            end
-            return children unless index
-
-            children.reject.with_index { |_, i| i == index }
           end
 
           # Transforms each CoreModel child and flattens one level so a

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/inline_transform_visitor.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/inline_transform_visitor.rb
@@ -35,19 +35,37 @@ module Coradoc
           end
         end
 
+        # Folds soft source line breaks into a single text run: when two
+        # +Model::TextElement+s sit adjacent in the content array (the parser
+        # emits one per source line of a paragraph), a space is inserted
+        # between them so wrapped text renders as flowing prose rather than
+        # concatenated words.
+        #
+        # The previous item must ALSO be a TextElement — if a non-text
+        # inline (HardLineBreak, Passthrough, Image, etc.) sits between two
+        # TextElements, the source did not have a soft break there and no
+        # space should be synthesised. Without this guard, `foo +\nbar`
+        # would emit `["foo", hard_break, " ", "bar"]` (stray space) and
+        # `Before +pass:[RAW]+ after` would emit a double space around the
+        # passthrough.
         def visit_array(items)
           result = []
-          items.each_with_index do |item, idx|
+          previous = nil
+          items.each do |item|
             transformed = visit_content(item)
             next if transformed.empty?
 
-            needs_space = idx.positive? &&
-                          item.is_a?(Model::TextElement) &&
-                          item.line_break != '+'
-            result << CoreModel::TextContent.new(text: ' ') if needs_space
+            result << CoreModel::TextContent.new(text: ' ') if soft_break_before?(previous, item)
             result.concat(transformed)
+            previous = item
           end
           result
+        end
+
+        def soft_break_before?(previous, current)
+          previous.is_a?(Model::TextElement) &&
+            current.is_a?(Model::TextElement) &&
+            current.line_break != '+'
         end
 
         def visit_model(model)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/to_core_model.rb
@@ -23,14 +23,38 @@ module Coradoc
             transformer ? transformer.call(model) : model
           end
 
-          def extract_block_lines(block)
-            non_break_lines = Array(block.lines).reject do |line|
-              line.is_a?(Coradoc::AsciiDoc::Model::LineBreak) ||
-                line.is_a?(Coradoc::AsciiDoc::Model::Break::PageBreak)
+          # Returns the source-line view of an AsciiDoc content array as
+          # an Array<String>. Single source of truth for source-line
+          # extraction — every transformer that needs to populate
+          # CoreModel::Block#lines goes through here so the filtering
+          # rules (skip Model::LineBreak and Model::Break::PageBreak,
+          # which carry no renderable text) apply consistently.
+          def extract_source_lines(content)
+            Array(content).filter_map do |item|
+              next if item.is_a?(Coradoc::AsciiDoc::Model::LineBreak) ||
+                      item.is_a?(Coradoc::AsciiDoc::Model::Break::PageBreak)
+
+              extract_text_content(item).to_s
             end
-            non_break_lines.map do |line|
-              extract_text_content(line)
-            end.join("\n")
+          end
+
+          def extract_block_lines(block)
+            extract_source_lines(block.lines).join("\n")
+          end
+
+          # Extracts the source_line of the first AsciiDoc::Model::Base in
+          # +content+. Single source of truth for source-line propagation
+          # from AsciiDoc::Model trees into CoreModel objects built from
+          # grouped content (e.g., paragraphs inside typed blocks).
+          # Returns nil when no model carries a source_line.
+          def extract_source_line(content)
+            Array(content).each do |item|
+              next unless item.is_a?(Coradoc::AsciiDoc::Model::Base)
+
+              line = item.source_line
+              return line if line
+            end
+            nil
           end
 
           def extract_title_text(title)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer.rb
@@ -33,6 +33,7 @@ module Coradoc
       autoload :BlockTypeClassifier, "#{__dir__}/transformer/block_type_classifier"
       autoload :TableLayout, "#{__dir__}/transformer/table_layout"
       autoload :TableCellBuilder, "#{__dir__}/transformer/table_cell_builder"
+      autoload :SourceLineExtractor, "#{__dir__}/transformer/source_line_extractor"
 
       # Apply all rule modules (triggers autoload)
       HeaderRules.apply(self)
@@ -139,7 +140,11 @@ module Coradoc
                           text_content
                         end
 
-          Model::TextElement.new(content: transformed, line_break: line[:line_break])
+          Model::TextElement.new(
+            content: transformed,
+            line_break: line[:line_break],
+            source_line: SourceLineExtractor.extract(line)
+          )
         end
       end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
@@ -23,7 +23,8 @@ module Coradoc
                 title: title,
                 delimiter_len: delimiter.size,
                 lines: lines,
-                ordering: ordering
+                ordering: ordering,
+                source_line: SourceLineExtractor.extract(block)
               }
               # Markdown fences carry the language tag inline (```ruby);
               # pass it through so the SourceCode classifier entry can set
@@ -34,7 +35,11 @@ module Coradoc
 
             # Example
             rule(example: sequence(:example)) do
-              Model::Block::Example.new(title: '', lines: example)
+              Model::Block::Example.new(
+                title: '',
+                lines: example,
+                source_line: SourceLineExtractor.extract(example)
+              )
             end
 
             # Admonition. Canonicalise the type to uppercase so round-trips
@@ -45,7 +50,11 @@ module Coradoc
               content: sequence(:content)
             ) do
               canonical = Coradoc::AsciiDoc::Transform::ElementTransformers::AdmonitionStyles.canonicalize(admonition_type.to_s)
-              Model::Admonition.new(content: content, type: canonical)
+              Model::Admonition.new(
+                content: content,
+                type: canonical,
+                source_line: SourceLineExtractor.extract(admonition_type)
+              )
             end
 
             # Block image
@@ -63,6 +72,7 @@ module Coradoc
                 src: path,
                 attributes: residual,
                 line_break: "\n",
+                source_line: SourceLineExtractor.extract(block_image),
                 **promoted
               )
             end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/header_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/header_rules.rb
@@ -21,7 +21,10 @@ module Coradoc
               id = id.to_s unless id.nil?
               id = nil if id && id.empty?
 
-              Model::Header.new(id:, title:, author:, revision:)
+              Model::Header.new(
+                id:, title:, author:, revision:,
+                source_line: SourceLineExtractor.extract(header)
+              )
             end
 
             rule(header: simple(:header)) do
@@ -34,7 +37,10 @@ module Coradoc
               last_name: simple(:last_name),
               email: simple(:email)
             ) do
-              Model::Author.new(first_name:, last_name:, email:, middle_name: nil)
+              Model::Author.new(
+                first_name:, last_name:, email:, middle_name: nil,
+                source_line: SourceLineExtractor.extract(first_name)
+              )
             end
 
             # Revision
@@ -43,7 +49,10 @@ module Coradoc
               date: simple(:date),
               remark: simple(:remark)
             ) do
-              Model::Revision.new(number:, date:, remark:)
+              Model::Revision.new(
+                number:, date:, remark:,
+                source_line: SourceLineExtractor.extract(number)
+              )
             end
           end
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
@@ -22,7 +22,8 @@ module Coradoc
             rule(link: subtree(:link)) do
               Model::Inline::Link.new(
                 path: link[:path].to_s,
-                name: link[:text]&.to_s
+                name: link[:text]&.to_s,
+                source_line: SourceLineExtractor.extract(link)
               )
             end
 
@@ -31,7 +32,10 @@ module Coradoc
               href = xref[:href].to_s
               text = xref[:text]
               args = text ? [text.to_s] : []
-              Model::Inline::CrossReference.new(href:, args:)
+              Model::Inline::CrossReference.new(
+                href:, args:,
+                source_line: SourceLineExtractor.extract(xref)
+              )
             end
 
             # Inline image
@@ -43,6 +47,7 @@ module Coradoc
               Model::Image::InlineImage.new(
                 src: inline_image[:path],
                 attributes: residual,
+                source_line: SourceLineExtractor.extract(inline_image),
                 **promoted
               )
             end
@@ -54,13 +59,17 @@ module Coradoc
             rule(inline_passthrough: subtree(:passthrough)) do
               Model::Inline::Passthrough.new(
                 content: passthrough[:raw].to_s,
-                form: 'triple'
+                form: 'triple',
+                source_line: SourceLineExtractor.extract(passthrough)
               )
             end
 
             # Attribute reference
             rule(attribute_reference: simple(:name)) do
-              Model::Inline::AttributeReference.new(name:)
+              Model::Inline::AttributeReference.new(
+                name:,
+                source_line: SourceLineExtractor.extract(name)
+              )
             end
 
             # Hard line break (` +\n` or `\\n`). Emitted as a dedicated
@@ -68,8 +77,10 @@ module Coradoc
             # Model::LineBreak, which only represents paragraph-separator
             # blank lines. Hard breaks carry semantic meaning: HTML/Markdown
             # renderers map them to <br>.
-            rule(hard_line_break: simple(:_)) do
-              Model::Inline::HardLineBreak.new
+            rule(hard_line_break: simple(:hard_line_break)) do
+              Model::Inline::HardLineBreak.new(
+                source_line: SourceLineExtractor.extract(hard_line_break)
+              )
             end
 
             # Term
@@ -77,30 +88,45 @@ module Coradoc
               term_type: simple(:term_type),
               term: simple(:term)
             ) do
-              Coradoc::AsciiDoc::Model::Term.new(term:, type: term_type, lang: :en)
+              Coradoc::AsciiDoc::Model::Term.new(
+                term:, type: term_type, lang: :en,
+                source_line: SourceLineExtractor.extract(term_type)
+              )
             end
 
             # Footnote
             rule(footnote: simple(:footnote)) do
               text_str = footnote.to_s
-              Coradoc::AsciiDoc::Model::Inline::Footnote.new(text: text_str)
+              Coradoc::AsciiDoc::Model::Inline::Footnote.new(
+                text: text_str,
+                source_line: SourceLineExtractor.extract(footnote)
+              )
             end
 
             rule(footnote: simple(:footnote), id: simple(:id)) do
               text_str = footnote.to_s
-              Coradoc::AsciiDoc::Model::Inline::Footnote.new(text: text_str, id: id.to_s)
+              Coradoc::AsciiDoc::Model::Inline::Footnote.new(
+                text: text_str, id: id.to_s,
+                source_line: SourceLineExtractor.extract(footnote)
+              )
             end
 
             # Footnote with empty content (reference to named footnote)
             rule(footnote: sequence(:footnote), id: simple(:id)) do
               text_str = footnote.map(&:to_s).join
-              Coradoc::AsciiDoc::Model::Inline::Footnote.new(text: text_str, id: id.to_s)
+              Coradoc::AsciiDoc::Model::Inline::Footnote.new(
+                text: text_str, id: id.to_s,
+                source_line: SourceLineExtractor.extract(footnote)
+              )
             end
 
             # Footnote with empty content and no id
             rule(footnote: sequence(:footnote)) do
               text_str = footnote.map(&:to_s).join
-              Coradoc::AsciiDoc::Model::Inline::Footnote.new(text: text_str)
+              Coradoc::AsciiDoc::Model::Inline::Footnote.new(
+                text: text_str,
+                source_line: SourceLineExtractor.extract(footnote)
+              )
             end
 
             # Inline formatting rules generated from a single registry.
@@ -114,11 +140,17 @@ module Coradoc
 
               rule(constrained_key => subtree(:subtree)) do
                 content = Transformer.extract_inline_content(subtree)
-                klass.new(content: content, unconstrained: false)
+                klass.new(
+                  content: content, unconstrained: false,
+                  source_line: SourceLineExtractor.extract(subtree)
+                )
               end
               rule(unconstrained_key => subtree(:subtree)) do
                 content = Transformer.extract_inline_content(subtree)
-                klass.new(content: content, unconstrained: true)
+                klass.new(
+                  content: content, unconstrained: true,
+                  source_line: SourceLineExtractor.extract(subtree)
+                )
               end
             end
 
@@ -127,7 +159,8 @@ module Coradoc
               Model::Inline::Span.new(
                 text: span_constrained[:text],
                 unconstrained: false,
-                attributes: span_constrained[:attribute_list]
+                attributes: span_constrained[:attribute_list],
+                source_line: SourceLineExtractor.extract(span_constrained)
               )
             end
 
@@ -136,31 +169,42 @@ module Coradoc
               Model::Inline::Span.new(
                 text: span_unconstrained[:text],
                 unconstrained: true,
-                attributes: span_unconstrained[:attribute_list]
+                attributes: span_unconstrained[:attribute_list],
+                source_line: SourceLineExtractor.extract(span_unconstrained)
               )
             end
 
             # Superscript
             rule(superscript: subtree(:superscript)) do
               content = Transformer.extract_simple_inline_content(superscript)
-              Model::Inline::Superscript.new(content:)
+              Model::Inline::Superscript.new(
+                content:,
+                source_line: SourceLineExtractor.extract(superscript)
+              )
             end
 
             # Subscript
             rule(subscript: subtree(:subscript)) do
               content = Transformer.extract_simple_inline_content(subscript)
-              Model::Inline::Subscript.new(content:)
+              Model::Inline::Subscript.new(
+                content:,
+                source_line: SourceLineExtractor.extract(subscript)
+              )
             end
 
             # Highlight (simple)
             rule(highlight: simple(:text)) do
-              Model::Highlight.new(content: text)
+              Model::Highlight.new(
+                content: text,
+                source_line: SourceLineExtractor.extract(text)
+              )
             end
             # Stem
             rule(stem: subtree(:stem)) do
               Coradoc::AsciiDoc::Model::Inline::Stem.new(
                 type: stem[:stem_type],
-                content: stem[:content]
+                content: stem[:content],
+                source_line: SourceLineExtractor.extract(stem)
               )
             end
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/list_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/list_rules.rb
@@ -74,7 +74,8 @@ module Coradoc
               end
 
               Model::List::Item.new(
-                content: content, id:, marker:, attached:, nested:, line_break:
+                content: content, id:, marker:, attached:, nested:, line_break:,
+                source_line: SourceLineExtractor.extract(list_item)
               )
             end
 
@@ -85,26 +86,40 @@ module Coradoc
 
             # Unordered list
             rule(unordered: sequence(:list_items)) do
-              Model::List::Unordered.new(items: list_items)
+              Model::List::Unordered.new(
+                items: list_items,
+                source_line: SourceLineExtractor.extract(list_items)
+              )
             end
 
             rule(
               attribute_list: simple(:attribute_list),
               unordered: sequence(:list_items)
             ) do
-              Model::List::Unordered.new(items: list_items, attrs: attribute_list)
+              Model::List::Unordered.new(
+                items: list_items,
+                attrs: attribute_list,
+                source_line: SourceLineExtractor.extract(attribute_list)
+              )
             end
 
             # Ordered list
             rule(ordered: sequence(:list_items)) do
-              Model::List::Ordered.new(items: list_items)
+              Model::List::Ordered.new(
+                items: list_items,
+                source_line: SourceLineExtractor.extract(list_items)
+              )
             end
 
             rule(
               attribute_list: simple(:attribute_list),
               ordered: sequence(:list_items)
             ) do
-              Model::List::Ordered.new(items: list_items, attrs: attribute_list)
+              Model::List::Ordered.new(
+                items: list_items,
+                attrs: attribute_list,
+                source_line: SourceLineExtractor.extract(attribute_list)
+              )
             end
 
             # Definition list term (with optional anchor)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/misc_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/misc_rules.rb
@@ -12,16 +12,25 @@ module Coradoc
                    comment_text: simple(:comment_text),
                    line_break: simple(:line_break)
                  }) do
-              Model::CommentLine.new(text: comment_text, line_break: line_break)
+              Model::CommentLine.new(
+                text: comment_text,
+                line_break: line_break,
+                source_line: SourceLineExtractor.extract(comment_text)
+              )
             end
 
             rule(comment_block: { comment_text: simple(:comment_text) }) do
-              Model::CommentBlock.new(text: comment_text)
+              Model::CommentBlock.new(
+                text: comment_text,
+                source_line: SourceLineExtractor.extract(comment_text)
+              )
             end
 
             # Page break
             rule(page_break: simple(:page_break)) do
-              Model::Break::PageBreak.new
+              Model::Break::PageBreak.new(
+                source_line: SourceLineExtractor.extract(page_break)
+              )
             end
 
             # Tag
@@ -30,7 +39,8 @@ module Coradoc
                 name: tag[:name],
                 attrs: tag[:attribute_list],
                 line_break: tag[:line_break],
-                prefix: tag[:prefix]
+                prefix: tag[:prefix],
+                source_line: SourceLineExtractor.extract(tag)
               )
             end
 
@@ -45,7 +55,7 @@ module Coradoc
             end
 
             rule(positional: simple(:positional)) do
-              positional.to_s
+              positional
             end
 
             rule(attribute_array: nil) do
@@ -53,11 +63,16 @@ module Coradoc
             end
 
             rule(attribute_array: sequence(:attributes)) do
-              attr_list = Model::AttributeList.new
+              attr_list = Model::AttributeList.new(
+                source_line: SourceLineExtractor.extract(attributes)
+              )
               attributes.each do |a|
-                if a.is_a?(String)
+                case a
+                when Parslet::Slice
+                  attr_list.add_positional(a.to_s)
+                when String
                   attr_list.add_positional(a)
-                elsif a.is_a?(Model::Attribute)
+                when Model::Attribute
                   attr_list.add_named(a.key, a.value)
                 end
               end
@@ -104,7 +119,8 @@ module Coradoc
               Model::Include.new(
                 path: path.to_s,
                 attributes: attribute_list,
-                line_break: line_break
+                line_break: line_break,
+                source_line: SourceLineExtractor.extract(path)
               )
             end
 
@@ -119,7 +135,8 @@ module Coradoc
               Model::Audio.new(
                 src: path.to_s,
                 attributes: attribute_list,
-                line_break: line_break
+                line_break: line_break,
+                source_line: SourceLineExtractor.extract(path)
               )
             end
 
@@ -134,7 +151,8 @@ module Coradoc
               Model::Video.new(
                 src: path.to_s,
                 attributes: attribute_list,
-                line_break: line_break
+                line_break: line_break,
+                source_line: SourceLineExtractor.extract(path)
               )
             end
 
@@ -162,7 +180,8 @@ module Coradoc
                 date: attrs[:date],
                 from: attrs[:from],
                 to: attrs[:to],
-                content: Transformer.lines_to_text_elements(lines)
+                content: Transformer.lines_to_text_elements(lines),
+                source_line: SourceLineExtractor.extract(reviewer_note)
               )
             end
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/source_line_extractor.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/source_line_extractor.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'parslet'
+
+module Coradoc
+  module AsciiDoc
+    class Transformer < Parslet::Transform
+      # Walks a Parslet AST subtree (Hash/Array/Slice/String/Model) and
+      # returns the 1-indexed source line of the first +Parslet::Slice+
+      # or Model::Base#source_line it finds.
+      #
+      # Parslet preserves byte offsets on every matched slice
+      # (+slice.line_and_column+ returns +[line, column]+); the
+      # transformer receives these slices in the AST but most rules
+      # discard the position when building Model objects. This helper
+      # recovers the start line of any subtree so transformer rules
+      # can populate +Model::Base#source_line+ without changing the
+      # parser.
+      #
+      # Handles two distinct shapes:
+      #   * Pre-transform AST (Hash/Array of Parslet::Slice) — used by
+      #     rules that bind raw slices via +simple(:x)+.
+      #   * Post-transform Model tree (Model::Base instances whose
+      #     +source_line+ was populated by an earlier rule) — used by
+      #     rules that bind via +subtree(:x)+ and receive already-
+      #     transformed content.
+      #
+      # Returns nil when no position is found (programmatic input,
+      # already-stripped ASTs, etc.) — callers should treat nil as
+      # "source position unavailable".
+      module SourceLineExtractor
+        module_function
+
+        def extract(node)
+          case node
+          when Parslet::Slice then line_of(node)
+          when Coradoc::AsciiDoc::Model::Base then node.source_line
+          when Hash then extract_from_hash(node)
+          when Array then extract_from_array(node)
+          else nil
+          end
+        end
+
+        def line_of(slice)
+          line, _column = slice.line_and_column
+          line
+        end
+
+        def extract_from_hash(hash)
+          hash.each_value do |value|
+            line = extract(value)
+            return line if line
+          end
+          nil
+        end
+
+        def extract_from_array(array)
+          array.each do |value|
+            line = extract(value)
+            return line if line
+          end
+          nil
+        end
+      end
+    end
+  end
+end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/structural_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/structural_rules.rb
@@ -72,6 +72,7 @@ module Coradoc
               opts = { rows: Transformer.regroup_table_rows(rows, attrs), attrs: attrs }
               opts[:id] = id if id
               opts[:title] = title unless title.nil? || title.empty?
+              opts[:source_line] = SourceLineExtractor.extract(table)
               Model::Table.new(**opts)
             end
 
@@ -84,7 +85,8 @@ module Coradoc
               Model::Title.new(
                 content: text,
                 level_int: level.size - 1,
-                line_break: line_break
+                line_break: line_break,
+                source_line: SourceLineExtractor.extract(level)
               )
             end
 
@@ -98,7 +100,8 @@ module Coradoc
                 content: text,
                 level_int: level.size - 1,
                 line_break: line_break,
-                id: name
+                id: name,
+                source_line: SourceLineExtractor.extract(name)
               )
             end
 
@@ -117,7 +120,8 @@ module Coradoc
                 id: id,
                 attribute_list: attribute_list,
                 contents: contents,
-                sections: sections
+                sections: sections,
+                source_line: SourceLineExtractor.extract(section)
               )
             end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/text_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/text_rules.rb
@@ -9,7 +9,10 @@ module Coradoc
           transformer_class.class_eval do
             # Text Model
             rule(text: simple(:text)) do
-              Model::TextElement.new(content: text.to_s)
+              Model::TextElement.new(
+                content: text.to_s,
+                source_line: Transformer::SourceLineExtractor.extract(text)
+              )
             end
 
             rule(text_string: subtree(:text_string)) do
@@ -17,19 +20,34 @@ module Coradoc
             end
 
             rule(text: simple(:text), line_break: simple(:line_break)) do
-              Model::TextElement.new(content: text.to_s, line_break: line_break)
+              Model::TextElement.new(
+                content: text.to_s,
+                line_break: line_break,
+                source_line: Transformer::SourceLineExtractor.extract(text)
+              )
             end
 
             rule(text: sequence(:text), line_break: simple(:line_break)) do
-              Model::TextElement.new(content: text, line_break: line_break)
+              Model::TextElement.new(
+                content: text,
+                line_break: line_break,
+                source_line: Transformer::SourceLineExtractor.extract(text)
+              )
             end
 
             rule(id: simple(:id), text: simple(:text)) do
-              Model::TextElement.new(content: text.to_s, id: id.to_s)
+              Model::TextElement.new(
+                content: text.to_s,
+                id: id.to_s,
+                source_line: Transformer::SourceLineExtractor.extract(id)
+              )
             end
 
             rule(text: sequence(:text)) do
-              Model::TextElement.new(content: text)
+              Model::TextElement.new(
+                content: text,
+                source_line: Transformer::SourceLineExtractor.extract(text)
+              )
             end
 
             rule(
@@ -40,7 +58,8 @@ module Coradoc
               Model::TextElement.new(
                 content: text.to_s,
                 id: id.to_s,
-                line_break: line_break
+                line_break: line_break,
+                source_line: Transformer::SourceLineExtractor.extract(id)
               )
             end
 
@@ -52,13 +71,17 @@ module Coradoc
               Model::TextElement.new(
                 content: text,
                 id: id.to_s,
-                line_break: line_break
+                line_break: line_break,
+                source_line: Transformer::SourceLineExtractor.extract(id)
               )
             end
 
             # Line break
             rule(line_break: simple(:line_break)) do
-              Model::LineBreak.new(line_break:)
+              Model::LineBreak.new(
+                line_break:,
+                source_line: Transformer::SourceLineExtractor.extract(line_break)
+              )
             end
 
             # Unparsed text
@@ -72,7 +95,8 @@ module Coradoc
                 content: Transformer.lines_to_text_elements(paragraph[:lines]),
                 id: paragraph[:id],
                 attributes: paragraph[:attribute_list],
-                title: paragraph[:title]
+                title: paragraph[:title],
+                source_line: Transformer::SourceLineExtractor.extract(paragraph)
               )
             end
           end

--- a/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
@@ -41,8 +41,11 @@ RSpec.describe 'Integration pipeline fixes' do
     it 'transforms page_break through to CoreModel as nil (filtered out)' do
       core = parse_to_core("= Title\n\nHello\n\n<<<\n\n== Section\n")
       expect(core).to be_a(Coradoc::CoreModel::StructuralElement)
-      # title heading (level-0) + paragraph + section, no page break
-      expect(core.children.length).to eq(3)
+      # The document title lives on DocumentElement#title only — it is
+      # NOT duplicated as a level-0 HeaderElement in children. Children
+      # are: paragraph + section. No page break.
+      expect(core.title).to eq('Title')
+      expect(core.children.length).to eq(2)
     end
   end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/block_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/block_transformer_spec.rb
@@ -15,8 +15,43 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::BlockTransform
       expect(result).to be_a(Coradoc::CoreModel::ParagraphBlock)
       expect(result.id).to eq('para-1')
       expect(result.content).to eq('Hello world')
+      expect(result.lines).to eq(['Hello world'])
       expect(result.children.size).to eq(1)
       expect(result.children.first).to be_a(Coradoc::CoreModel::TextContent)
+    end
+
+    it 'preserves source line structure for multi-line paragraphs' do
+      para = Coradoc::AsciiDoc::Model::Paragraph.new(
+        content: [
+          Coradoc::AsciiDoc::Model::TextElement.new(content: 'This is line one'),
+          Coradoc::AsciiDoc::Model::TextElement.new(content: 'of a paragraph'),
+          Coradoc::AsciiDoc::Model::TextElement.new(content: 'that spans three.')
+        ]
+      )
+
+      result = described_class.transform_paragraph(para)
+
+      expect(result).to be_a(Coradoc::CoreModel::ParagraphBlock)
+      # `content` is the rendered view — soft-wrapped lines joined with
+      # spaces so they read as flowing prose.
+      expect(result.content).to eq('This is line one of a paragraph that spans three.')
+      # `lines` is the source-line view — each entry corresponds to one
+      # line in the AsciiDoc source.
+      expect(result.lines).to eq(['This is line one', 'of a paragraph', 'that spans three.'])
+    end
+
+    it 'filters out LineBreak and PageBreak items when extracting source lines' do
+      para = Coradoc::AsciiDoc::Model::Paragraph.new(
+        content: [
+          Coradoc::AsciiDoc::Model::TextElement.new(content: 'Before'),
+          Coradoc::AsciiDoc::Model::LineBreak.new,
+          Coradoc::AsciiDoc::Model::TextElement.new(content: 'After')
+        ]
+      )
+
+      result = described_class.transform_paragraph(para)
+
+      expect(result.lines).to eq(%w[Before After])
     end
 
     it 'transforms a paragraph with inline elements' do
@@ -33,7 +68,12 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::BlockTransform
 
       expect(result).to be_a(Coradoc::CoreModel::ParagraphBlock)
       expect(result.content).to match(/Hello\s+bold\s*world/)
-      expect(result.children.size).to eq(4)
+      # Inline elements between two TextElements do NOT synthesize a
+      # soft-break space — the visitor only inserts " " between two
+      # adjacent TextElements (i.e. real source line breaks). An
+      # inline element sitting between two text runs means the source
+      # had them on the same line.
+      expect(result.children.size).to eq(3)
       expect(result.children.find { |c| c.is_a?(Coradoc::CoreModel::BoldElement) }).not_to be_nil
       expect(result.children.find { |c| c.is_a?(Coradoc::CoreModel::BoldElement) }.content).to eq('bold')
     end
@@ -77,6 +117,7 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::BlockTransform
       expect(result.title).to eq('Example')
       expect(result.language).to eq('ruby')
       expect(result.content).to eq("def test\n  true\nend")
+      expect(result.lines).to eq(['def test', '  true', 'end'])
     end
 
     it 'handles source block without language' do
@@ -107,6 +148,7 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::BlockTransform
       expect(result.id).to eq('blk-1')
       expect(result.title).to eq('Note')
       expect(result.content).to eq('Note content')
+      expect(result.lines).to eq(['Note content'])
       expect(result.block_semantic_type).to eq('example')
       expect(result.delimiter_type).to eq('====')
     end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/document_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/document_transformer_spec.rb
@@ -27,14 +27,13 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::DocumentTransf
       expect(result).to be_a(Coradoc::CoreModel::DocumentElement)
       expect(result.id).to eq('doc-1')
       expect(result.title).to eq('My Document')
-      # The document title is prepended as a level-0 HeaderElement so
-      # body-walking consumers see it. The Paragraph follows.
-      expect(result.children.size).to eq(2)
-      expect(result.children[0]).to be_a(Coradoc::CoreModel::HeaderElement)
-      expect(result.children[0].level).to eq(0)
-      expect(result.children[0].title).to eq('My Document')
-      expect(result.children[1]).to be_a(Coradoc::CoreModel::ParagraphBlock)
-      expect(result.children[1].content).to eq('Content')
+      # The document title is the canonical source of truth on
+      # DocumentElement#title. It is NOT duplicated into the body as a
+      # level-0 HeaderElement — that synthesis caused the title to render
+      # twice in the mirror layer (attrs.title + floating_title).
+      expect(result.children.size).to eq(1)
+      expect(result.children[0]).to be_a(Coradoc::CoreModel::ParagraphBlock)
+      expect(result.children[0].content).to eq('Content')
     end
 
     it 'handles a document without header' do

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/inline_transform_visitor_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/inline_transform_visitor_spec.rb
@@ -130,6 +130,35 @@ RSpec.describe Coradoc::AsciiDoc::Transform::InlineTransformVisitor do
         texts = result.map { |r| r.is_a?(Coradoc::CoreModel::TextContent) ? r.text : r.content.to_s }
         expect(texts).not_to include(' ')
       end
+
+      # Soft-break spaces must only be synthesised between two
+      # adjacent TextElements — i.e. real source line breaks. When
+      # an inline element (Bold, Passthrough, Image, etc.) sits
+      # between two TextElements, the source had them on the same
+      # line, so no space should be synthesised. Without this guard,
+      # `Before +pass:[RAW]+ after` would emit a double space around
+      # the passthrough, and `foo +\nbar` (hard break) would emit a
+      # stray space between the hard break and "bar".
+      it 'does not insert space around an inline element between TextElements' do
+        items = [
+          Coradoc::AsciiDoc::Model::TextElement.new(content: 'Before '),
+          Coradoc::AsciiDoc::Model::Inline::Bold.new(content: 'middle'),
+          Coradoc::AsciiDoc::Model::TextElement.new(content: ' after')
+        ]
+        result = visitor.transform(items)
+        text_contents = result.select { |r| r.is_a?(Coradoc::CoreModel::TextContent) }
+        expect(text_contents.map(&:text)).to eq(['Before ', ' after'])
+      end
+
+      it 'does not insert space between TextElement and Passthrough' do
+        items = [
+          Coradoc::AsciiDoc::Model::TextElement.new(content: 'Before '),
+          Coradoc::AsciiDoc::Model::Inline::Passthrough.new(content: 'RAW')
+        ]
+        result = visitor.transform(items)
+        text_contents = result.select { |r| r.is_a?(Coradoc::CoreModel::TextContent) }
+        expect(text_contents.map(&:text)).to eq(['Before '])
+      end
     end
 
     context 'with unknown type' do

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/named_block_styles_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/named_block_styles_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Named block style preservation', :asciidoc do
   end
 
   describe '[abstract] block style' do
-    it 'casts a delimited block into an AbstractBlock' do
+    it 'casts a delimited block into an AbstractBlock', :aggregate_failures do
       block = first_child("[abstract]\n====\nAbstract text\n====\n")
 
       expect(block).to be_a(Coradoc::CoreModel::AbstractBlock)
@@ -27,7 +27,7 @@ RSpec.describe 'Named block style preservation', :asciidoc do
       expect(block).to be_a(Coradoc::CoreModel::AbstractBlock)
     end
 
-    it 'reports :abstract as its semantic type' do
+    it 'reports :abstract as its semantic type', :aggregate_failures do
       block = first_child("[abstract]\n====\nx\n====\n")
 
       expect(block.class.semantic_type).to eq(:abstract)
@@ -42,7 +42,7 @@ RSpec.describe 'Named block style preservation', :asciidoc do
   end
 
   describe '[partintro] block style' do
-    it 'casts a delimited block into a PartintroBlock' do
+    it 'casts a delimited block into a PartintroBlock', :aggregate_failures do
       block = first_child("[partintro]\n====\nPart intro\n====\n")
 
       expect(block).to be_a(Coradoc::CoreModel::PartintroBlock)
@@ -55,7 +55,7 @@ RSpec.describe 'Named block style preservation', :asciidoc do
       expect(block).to be_a(Coradoc::CoreModel::PartintroBlock)
     end
 
-    it 'reports :partintro as its semantic type' do
+    it 'reports :partintro as its semantic type', :aggregate_failures do
       block = first_child("[partintro]\n====\nx\n====\n")
 
       expect(block.class.semantic_type).to eq(:partintro)
@@ -76,7 +76,7 @@ RSpec.describe 'Named block style preservation', :asciidoc do
       expect(block.annotation_type).to eq('ADMONITION')
     end
 
-    it 'takes precedence over the native ExampleBlock type' do
+    it 'takes precedence over the native ExampleBlock type', :aggregate_failures do
       # The cast ladder resolves admonition before typed-cast, so
       # `[admonition]` on an `====` block is an admonition, not an example.
       block = first_child("[admonition]\n====\nx\n====\n")
@@ -85,7 +85,7 @@ RSpec.describe 'Named block style preservation', :asciidoc do
       expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
     end
 
-    it 'works on open blocks too' do
+    it 'works on open blocks too', :aggregate_failures do
       block = first_child("[admonition]\n--\nx\n--\n")
 
       expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
@@ -95,7 +95,7 @@ RSpec.describe 'Named block style preservation', :asciidoc do
 
   describe 'cast ladder still recognises existing admonitions' do
     %w[note tip warning caution important].each do |style|
-      it "[#{style.upcase}] still maps to AnnotationBlock with #{style.upcase} type" do
+      it "[#{style.upcase}] still maps to AnnotationBlock with #{style.upcase} type", :aggregate_failures do
         block = first_child("[#{style.upcase}]\n====\nx\n====\n")
 
         expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/named_block_styles_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/named_block_styles_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+
+# Block-style preservation for `[abstract]`, `[partintro]`, and the generic
+# `[admonition]` style. Before this fix, all three collapsed to ExampleBlock
+# (mirror type `example`), losing their semantic identity. Each now has a
+# dedicated CoreModel class + Mirror node type so the AsciiDoc author's
+# intent survives the round-trip.
+RSpec.describe 'Named block style preservation', :asciidoc do
+  def first_child(adoc)
+    Coradoc.parse(adoc, format: :asciidoc).children.first
+  end
+
+  describe '[abstract] block style' do
+    it 'casts a delimited block into an AbstractBlock' do
+      block = first_child("[abstract]\n====\nAbstract text\n====\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::AbstractBlock)
+      expect(block.content).to eq('Abstract text')
+    end
+
+    it 'casts an open block into an AbstractBlock' do
+      block = first_child("[abstract]\n--\nAbstract text\n--\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::AbstractBlock)
+    end
+
+    it 'reports :abstract as its semantic type' do
+      block = first_child("[abstract]\n====\nx\n====\n")
+
+      expect(block.class.semantic_type).to eq(:abstract)
+      expect(block.resolve_semantic_type).to eq(:abstract)
+    end
+
+    it 'preserves block title' do
+      block = first_child(".Abstract Title\n[abstract]\n====\nBody\n====\n")
+
+      expect(block.title).to eq('Abstract Title')
+    end
+  end
+
+  describe '[partintro] block style' do
+    it 'casts a delimited block into a PartintroBlock' do
+      block = first_child("[partintro]\n====\nPart intro\n====\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::PartintroBlock)
+      expect(block.content).to eq('Part intro')
+    end
+
+    it 'casts an open block into a PartintroBlock' do
+      block = first_child("[partintro]\n--\nPart intro\n--\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::PartintroBlock)
+    end
+
+    it 'reports :partintro as its semantic type' do
+      block = first_child("[partintro]\n====\nx\n====\n")
+
+      expect(block.class.semantic_type).to eq(:partintro)
+      expect(block.resolve_semantic_type).to eq(:partintro)
+    end
+  end
+
+  describe 'generic [admonition] block style' do
+    it 'casts a delimited block into an AnnotationBlock' do
+      block = first_child("[admonition]\n====\nGeneric\n====\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+    end
+
+    it 'canonicalises the type to ADMONITION (uppercase)' do
+      block = first_child("[admonition]\n====\nGeneric\n====\n")
+
+      expect(block.annotation_type).to eq('ADMONITION')
+    end
+
+    it 'takes precedence over the native ExampleBlock type' do
+      # The cast ladder resolves admonition before typed-cast, so
+      # `[admonition]` on an `====` block is an admonition, not an example.
+      block = first_child("[admonition]\n====\nx\n====\n")
+
+      expect(block).not_to be_a(Coradoc::CoreModel::ExampleBlock)
+      expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+    end
+
+    it 'works on open blocks too' do
+      block = first_child("[admonition]\n--\nx\n--\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+      expect(block.annotation_type).to eq('ADMONITION')
+    end
+  end
+
+  describe 'cast ladder still recognises existing admonitions' do
+    %w[note tip warning caution important].each do |style|
+      it "[#{style.upcase}] still maps to AnnotationBlock with #{style.upcase} type" do
+        block = first_child("[#{style.upcase}]\n====\nx\n====\n")
+
+        expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+        expect(block.annotation_type).to eq(style.upcase)
+      end
+    end
+  end
+
+  describe 'typed-cast ladder still recognises sidebar/example/quote' do
+    it '[sidebar] still maps to SidebarBlock' do
+      expect(first_child("[sidebar]\n====\nx\n====\n"))
+        .to be_a(Coradoc::CoreModel::SidebarBlock)
+    end
+
+    it '[example] still maps to ExampleBlock' do
+      expect(first_child("[example]\n====\nx\n====\n"))
+        .to be_a(Coradoc::CoreModel::ExampleBlock)
+    end
+
+    it '[quote] still maps to QuoteBlock' do
+      expect(first_child("[quote]\n====\nx\n====\n"))
+        .to be_a(Coradoc::CoreModel::QuoteBlock)
+    end
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/open_block_typed_cast_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/open_block_typed_cast_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Open-block typed casts', :asciidoc do
   end
 
   describe '[sidebar] cast' do
-    it 'casts an open block into a SidebarBlock' do
+    it 'casts an open block into a SidebarBlock', :aggregate_failures do
       block = first_child("[sidebar]\n--\nSide content\n--\n")
 
       expect(block).to be_a(Coradoc::CoreModel::SidebarBlock)
@@ -23,7 +23,7 @@ RSpec.describe 'Open-block typed casts', :asciidoc do
   end
 
   describe '[example] cast' do
-    it 'casts an open block into an ExampleBlock' do
+    it 'casts an open block into an ExampleBlock', :aggregate_failures do
       block = first_child("[example]\n--\nExample body\n--\n")
 
       expect(block).to be_a(Coradoc::CoreModel::ExampleBlock)
@@ -32,7 +32,7 @@ RSpec.describe 'Open-block typed casts', :asciidoc do
   end
 
   describe '[quote] cast' do
-    it 'casts an open block into a QuoteBlock' do
+    it 'casts an open block into a QuoteBlock', :aggregate_failures do
       block = first_child("[quote]\n--\nQuoted text\n--\n")
 
       expect(block).to be_a(Coradoc::CoreModel::QuoteBlock)
@@ -49,7 +49,7 @@ RSpec.describe 'Open-block typed casts', :asciidoc do
   end
 
   describe 'cast precedence (admonition > typed)' do
-    it 'prefers admonition when both could apply' do
+    it 'prefers admonition when both could apply', :aggregate_failures do
       # [NOTE] is an admonition label, not a typed-cast style.
       # The cast ladder resolves admonition before typed-cast.
       block = first_child("[NOTE]\n--\nwatch out\n--\n")

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/open_block_typed_cast_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/open_block_typed_cast_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+
+# Open blocks (`--`) are generic containers in AsciiDoc. A positional
+# style attribute on the open block can cast it into a richer semantic
+# type — e.g. `[sidebar]\n--\nSide\n--` is semantically a sidebar,
+# not an open block. Single source of truth for the cast ladder lives
+# in BlockTransformer::TYPED_BLOCK_CAST_STYLES.
+RSpec.describe 'Open-block typed casts', :asciidoc do
+  def first_child(adoc)
+    Coradoc.parse(adoc, format: :asciidoc).children.first
+  end
+
+  describe '[sidebar] cast' do
+    it 'casts an open block into a SidebarBlock' do
+      block = first_child("[sidebar]\n--\nSide content\n--\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::SidebarBlock)
+      expect(block.content).to eq('Side content')
+    end
+  end
+
+  describe '[example] cast' do
+    it 'casts an open block into an ExampleBlock' do
+      block = first_child("[example]\n--\nExample body\n--\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::ExampleBlock)
+      expect(block.content).to eq('Example body')
+    end
+  end
+
+  describe '[quote] cast' do
+    it 'casts an open block into a QuoteBlock' do
+      block = first_child("[quote]\n--\nQuoted text\n--\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::QuoteBlock)
+      expect(block.content).to eq('Quoted text')
+    end
+  end
+
+  describe 'uncast open block' do
+    it 'keeps a plain open block as OpenBlock' do
+      block = first_child("--\nJust open\n--\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::OpenBlock)
+    end
+  end
+
+  describe 'cast precedence (admonition > typed)' do
+    it 'prefers admonition when both could apply' do
+      # [NOTE] is an admonition label, not a typed-cast style.
+      # The cast ladder resolves admonition before typed-cast.
+      block = first_child("[NOTE]\n--\nwatch out\n--\n")
+
+      expect(block).to be_a(Coradoc::CoreModel::AnnotationBlock)
+      expect(block.annotation_type).to eq('NOTE')
+    end
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/source_line_propagation_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/source_line_propagation_spec.rb
@@ -1,0 +1,303 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+
+# Source-line propagation (Issue 1, STATUS-2026-06-28).
+#
+# Every CoreModel block must carry a 1-indexed +source_line+ so consumers
+# (linters, formatters, editor integrations) can map AST nodes back to the
+# source text. Parslet tracks byte offsets on every +Parslet::Slice+; the
+# AsciiDoc transformer funnels those positions through
+# +Transformer::SourceLineExtractor+ into +Model::Base#source_line+, and
+# the ToCoreModel transformers propagate the line onto the corresponding
+# CoreModel types.
+RSpec.describe 'Source-line propagation', :asciidoc do
+  def parse(adoc)
+    Coradoc.parse(adoc, format: :asciidoc)
+  end
+
+  def first_child(adoc)
+    parse(adoc).children.first
+  end
+
+  describe 'paragraphs' do
+    it 'records the line of the first paragraph' do
+      doc = parse("Para 1\n\nPara 2\n")
+      expect(doc.children[0].source_line).to eq(1)
+    end
+
+    it 'records the line of subsequent paragraphs' do
+      doc = parse("Para 1\n\nPara 2\n")
+      expect(doc.children[1].source_line).to eq(3)
+    end
+
+    it 'records correct lines when paragraphs are offset by a header' do
+      doc = parse("= Title\n\nFirst body paragraph.\n\nSecond body paragraph.\n")
+      paragraphs = doc.children.grep(Coradoc::CoreModel::ParagraphBlock)
+      expect(paragraphs[0].source_line).to eq(3)
+      expect(paragraphs[1].source_line).to eq(5)
+    end
+  end
+
+  describe 'sections' do
+    it 'records the line of the section heading' do
+      adoc = <<~ADOC
+        Preamble paragraph.
+
+        == Section A
+
+        Body under A.
+      ADOC
+      section = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::SectionElement) }
+      expect(section.source_line).to eq(3)
+    end
+
+    it 'records nested section lines' do
+      adoc = <<~ADOC
+        == Parent
+
+        Parent body.
+
+        === Child
+      ADOC
+      parent = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::SectionElement) }
+      child = parent.children.find { |c| c.is_a?(Coradoc::CoreModel::SectionElement) }
+      expect(parent.source_line).to eq(1)
+      expect(child.source_line).to eq(5)
+    end
+  end
+
+  describe 'delimited blocks' do
+    it 'records the line of a source block' do
+      adoc = <<~ADOC
+        Para.
+
+        [source,ruby]
+        ----
+        puts 1
+        ----
+      ADOC
+      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::SourceBlock) }
+      expect(block.source_line).to eq(3)
+    end
+
+    it 'records the line of an example block' do
+      adoc = <<~ADOC
+        Para.
+
+        ====
+        Example body.
+        ====
+      ADOC
+      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::ExampleBlock) }
+      expect(block.source_line).to eq(3)
+    end
+
+    it 'records the line of a quote block' do
+      adoc = <<~ADOC
+        Para.
+
+        ____
+        Quote body.
+        ____
+      ADOC
+      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::QuoteBlock) }
+      expect(block.source_line).to eq(3)
+    end
+
+    it 'records the line of a sidebar block' do
+      adoc = <<~ADOC
+        Para.
+
+        ****
+        Sidebar body.
+        ****
+      ADOC
+      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::SidebarBlock) }
+      expect(block.source_line).to eq(3)
+    end
+
+    it 'records the line of a literal block' do
+      adoc = <<~ADOC
+        Para.
+
+        ....
+          Indented literal.
+        ....
+      ADOC
+      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::LiteralBlock) }
+      expect(block.source_line).to eq(3)
+    end
+  end
+
+  describe 'lists' do
+    it 'records the line of a unordered list' do
+      adoc = <<~ADOC
+        Para.
+
+        * one
+        * two
+      ADOC
+      list = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      expect(list.source_line).to eq(3)
+    end
+
+    it 'records source_line on individual list items' do
+      adoc = <<~ADOC
+        * one
+        * two
+        * three
+      ADOC
+      list = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      expect(list.items[0].source_line).to eq(1)
+      expect(list.items[1].source_line).to eq(2)
+      expect(list.items[2].source_line).to eq(3)
+    end
+
+    it 'records the line of an ordered list' do
+      adoc = <<~ADOC
+        Para.
+
+        . one
+        . two
+      ADOC
+      list = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      expect(list.source_line).to eq(3)
+    end
+  end
+
+  describe 'tables' do
+    it 'records the line of a table' do
+      adoc = <<~ADOC
+        Para.
+
+        |===
+        | A | B
+        | 1 | 2
+        |===
+      ADOC
+      table = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::Table) }
+      expect(table.source_line).to eq(3)
+    end
+  end
+
+  describe 'admonitions' do
+    it 'records the line of a line-form admonition' do
+      adoc = <<~ADOC
+        Para.
+
+        NOTE: This is a note.
+      ADOC
+      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::AnnotationBlock) }
+      expect(block.source_line).to eq(3)
+    end
+
+    it 'records the line of a block-form admonition' do
+      adoc = <<~ADOC
+        Para.
+
+        [NOTE]
+        ====
+        Block note body.
+        ====
+      ADOC
+      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::AnnotationBlock) }
+      expect(block.source_line).to eq(3)
+    end
+  end
+
+  describe 'block images' do
+    it 'records the line of a block image' do
+      adoc = <<~ADOC
+        Para.
+
+        image::diagram.png[]
+      ADOC
+      image = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::Image) }
+      expect(image.source_line).to eq(3)
+    end
+  end
+
+  describe 'typed cast blocks (abstract/partintro)' do
+    it 'records the line of an abstract block' do
+      adoc = <<~ADOC
+        Para.
+
+        [abstract]
+        ====
+        Abstract text.
+        ====
+      ADOC
+      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::AbstractBlock) }
+      expect(block.source_line).to eq(3)
+    end
+
+    it 'records the line of a partintro block' do
+      adoc = <<~ADOC
+        = Book
+
+        [partintro]
+        --
+        Introduction to the part.
+        --
+      ADOC
+      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::PartintroBlock) }
+      expect(block.source_line).to eq(3)
+    end
+  end
+
+  describe 'SourceLineExtractor' do
+    let(:extractor) { Coradoc::AsciiDoc::Transformer::SourceLineExtractor }
+
+    it 'returns nil for untracked values' do
+      expect(extractor.extract(nil)).to be_nil
+      expect(extractor.extract('string')).to be_nil
+      expect(extractor.extract(123)).to be_nil
+    end
+
+    it 'returns source_line of a Model::Base' do
+      model = Coradoc::AsciiDoc::Model::TextElement.new(content: 'x', source_line: 42)
+      expect(extractor.extract(model)).to eq(42)
+    end
+
+    it 'walks a Hash to find the first source_line' do
+      model_with_line = Coradoc::AsciiDoc::Model::TextElement.new(content: 'x', source_line: 7)
+      hash = { a: nil, b: model_with_line }
+      expect(extractor.extract(hash)).to eq(7)
+    end
+
+    it 'walks an Array to find the first source_line' do
+      model_with_line = Coradoc::AsciiDoc::Model::TextElement.new(content: 'x', source_line: 11)
+      expect(extractor.extract([nil, model_with_line])).to eq(11)
+    end
+
+    it 'extracts source_line from Parslet Slices produced by the parser' do
+      parser = Coradoc::AsciiDoc::Parser::Base.new
+      ast = parser.parse("line one\nline two\n")
+      # Walk to a leaf Slice in the parsed tree.
+      first_slice = find_first_slice(ast)
+      expect(first_slice).to be_a(Parslet::Slice)
+      line = extractor.extract(first_slice)
+      expect(line).to eq(1)
+    end
+
+    def find_first_slice(node)
+      return node if node.is_a?(Parslet::Slice)
+
+      case node
+      when Hash
+        node.each_value do |v|
+          s = find_first_slice(v)
+          return s if s
+        end
+      when Array
+        node.each do |v|
+          s = find_first_slice(v)
+          return s if s
+        end
+      end
+      nil
+    end
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/source_line_propagation_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/source_line_propagation_spec.rb
@@ -3,6 +3,45 @@
 require 'spec_helper'
 require 'coradoc/asciidoc'
 
+# Walks a parsed Parslet AST tree (Hash/Array/Slice) and returns the
+# first +Parslet::Slice+ encountered. Used by the SourceLineExtractor
+# spec to exercise the real Slice code path without hand-constructing
+# a Parslet::Slice (which requires a line_cache).
+class SliceFinder
+  class << self
+    def first(node)
+      return node if node.is_a?(Parslet::Slice)
+
+      walk(node)
+    end
+
+    private
+
+    def walk(node)
+      return nil unless node.is_a?(Enumerable)
+      return walk_pairs(node) if node.is_a?(Hash)
+
+      walk_array(node)
+    end
+
+    def walk_pairs(hash)
+      hash.each_value do |v|
+        s = first(v)
+        return s if s
+      end
+      nil
+    end
+
+    def walk_array(array)
+      array.each do |v|
+        s = first(v)
+        return s if s
+      end
+      nil
+    end
+  end
+end
+
 # Source-line propagation (Issue 1, STATUS-2026-06-28).
 #
 # Every CoreModel block must carry a 1-indexed +source_line+ so consumers
@@ -13,291 +52,180 @@ require 'coradoc/asciidoc'
 # the ToCoreModel transformers propagate the line onto the corresponding
 # CoreModel types.
 RSpec.describe 'Source-line propagation', :asciidoc do
+  let(:extractor) { Coradoc::AsciiDoc::Transformer::SourceLineExtractor }
+  let(:two_paras) { parse("Para 1\n\nPara 2\n") }
+
   def parse(adoc)
     Coradoc.parse(adoc, format: :asciidoc)
   end
 
-  def first_child(adoc)
-    parse(adoc).children.first
+  def find_child(parsed, type)
+    parsed.children.find { |c| c.is_a?(type) }
   end
 
-  describe 'paragraphs' do
-    it 'records the line of the first paragraph' do
-      doc = parse("Para 1\n\nPara 2\n")
-      expect(doc.children[0].source_line).to eq(1)
-    end
-
-    it 'records the line of subsequent paragraphs' do
-      doc = parse("Para 1\n\nPara 2\n")
-      expect(doc.children[1].source_line).to eq(3)
-    end
-
-    it 'records correct lines when paragraphs are offset by a header' do
-      doc = parse("= Title\n\nFirst body paragraph.\n\nSecond body paragraph.\n")
-      paragraphs = doc.children.grep(Coradoc::CoreModel::ParagraphBlock)
-      expect(paragraphs[0].source_line).to eq(3)
-      expect(paragraphs[1].source_line).to eq(5)
-    end
+  def block_at_line(adoc, type)
+    find_child(parse(adoc), type).source_line
   end
 
-  describe 'sections' do
-    it 'records the line of the section heading' do
-      adoc = <<~ADOC
-        Preamble paragraph.
-
-        == Section A
-
-        Body under A.
-      ADOC
-      section = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::SectionElement) }
-      expect(section.source_line).to eq(3)
-    end
-
-    it 'records nested section lines' do
-      adoc = <<~ADOC
-        == Parent
-
-        Parent body.
-
-        === Child
-      ADOC
-      parent = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::SectionElement) }
-      child = parent.children.find { |c| c.is_a?(Coradoc::CoreModel::SectionElement) }
-      expect(parent.source_line).to eq(1)
-      expect(child.source_line).to eq(5)
-    end
+  def child_source_lines(parsed, type)
+    find_child(parsed, type).children.map(&:source_line)
   end
 
-  describe 'delimited blocks' do
-    it 'records the line of a source block' do
-      adoc = <<~ADOC
-        Para.
-
-        [source,ruby]
-        ----
-        puts 1
-        ----
-      ADOC
-      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::SourceBlock) }
-      expect(block.source_line).to eq(3)
-    end
-
-    it 'records the line of an example block' do
-      adoc = <<~ADOC
-        Para.
-
-        ====
-        Example body.
-        ====
-      ADOC
-      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::ExampleBlock) }
-      expect(block.source_line).to eq(3)
-    end
-
-    it 'records the line of a quote block' do
-      adoc = <<~ADOC
-        Para.
-
-        ____
-        Quote body.
-        ____
-      ADOC
-      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::QuoteBlock) }
-      expect(block.source_line).to eq(3)
-    end
-
-    it 'records the line of a sidebar block' do
-      adoc = <<~ADOC
-        Para.
-
-        ****
-        Sidebar body.
-        ****
-      ADOC
-      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::SidebarBlock) }
-      expect(block.source_line).to eq(3)
-    end
-
-    it 'records the line of a literal block' do
-      adoc = <<~ADOC
-        Para.
-
-        ....
-          Indented literal.
-        ....
-      ADOC
-      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::LiteralBlock) }
-      expect(block.source_line).to eq(3)
-    end
+  it 'records the line of the first paragraph' do
+    expect(two_paras.children[0].source_line).to eq(1)
   end
 
-  describe 'lists' do
-    it 'records the line of a unordered list' do
-      adoc = <<~ADOC
-        Para.
-
-        * one
-        * two
-      ADOC
-      list = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
-      expect(list.source_line).to eq(3)
-    end
-
-    it 'records source_line on individual list items' do
-      adoc = <<~ADOC
-        * one
-        * two
-        * three
-      ADOC
-      list = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
-      expect(list.items[0].source_line).to eq(1)
-      expect(list.items[1].source_line).to eq(2)
-      expect(list.items[2].source_line).to eq(3)
-    end
-
-    it 'records the line of an ordered list' do
-      adoc = <<~ADOC
-        Para.
-
-        . one
-        . two
-      ADOC
-      list = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
-      expect(list.source_line).to eq(3)
-    end
+  it 'records the line of subsequent paragraphs' do
+    expect(two_paras.children[1].source_line).to eq(3)
   end
 
-  describe 'tables' do
-    it 'records the line of a table' do
-      adoc = <<~ADOC
-        Para.
-
-        |===
-        | A | B
-        | 1 | 2
-        |===
-      ADOC
-      table = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::Table) }
-      expect(table.source_line).to eq(3)
-    end
+  it 'records correct lines when paragraphs are offset by a header' do
+    doc = parse("= Title\n\nFirst body paragraph.\n\nSecond body paragraph.\n")
+    paragraphs = doc.children.grep(Coradoc::CoreModel::ParagraphBlock)
+    expect(paragraphs.map(&:source_line)).to eq([3, 5])
   end
 
-  describe 'admonitions' do
-    it 'records the line of a line-form admonition' do
-      adoc = <<~ADOC
-        Para.
-
-        NOTE: This is a note.
-      ADOC
-      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::AnnotationBlock) }
-      expect(block.source_line).to eq(3)
-    end
-
-    it 'records the line of a block-form admonition' do
-      adoc = <<~ADOC
-        Para.
-
-        [NOTE]
-        ====
-        Block note body.
-        ====
-      ADOC
-      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::AnnotationBlock) }
-      expect(block.source_line).to eq(3)
-    end
+  it 'records the line of the section heading' do
+    adoc = "Preamble paragraph.\n\n== Section A\n\nBody under A.\n"
+    expect(find_child(parse(adoc), Coradoc::CoreModel::SectionElement).source_line).to eq(3)
   end
 
-  describe 'block images' do
-    it 'records the line of a block image' do
-      adoc = <<~ADOC
-        Para.
-
-        image::diagram.png[]
-      ADOC
-      image = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::Image) }
-      expect(image.source_line).to eq(3)
-    end
+  it 'records nested section lines' do
+    adoc = "== Parent\n\nParent body.\n\n=== Child\n"
+    parent = find_child(parse(adoc), Coradoc::CoreModel::SectionElement)
+    child = find_child(parent, Coradoc::CoreModel::SectionElement)
+    expect([parent.source_line, child.source_line]).to eq([1, 5])
   end
 
-  describe 'typed cast blocks (abstract/partintro)' do
-    it 'records the line of an abstract block' do
-      adoc = <<~ADOC
-        Para.
-
-        [abstract]
-        ====
-        Abstract text.
-        ====
-      ADOC
-      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::AbstractBlock) }
-      expect(block.source_line).to eq(3)
-    end
-
-    it 'records the line of a partintro block' do
-      adoc = <<~ADOC
-        = Book
-
-        [partintro]
-        --
-        Introduction to the part.
-        --
-      ADOC
-      block = parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::PartintroBlock) }
-      expect(block.source_line).to eq(3)
-    end
+  it 'records the line of a source block' do
+    adoc = "Para.\n\n[source,ruby]\n----\nputs 1\n----\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::SourceBlock)).to eq(3)
   end
 
-  describe 'SourceLineExtractor' do
-    let(:extractor) { Coradoc::AsciiDoc::Transformer::SourceLineExtractor }
+  it 'records the line of an example block' do
+    adoc = "Para.\n\n====\nExample body.\n====\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::ExampleBlock)).to eq(3)
+  end
 
-    it 'returns nil for untracked values' do
-      expect(extractor.extract(nil)).to be_nil
-      expect(extractor.extract('string')).to be_nil
-      expect(extractor.extract(123)).to be_nil
+  it 'records the line of a quote block' do
+    adoc = "Para.\n\n____\nQuote body.\n____\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::QuoteBlock)).to eq(3)
+  end
+
+  it 'records the line of a sidebar block' do
+    adoc = "Para.\n\n****\nSidebar body.\n****\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::SidebarBlock)).to eq(3)
+  end
+
+  it 'records the line of a literal block' do
+    adoc = "Para.\n\n....\n  Indented literal.\n....\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::LiteralBlock)).to eq(3)
+  end
+
+  it 'records the line of an unordered list' do
+    adoc = "Para.\n\n* one\n* two\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::ListBlock)).to eq(3)
+  end
+
+  it 'records source_line on individual list items' do
+    list = find_child(parse("* one\n* two\n* three\n"), Coradoc::CoreModel::ListBlock)
+    expect(list.items.map(&:source_line)).to eq([1, 2, 3])
+  end
+
+  it 'records the line of an ordered list' do
+    adoc = "Para.\n\n. one\n. two\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::ListBlock)).to eq(3)
+  end
+
+  it 'records the line of a table' do
+    adoc = "Para.\n\n|===\n| A | B\n| 1 | 2\n|===\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::Table)).to eq(3)
+  end
+
+  it 'records the line of a line-form admonition' do
+    adoc = "Para.\n\nNOTE: This is a note.\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::AnnotationBlock)).to eq(3)
+  end
+
+  it 'records the line of a block-form admonition' do
+    adoc = "Para.\n\n[NOTE]\n====\nBlock note body.\n====\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::AnnotationBlock)).to eq(3)
+  end
+
+  it 'records the line of a block image' do
+    adoc = "Para.\n\nimage::diagram.png[]\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::Image)).to eq(3)
+  end
+
+  it 'records the line of an abstract block' do
+    adoc = "Para.\n\n[abstract]\n====\nAbstract text.\n====\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::AbstractBlock)).to eq(3)
+  end
+
+  it 'records the line of a partintro block' do
+    adoc = "= Book\n\n[partintro]\n--\nIntroduction to the part.\n--\n"
+    expect(block_at_line(adoc, Coradoc::CoreModel::PartintroBlock)).to eq(3)
+  end
+
+  describe Coradoc::AsciiDoc::Transformer::SourceLineExtractor do
+    subject(:line) { described_class.extract(node) }
+
+    context 'with nil' do
+      let(:node) { nil }
+
+      it { is_expected.to be_nil }
     end
 
-    it 'returns source_line of a Model::Base' do
-      model = Coradoc::AsciiDoc::Model::TextElement.new(content: 'x', source_line: 42)
-      expect(extractor.extract(model)).to eq(42)
+    context 'with a String' do
+      let(:node) { 'string' }
+
+      it { is_expected.to be_nil }
     end
 
-    it 'walks a Hash to find the first source_line' do
-      model_with_line = Coradoc::AsciiDoc::Model::TextElement.new(content: 'x', source_line: 7)
-      hash = { a: nil, b: model_with_line }
-      expect(extractor.extract(hash)).to eq(7)
+    context 'with a Numeric' do
+      let(:node) { 123 }
+
+      it { is_expected.to be_nil }
     end
 
-    it 'walks an Array to find the first source_line' do
-      model_with_line = Coradoc::AsciiDoc::Model::TextElement.new(content: 'x', source_line: 11)
-      expect(extractor.extract([nil, model_with_line])).to eq(11)
-    end
-
-    it 'extracts source_line from Parslet Slices produced by the parser' do
-      parser = Coradoc::AsciiDoc::Parser::Base.new
-      ast = parser.parse("line one\nline two\n")
-      # Walk to a leaf Slice in the parsed tree.
-      first_slice = find_first_slice(ast)
-      expect(first_slice).to be_a(Parslet::Slice)
-      line = extractor.extract(first_slice)
-      expect(line).to eq(1)
-    end
-
-    def find_first_slice(node)
-      return node if node.is_a?(Parslet::Slice)
-
-      case node
-      when Hash
-        node.each_value do |v|
-          s = find_first_slice(v)
-          return s if s
-        end
-      when Array
-        node.each do |v|
-          s = find_first_slice(v)
-          return s if s
-        end
+    context 'with a Model::Base carrying source_line' do
+      let(:node) do
+        Coradoc::AsciiDoc::Model::TextElement.new(content: 'x', source_line: 42)
       end
-      nil
+
+      it { is_expected.to eq(42) }
+    end
+
+    context 'with a Hash containing a Model::Base' do
+      let(:node) do
+        { a: nil,
+          b: Coradoc::AsciiDoc::Model::TextElement.new(content: 'x', source_line: 7) }
+      end
+
+      it { is_expected.to eq(7) }
+    end
+
+    context 'with an Array containing a Model::Base' do
+      let(:node) do
+        [nil, Coradoc::AsciiDoc::Model::TextElement.new(content: 'x', source_line: 11)]
+      end
+
+      it { is_expected.to eq(11) }
+    end
+
+    context 'with a real Parslet::Slice from the parser' do
+      let(:node) do
+        ast = Coradoc::AsciiDoc::Parser::Base.new.parse("line one\nline two\n")
+        SliceFinder.first(ast)
+      end
+
+      it 'returns the 1-indexed source line' do
+        expect(line).to eq(1)
+      end
+
+      it 'is a Parslet::Slice' do
+        expect(node).to be_a(Parslet::Slice)
+      end
     end
   end
 end

--- a/coradoc-mirror/lib/coradoc/mirror.rb
+++ b/coradoc-mirror/lib/coradoc/mirror.rb
@@ -75,6 +75,8 @@ module Coradoc
       registry.register(CoreModel::QuoteBlock, Handlers::Blockquote)
       registry.register(CoreModel::ExampleBlock, Handlers::Example)
       registry.register(CoreModel::SidebarBlock, Handlers::Sidebar)
+      registry.register(CoreModel::AbstractBlock, Handlers::Abstract)
+      registry.register(CoreModel::PartintroBlock, Handlers::Partintro)
       registry.register(CoreModel::OpenBlock, Handlers::OpenBlock)
       registry.register(CoreModel::VerseBlock, Handlers::Verse)
       registry.register(CoreModel::CommentBlock, Handlers::Comment)

--- a/coradoc-mirror/lib/coradoc/mirror/handlers.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers.rb
@@ -17,6 +17,8 @@ module Coradoc
       autoload :Blockquote, "#{__dir__}/handlers/blockquote"
       autoload :Example, "#{__dir__}/handlers/example"
       autoload :Sidebar, "#{__dir__}/handlers/sidebar"
+      autoload :Abstract, "#{__dir__}/handlers/abstract"
+      autoload :Partintro, "#{__dir__}/handlers/partintro"
       autoload :OpenBlock, "#{__dir__}/handlers/open_block"
       autoload :Verse, "#{__dir__}/handlers/verse"
       autoload :Comment, "#{__dir__}/handlers/comment"

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/abstract.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/abstract.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Abstract
+        def self.call(element, context:)
+          content = context.extract_content(element)
+          return nil if content.empty?
+
+          Node::Abstract.new(
+            attrs: Node::Abstract::Attrs.new(id: element.id, title: element.title),
+            content: content
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
@@ -102,7 +102,9 @@ module Coradoc
               build_span_mark(element, context)
             when CoreModel::FootnoteElement
               build_footnote_node(element, context)
-            when CoreModel::HardLineBreakElement, CoreModel::LineBreakElement
+            when CoreModel::HardLineBreakElement
+              Node::HardBreak.new
+            when CoreModel::LineBreakElement
               Node::SoftBreak.new
             when CoreModel::TextElement
               build_text_only(element, context)

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/partintro.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/partintro.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module Mirror
+    module Handlers
+      module Partintro
+        def self.call(element, context:)
+          content = context.extract_content(element)
+          return nil if content.empty?
+
+          Node::Partintro.new(
+            attrs: Node::Partintro::Attrs.new(id: element.id, title: element.title),
+            content: content
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/node.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/node.rb
@@ -303,6 +303,60 @@ module Coradoc
         end
       end
 
+      # Abstract block — `[abstract]\n====\n...\n====` in AsciiDoc. Carries
+      # the same shape as Sidebar/Example but a distinct wire type so the
+      # block-level construct does not collide with the section-level
+      # `abstract` (one of Section's PM_ALIASES). The block preserves its
+      # block identity through round-trip; renderers that want a section
+      # view should look at SectionElement-style sources instead.
+      class Abstract < Node
+        PM_TYPE = 'abstract_block'
+
+        class Attrs < Lutaml::Model::Serializable
+          attribute :title, :string
+          attribute :id, :string
+
+          key_value do
+            map 'title', to: :title
+            map 'id', to: :id
+          end
+        end
+
+        attribute :attrs, Attrs
+
+        key_value do
+          map 'type', to: :type, render_default: true
+          map 'attrs', to: :attrs
+          map 'content', to: :content, polymorphic: Node::POLYMORPHIC
+        end
+      end
+
+      # Partintro block — `[partintro]\n====\n...\n====` in AsciiDoc, used
+      # to introduce a "part" in multi-part documents. Distinct wire type
+      # for the same reason as Abstract (no collision with potential
+      # section-level uses of "partintro").
+      class Partintro < Node
+        PM_TYPE = 'partintro_block'
+
+        class Attrs < Lutaml::Model::Serializable
+          attribute :title, :string
+          attribute :id, :string
+
+          key_value do
+            map 'title', to: :title
+            map 'id', to: :id
+          end
+        end
+
+        attribute :attrs, Attrs
+
+        key_value do
+          map 'type', to: :type, render_default: true
+          map 'attrs', to: :attrs
+          map 'content', to: :content, polymorphic: Node::POLYMORPHIC
+        end
+      end
+
       class OpenBlock < Node
         PM_TYPE = 'open_block'
 
@@ -342,6 +396,15 @@ module Coradoc
 
       class SoftBreak < Node
         PM_TYPE = 'soft_break'
+      end
+
+      # Hard line break — author-requested explicit break (`foo +\nbar` in
+      # AsciiDoc, `<br>` semantics in HTML). Distinct from SoftBreak so
+      # downstream renderers can map it to `<br>` rather than collapsing
+      # the break into a soft newline-or-space convention. ProseMirror's
+      # schema uses `hard_break` for the same purpose.
+      class HardBreak < Node
+        PM_TYPE = 'hard_break'
       end
 
       # ── Admonition (NOTE, TIP, WARNING, CAUTION, IMPORTANT) ──

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
@@ -62,6 +62,8 @@ module Coradoc
       require_relative 'reverse_builder/blockquote'
       require_relative 'reverse_builder/example'
       require_relative 'reverse_builder/sidebar'
+      require_relative 'reverse_builder/abstract'
+      require_relative 'reverse_builder/partintro'
       require_relative 'reverse_builder/open_block'
       require_relative 'reverse_builder/verse'
       require_relative 'reverse_builder/horizontal_rule'
@@ -91,6 +93,7 @@ module Coradoc
       require_relative 'reverse_builder/text'
       require_relative 'reverse_builder/raw_inline'
       require_relative 'reverse_builder/soft_break'
+      require_relative 'reverse_builder/hard_break'
       require_relative 'reverse_builder/generic_block'
     end
   end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/abstract.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/abstract.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Abstract < Base
+        registers 'abstract_block'
+
+        def build(node)
+          CoreModel::AbstractBlock.new(
+            title: node.attrs&.title,
+            id: node.attrs&.id,
+            children: build_content(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/hard_break.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/hard_break.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class HardBreak < Base
+        registers 'hard_break'
+
+        def build(_node)
+          CoreModel::HardLineBreakElement.new(content: '')
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/partintro.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/partintro.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Coradoc
+  module Mirror
+    module ReverseBuilder
+      class Partintro < Base
+        registers 'partintro_block'
+
+        def build(node)
+          CoreModel::PartintroBlock.new(
+            title: node.attrs&.title,
+            id: node.attrs&.id,
+            children: build_content(node)
+          )
+        end
+      end
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/handlers/inline_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/handlers/inline_spec.rb
@@ -112,4 +112,47 @@ RSpec.describe Coradoc::Mirror::Handlers::Inline do
       expect(json2).to eq(json1)
     end
   end
+
+  describe 'hard line break (foo +\nbar)' do
+    # Author-requested explicit break must map to a distinct ProseMirror
+    # node type so downstream renderers can emit `<br>` rather than a
+    # soft line wrap. Collapsing to SoftBreak silently lost the break.
+    it 'dispatches HardLineBreakElement to a hard_break node' do
+      hard_break = Coradoc::CoreModel::HardLineBreakElement.new(content: '')
+      node = described_class.call(hard_break, context: context)
+
+      expect(node).to be_a(Coradoc::Mirror::Node::HardBreak)
+      expect(node.type).to eq('hard_break')
+    end
+
+    it 'dispatches LineBreakElement to a soft_break node' do
+      soft_break = Coradoc::CoreModel::LineBreakElement.new(content: '')
+      node = described_class.call(soft_break, context: context)
+
+      expect(node).to be_a(Coradoc::Mirror::Node::SoftBreak)
+      expect(node.type).to eq('soft_break')
+    end
+
+    it 'round-trips hard_break through mirror_json → CoreModel → mirror_json' do
+      original = Coradoc::CoreModel::ParagraphBlock.new(
+        children: [
+          Coradoc::CoreModel::TextContent.new(text: 'foo'),
+          Coradoc::CoreModel::HardLineBreakElement.new(content: ''),
+          Coradoc::CoreModel::TextContent.new(text: 'bar')
+        ]
+      )
+      json1 = Coradoc.serialize(original, to: :mirror_json)
+
+      parsed_node = Coradoc::Mirror.from_hash(JSON.parse(json1))
+      document = Coradoc::Mirror::MirrorToCoreModel.new.call(parsed_node)
+
+      hard_break = Array(document.children).find do |child|
+        child.is_a?(Coradoc::CoreModel::HardLineBreakElement)
+      end
+      expect(hard_break).not_to be_nil
+
+      json2 = Coradoc.serialize(document, to: :mirror_json)
+      expect(json2).to eq(json1)
+    end
+  end
 end

--- a/coradoc-mirror/spec/coradoc/mirror/named_block_styles_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/named_block_styles_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+# Mirror-side coverage for the named block styles that previously collapsed
+# to `example` (Issue 2 from STATUS-2026-06-28). Each style now has:
+#
+#   - a dedicated CoreModel class (AbstractBlock / PartintroBlock)
+#   - a dedicated Mirror::Node class (Node::Abstract / Node::Partintro)
+#   - a Handler that maps CoreModel → Mirror node
+#   - a ReverseBuilder that maps Mirror node → CoreModel
+#
+# The wire names are `abstract_block` and `partintro_block` so they do
+# not collide with the Section PM_ALIAS `abstract` (used for section-style
+# abstracts). The generic `[admonition]` style reuses the existing
+# Admonition node with `attrs.type: "ADMONITION"`.
+RSpec.describe 'Named block style mirror coverage', :asciidoc do
+  let(:reverse) { Coradoc::Mirror::MirrorToCoreModel.new }
+
+  describe 'CoreModel::AbstractBlock → Mirror' do
+    it 'emits a Node::Abstract with PM_TYPE "abstract_block"' do
+      block = Coradoc::CoreModel::AbstractBlock.new(
+        content: 'Abstract body',
+        title: 'Abs',
+        id: 'abs-1'
+      )
+      doc = Coradoc::CoreModel::DocumentElement.new(children: [block])
+
+      node = Coradoc::Mirror.transform(doc).content.first
+      expect(node).to be_a(Coradoc::Mirror::Node::Abstract)
+      expect(node.type).to eq('abstract_block')
+      expect(node.attrs.title).to eq('Abs')
+      expect(node.attrs.id).to eq('abs-1')
+    end
+
+    it 'renders the type attribute on the wire' do
+      block = Coradoc::CoreModel::AbstractBlock.new(content: 'x')
+      doc = Coradoc::CoreModel::DocumentElement.new(children: [block])
+
+      hash = Coradoc::Mirror.transform(doc).content.first.to_hash
+      expect(hash['type']).to eq('abstract_block')
+    end
+  end
+
+  describe 'CoreModel::PartintroBlock → Mirror' do
+    it 'emits a Node::Partintro with PM_TYPE "partintro_block"' do
+      block = Coradoc::CoreModel::PartintroBlock.new(
+        content: 'Part intro',
+        title: 'Part 1',
+        id: 'pi-1'
+      )
+      doc = Coradoc::CoreModel::DocumentElement.new(children: [block])
+
+      node = Coradoc::Mirror.transform(doc).content.first
+      expect(node).to be_a(Coradoc::Mirror::Node::Partintro)
+      expect(node.type).to eq('partintro_block')
+      expect(node.attrs.title).to eq('Part 1')
+      expect(node.attrs.id).to eq('pi-1')
+    end
+  end
+
+  describe 'Handlers::Abstract' do
+    it 'returns nil for empty content (no abstract emitted)' do
+      block = Coradoc::CoreModel::AbstractBlock.new(content: '', children: [])
+      node = Coradoc::Mirror::Handlers::Abstract.call(
+        block, context: Coradoc::Mirror::CoreModelToMirror.new
+      )
+      expect(node).to be_nil
+    end
+  end
+
+  describe 'Handlers::Partintro' do
+    it 'returns nil for empty content (no partintro emitted)' do
+      block = Coradoc::CoreModel::PartintroBlock.new(content: '', children: [])
+      node = Coradoc::Mirror::Handlers::Partintro.call(
+        block, context: Coradoc::Mirror::CoreModelToMirror.new
+      )
+      expect(node).to be_nil
+    end
+  end
+
+  describe 'reverse builder: abstract_block → AbstractBlock' do
+    it 'round-trips Node::Abstract back to CoreModel::AbstractBlock' do
+      mirror = Coradoc::Mirror::Node::Abstract.new(
+        attrs: Coradoc::Mirror::Node::Abstract::Attrs.new(
+          title: 'Abs', id: 'abs-1'
+        ),
+        content: [Coradoc::Mirror::Node::Text.new(text: 'body')]
+      )
+      doc = Coradoc::Mirror::Node::Document.new(content: [mirror])
+
+      core = reverse.call(doc)
+      expect(core.children.first).to be_a(Coradoc::CoreModel::AbstractBlock)
+      expect(core.children.first.title).to eq('Abs')
+      expect(core.children.first.id).to eq('abs-1')
+    end
+  end
+
+  describe 'reverse builder: partintro_block → PartintroBlock' do
+    it 'round-trips Node::Partintro back to CoreModel::PartintroBlock' do
+      mirror = Coradoc::Mirror::Node::Partintro.new(
+        attrs: Coradoc::Mirror::Node::Partintro::Attrs.new(
+          title: 'Part 1', id: 'pi-1'
+        ),
+        content: [Coradoc::Mirror::Node::Text.new(text: 'intro')]
+      )
+      doc = Coradoc::Mirror::Node::Document.new(content: [mirror])
+
+      core = reverse.call(doc)
+      expect(core.children.first).to be_a(Coradoc::CoreModel::PartintroBlock)
+      expect(core.children.first.title).to eq('Part 1')
+      expect(core.children.first.id).to eq('pi-1')
+    end
+  end
+
+  describe 'JSON round-trip (forward → JSON → reverse → CoreModel)' do
+    it 'preserves AbstractBlock identity through JSON' do
+      original = Coradoc::CoreModel::DocumentElement.new(
+        children: [
+          Coradoc::CoreModel::AbstractBlock.new(
+            title: 'Abs',
+            children: [Coradoc::CoreModel::ParagraphBlock.new(content: 'Body')]
+          )
+        ]
+      )
+      json1 = Coradoc.serialize(original, to: :mirror_json)
+      parsed = Coradoc::Mirror.from_hash(JSON.parse(json1))
+      rebuilt = reverse.call(parsed)
+
+      expect(rebuilt.children.first).to be_a(Coradoc::CoreModel::AbstractBlock)
+      expect(rebuilt.children.first.title).to eq('Abs')
+
+      # JSON shape is stable across the round-trip.
+      json2 = Coradoc.serialize(rebuilt, to: :mirror_json)
+      expect(JSON.parse(json2)).to eq(JSON.parse(json1))
+    end
+
+    it 'preserves PartintroBlock identity through JSON' do
+      original = Coradoc::CoreModel::DocumentElement.new(
+        children: [
+          Coradoc::CoreModel::PartintroBlock.new(
+            title: 'Intro',
+            children: [Coradoc::CoreModel::ParagraphBlock.new(content: 'Body')]
+          )
+        ]
+      )
+      json1 = Coradoc.serialize(original, to: :mirror_json)
+      parsed = Coradoc::Mirror.from_hash(JSON.parse(json1))
+      rebuilt = reverse.call(parsed)
+
+      expect(rebuilt.children.first).to be_a(Coradoc::CoreModel::PartintroBlock)
+      expect(rebuilt.children.first.title).to eq('Intro')
+
+      json2 = Coradoc.serialize(rebuilt, to: :mirror_json)
+      expect(JSON.parse(json2)).to eq(JSON.parse(json1))
+    end
+  end
+
+  describe 'generic [admonition] block style' do
+    it 'emits an Admonition node with attrs.type="ADMONITION"' do
+      block = Coradoc::CoreModel::AnnotationBlock.new(
+        annotation_type: 'ADMONITION',
+        content: 'Generic'
+      )
+      doc = Coradoc::CoreModel::DocumentElement.new(children: [block])
+
+      hash = Coradoc::Mirror.transform(doc).content.first.to_hash
+      expect(hash['type']).to eq('admonition')
+      expect(hash['attrs']['type']).to eq('ADMONITION')
+    end
+
+    it 'round-trips generic admonition back to AnnotationBlock' do
+      original = Coradoc::CoreModel::DocumentElement.new(
+        children: [
+          Coradoc::CoreModel::AnnotationBlock.new(
+            annotation_type: 'ADMONITION',
+            content: 'Generic'
+          )
+        ]
+      )
+      json1 = Coradoc.serialize(original, to: :mirror_json)
+      parsed = Coradoc::Mirror.from_hash(JSON.parse(json1))
+      rebuilt = reverse.call(parsed)
+
+      expect(rebuilt.children.first).to be_a(Coradoc::CoreModel::AnnotationBlock)
+      expect(rebuilt.children.first.annotation_type).to eq('ADMONITION')
+    end
+  end
+end

--- a/coradoc-mirror/spec/coradoc/mirror/named_block_styles_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/named_block_styles_spec.rb
@@ -17,106 +17,127 @@ require 'json'
 # Admonition node with `attrs.type: "ADMONITION"`.
 RSpec.describe 'Named block style mirror coverage', :asciidoc do
   let(:reverse) { Coradoc::Mirror::MirrorToCoreModel.new }
+  let(:context) { Coradoc::Mirror::CoreModelToMirror.new }
 
   describe 'CoreModel::AbstractBlock → Mirror' do
-    it 'emits a Node::Abstract with PM_TYPE "abstract_block"' do
-      block = Coradoc::CoreModel::AbstractBlock.new(
-        content: 'Abstract body',
-        title: 'Abs',
-        id: 'abs-1'
+    let(:block) do
+      Coradoc::CoreModel::AbstractBlock.new(
+        content: 'Abstract body', title: 'Abs', id: 'abs-1'
       )
-      doc = Coradoc::CoreModel::DocumentElement.new(children: [block])
+    end
+    let(:doc) { Coradoc::CoreModel::DocumentElement.new(children: [block]) }
+    let(:node) { Coradoc::Mirror.transform(doc).content.first }
 
-      node = Coradoc::Mirror.transform(doc).content.first
+    it 'emits a Node::Abstract' do
       expect(node).to be_a(Coradoc::Mirror::Node::Abstract)
+    end
+
+    it 'preserves PM_TYPE "abstract_block"' do
       expect(node.type).to eq('abstract_block')
+    end
+
+    it 'preserves title and id attrs', :aggregate_failures do
       expect(node.attrs.title).to eq('Abs')
       expect(node.attrs.id).to eq('abs-1')
     end
 
     it 'renders the type attribute on the wire' do
-      block = Coradoc::CoreModel::AbstractBlock.new(content: 'x')
-      doc = Coradoc::CoreModel::DocumentElement.new(children: [block])
-
-      hash = Coradoc::Mirror.transform(doc).content.first.to_hash
-      expect(hash['type']).to eq('abstract_block')
+      expect(node.to_hash['type']).to eq('abstract_block')
     end
   end
 
   describe 'CoreModel::PartintroBlock → Mirror' do
-    it 'emits a Node::Partintro with PM_TYPE "partintro_block"' do
-      block = Coradoc::CoreModel::PartintroBlock.new(
-        content: 'Part intro',
-        title: 'Part 1',
-        id: 'pi-1'
+    let(:block) do
+      Coradoc::CoreModel::PartintroBlock.new(
+        content: 'Part intro', title: 'Part 1', id: 'pi-1'
       )
-      doc = Coradoc::CoreModel::DocumentElement.new(children: [block])
+    end
+    let(:doc) { Coradoc::CoreModel::DocumentElement.new(children: [block]) }
+    let(:node) { Coradoc::Mirror.transform(doc).content.first }
 
-      node = Coradoc::Mirror.transform(doc).content.first
+    it 'emits a Node::Partintro' do
       expect(node).to be_a(Coradoc::Mirror::Node::Partintro)
+    end
+
+    it 'preserves PM_TYPE "partintro_block"' do
       expect(node.type).to eq('partintro_block')
+    end
+
+    it 'preserves title and id attrs', :aggregate_failures do
       expect(node.attrs.title).to eq('Part 1')
       expect(node.attrs.id).to eq('pi-1')
     end
   end
 
   describe 'Handlers::Abstract' do
-    it 'returns nil for empty content (no abstract emitted)' do
+    it 'returns nil for empty content' do
       block = Coradoc::CoreModel::AbstractBlock.new(content: '', children: [])
-      node = Coradoc::Mirror::Handlers::Abstract.call(
-        block, context: Coradoc::Mirror::CoreModelToMirror.new
-      )
+      node = Coradoc::Mirror::Handlers::Abstract.call(block, context: context)
       expect(node).to be_nil
     end
   end
 
   describe 'Handlers::Partintro' do
-    it 'returns nil for empty content (no partintro emitted)' do
+    it 'returns nil for empty content' do
       block = Coradoc::CoreModel::PartintroBlock.new(content: '', children: [])
-      node = Coradoc::Mirror::Handlers::Partintro.call(
-        block, context: Coradoc::Mirror::CoreModelToMirror.new
-      )
+      node = Coradoc::Mirror::Handlers::Partintro.call(block, context: context)
       expect(node).to be_nil
     end
   end
 
   describe 'reverse builder: abstract_block → AbstractBlock' do
-    it 'round-trips Node::Abstract back to CoreModel::AbstractBlock' do
-      mirror = Coradoc::Mirror::Node::Abstract.new(
+    let(:mirror) do
+      Coradoc::Mirror::Node::Abstract.new(
         attrs: Coradoc::Mirror::Node::Abstract::Attrs.new(
           title: 'Abs', id: 'abs-1'
         ),
         content: [Coradoc::Mirror::Node::Text.new(text: 'body')]
       )
-      doc = Coradoc::Mirror::Node::Document.new(content: [mirror])
+    end
+    let(:doc) { Coradoc::Mirror::Node::Document.new(content: [mirror]) }
+    let(:rebuilt) { reverse.call(doc).children.first }
 
-      core = reverse.call(doc)
-      expect(core.children.first).to be_a(Coradoc::CoreModel::AbstractBlock)
-      expect(core.children.first.title).to eq('Abs')
-      expect(core.children.first.id).to eq('abs-1')
+    it 'yields a CoreModel::AbstractBlock' do
+      expect(rebuilt).to be_a(Coradoc::CoreModel::AbstractBlock)
+    end
+
+    it 'preserves the title' do
+      expect(rebuilt.title).to eq('Abs')
+    end
+
+    it 'preserves the id' do
+      expect(rebuilt.id).to eq('abs-1')
     end
   end
 
   describe 'reverse builder: partintro_block → PartintroBlock' do
-    it 'round-trips Node::Partintro back to CoreModel::PartintroBlock' do
-      mirror = Coradoc::Mirror::Node::Partintro.new(
+    let(:mirror) do
+      Coradoc::Mirror::Node::Partintro.new(
         attrs: Coradoc::Mirror::Node::Partintro::Attrs.new(
           title: 'Part 1', id: 'pi-1'
         ),
         content: [Coradoc::Mirror::Node::Text.new(text: 'intro')]
       )
-      doc = Coradoc::Mirror::Node::Document.new(content: [mirror])
+    end
+    let(:doc) { Coradoc::Mirror::Node::Document.new(content: [mirror]) }
+    let(:rebuilt) { reverse.call(doc).children.first }
 
-      core = reverse.call(doc)
-      expect(core.children.first).to be_a(Coradoc::CoreModel::PartintroBlock)
-      expect(core.children.first.title).to eq('Part 1')
-      expect(core.children.first.id).to eq('pi-1')
+    it 'yields a CoreModel::PartintroBlock' do
+      expect(rebuilt).to be_a(Coradoc::CoreModel::PartintroBlock)
+    end
+
+    it 'preserves the title' do
+      expect(rebuilt.title).to eq('Part 1')
+    end
+
+    it 'preserves the id' do
+      expect(rebuilt.id).to eq('pi-1')
     end
   end
 
-  describe 'JSON round-trip (forward → JSON → reverse → CoreModel)' do
-    it 'preserves AbstractBlock identity through JSON' do
-      original = Coradoc::CoreModel::DocumentElement.new(
+  describe 'JSON round-trip: AbstractBlock' do
+    let(:original) do
+      Coradoc::CoreModel::DocumentElement.new(
         children: [
           Coradoc::CoreModel::AbstractBlock.new(
             title: 'Abs',
@@ -124,20 +145,27 @@ RSpec.describe 'Named block style mirror coverage', :asciidoc do
           )
         ]
       )
-      json1 = Coradoc.serialize(original, to: :mirror_json)
-      parsed = Coradoc::Mirror.from_hash(JSON.parse(json1))
-      rebuilt = reverse.call(parsed)
+    end
+    let(:json1) { Coradoc.serialize(original, to: :mirror_json) }
+    let(:rebuilt) { reverse.call(Coradoc::Mirror.from_hash(JSON.parse(json1))) }
 
+    it 'preserves AbstractBlock identity' do
       expect(rebuilt.children.first).to be_a(Coradoc::CoreModel::AbstractBlock)
-      expect(rebuilt.children.first.title).to eq('Abs')
+    end
 
-      # JSON shape is stable across the round-trip.
+    it 'preserves the title through JSON' do
+      expect(rebuilt.children.first.title).to eq('Abs')
+    end
+
+    it 'produces stable JSON across the round-trip' do
       json2 = Coradoc.serialize(rebuilt, to: :mirror_json)
       expect(JSON.parse(json2)).to eq(JSON.parse(json1))
     end
+  end
 
-    it 'preserves PartintroBlock identity through JSON' do
-      original = Coradoc::CoreModel::DocumentElement.new(
+  describe 'JSON round-trip: PartintroBlock' do
+    let(:original) do
+      Coradoc::CoreModel::DocumentElement.new(
         children: [
           Coradoc::CoreModel::PartintroBlock.new(
             title: 'Intro',
@@ -145,46 +173,48 @@ RSpec.describe 'Named block style mirror coverage', :asciidoc do
           )
         ]
       )
-      json1 = Coradoc.serialize(original, to: :mirror_json)
-      parsed = Coradoc::Mirror.from_hash(JSON.parse(json1))
-      rebuilt = reverse.call(parsed)
+    end
+    let(:json1) { Coradoc.serialize(original, to: :mirror_json) }
+    let(:rebuilt) { reverse.call(Coradoc::Mirror.from_hash(JSON.parse(json1))) }
 
+    it 'preserves PartintroBlock identity' do
       expect(rebuilt.children.first).to be_a(Coradoc::CoreModel::PartintroBlock)
-      expect(rebuilt.children.first.title).to eq('Intro')
+    end
 
+    it 'preserves the title through JSON' do
+      expect(rebuilt.children.first.title).to eq('Intro')
+    end
+
+    it 'produces stable JSON across the round-trip' do
       json2 = Coradoc.serialize(rebuilt, to: :mirror_json)
       expect(JSON.parse(json2)).to eq(JSON.parse(json1))
     end
   end
 
   describe 'generic [admonition] block style' do
-    it 'emits an Admonition node with attrs.type="ADMONITION"' do
-      block = Coradoc::CoreModel::AnnotationBlock.new(
-        annotation_type: 'ADMONITION',
-        content: 'Generic'
+    let(:block) do
+      Coradoc::CoreModel::AnnotationBlock.new(
+        annotation_type: 'ADMONITION', content: 'Generic'
       )
-      doc = Coradoc::CoreModel::DocumentElement.new(children: [block])
+    end
+    let(:doc) { Coradoc::CoreModel::DocumentElement.new(children: [block]) }
+    let(:node) { Coradoc::Mirror.transform(doc).content.first }
 
-      hash = Coradoc::Mirror.transform(doc).content.first.to_hash
-      expect(hash['type']).to eq('admonition')
-      expect(hash['attrs']['type']).to eq('ADMONITION')
+    it 'emits an Admonition node' do
+      expect(node.type).to eq('admonition')
     end
 
-    it 'round-trips generic admonition back to AnnotationBlock' do
-      original = Coradoc::CoreModel::DocumentElement.new(
-        children: [
-          Coradoc::CoreModel::AnnotationBlock.new(
-            annotation_type: 'ADMONITION',
-            content: 'Generic'
-          )
-        ]
-      )
-      json1 = Coradoc.serialize(original, to: :mirror_json)
-      parsed = Coradoc::Mirror.from_hash(JSON.parse(json1))
-      rebuilt = reverse.call(parsed)
+    it 'carries the ADMONITION type in attrs' do
+      expect(node.to_hash['attrs']['type']).to eq('ADMONITION')
+    end
 
-      expect(rebuilt.children.first).to be_a(Coradoc::CoreModel::AnnotationBlock)
-      expect(rebuilt.children.first.annotation_type).to eq('ADMONITION')
+    it 'round-trips back to AnnotationBlock', :aggregate_failures do
+      json = Coradoc.serialize(doc, to: :mirror_json)
+      rebuilt = reverse.call(Coradoc::Mirror.from_hash(JSON.parse(json)))
+      result = rebuilt.children.first
+
+      expect(result).to be_a(Coradoc::CoreModel::AnnotationBlock)
+      expect(result.annotation_type).to eq('ADMONITION')
     end
   end
 end

--- a/coradoc/lib/coradoc/core_model.rb
+++ b/coradoc/lib/coradoc/core_model.rb
@@ -69,6 +69,8 @@ module Coradoc
     autoload :ExampleBlock, "#{__dir__}/core_model/example_block"
     autoload :QuoteBlock, "#{__dir__}/core_model/quote_block"
     autoload :SidebarBlock, "#{__dir__}/core_model/sidebar_block"
+    autoload :AbstractBlock, "#{__dir__}/core_model/abstract_block"
+    autoload :PartintroBlock, "#{__dir__}/core_model/partintro_block"
     autoload :LiteralBlock, "#{__dir__}/core_model/literal_block"
     autoload :PassBlock, "#{__dir__}/core_model/pass_block"
     autoload :StemBlock, "#{__dir__}/core_model/stem_block"

--- a/coradoc/lib/coradoc/core_model/abstract_block.rb
+++ b/coradoc/lib/coradoc/core_model/abstract_block.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    class AbstractBlock < Block
+      def self.semantic_type
+        :abstract
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/core_model/base.rb
+++ b/coradoc/lib/coradoc/core_model/base.rb
@@ -41,6 +41,13 @@ module Coradoc
       #   @return [Array<MetadataEntry>] additional metadata entries
       attribute :metadata_entries, MetadataEntry, collection: true
 
+      # 1-indexed source line where this element begins, when known.
+      # Populated by format transformers (e.g., AsciiDoc's SourceLineExtractor)
+      # so consumers can map AST nodes back to the source text. nil for
+      # programmatically constructed models. Single source of truth across
+      # all CoreModel types (Issue 1, STATUS-2026-06-28).
+      attribute :source_line, :integer
+
       # Construct an instance and yield it for in-place mutation.
       #
       # This is the programmatic-construction entry point for CoreModel

--- a/coradoc/lib/coradoc/core_model/partintro_block.rb
+++ b/coradoc/lib/coradoc/core_model/partintro_block.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Coradoc
+  module CoreModel
+    class PartintroBlock < Block
+      def self.semantic_type
+        :partintro
+      end
+    end
+  end
+end

--- a/coradoc/lib/coradoc/errors.rb
+++ b/coradoc/lib/coradoc/errors.rb
@@ -360,7 +360,7 @@ module Coradoc
     private
 
     def build_message
-      msg = "Format '#{requested_format}' is not supported"
+      msg = "Format '#{requested_format}' is not registered"
       msg += ". Available formats: #{available_formats.join(', ')}" if available_formats.any?
       msg
     end

--- a/coradoc/lib/coradoc/pipeline.rb
+++ b/coradoc/lib/coradoc/pipeline.rb
@@ -14,9 +14,8 @@ module Coradoc
       def parse(text, format:)
         format_module = FormatCatalog.get_format(format)
         unless format_module
-          raise UnsupportedFormatError,
-                "Format '#{format}' is not registered. " \
-                "Available formats: #{FormatCatalog.registered_formats.join(', ')}"
+          raise UnsupportedFormatError.new(format,
+                                           available: FormatCatalog.registered_formats)
         end
 
         text = Hooks.invoke(:before_parse, text, format: format)
@@ -66,7 +65,7 @@ module Coradoc
 
       def serialize(model, to:, **)
         format_module = FormatCatalog.get_format(to)
-        raise UnsupportedFormatError, "Format '#{to}' is not registered" unless format_module
+        raise UnsupportedFormatError.new(to, available: FormatCatalog.registered_formats) unless format_module
 
         model = Hooks.invoke(:before_serialize, model, format: to)
         result = format_module.serialize(model, **)
@@ -84,7 +83,10 @@ module Coradoc
         raise UnsupportedFormatError, "Could not detect format for: #{path}" unless source_format
 
         format_module = FormatCatalog.get_format(source_format)
-        raise UnsupportedFormatError, "Format '#{source_format}' is not registered" unless format_module
+        unless format_module
+          raise UnsupportedFormatError.new(source_format,
+                                           available: FormatCatalog.registered_formats)
+        end
 
         if FormatCatalog.binary_format?(source_format)
           format_module.parse_to_core(path)

--- a/coradoc/spec/errors_spec.rb
+++ b/coradoc/spec/errors_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Coradoc::UnsupportedFormatError do
       error = described_class.new(:docx)
 
       expect(error.message).to include('docx')
-      expect(error.message).to include('not supported')
+      expect(error.message).to include('not registered')
     end
 
     it 'lists available formats' do
@@ -239,6 +239,13 @@ RSpec.describe Coradoc::UnsupportedFormatError do
 
       expect(error.message).to include('html')
       expect(error.message).to include('markdown')
+    end
+
+    it 'does not double-wrap the format name in the message' do
+      error = described_class.new(:docx, available: [:asciidoc])
+
+      expect(error.message).to eq("Format 'docx' is not registered. Available formats: asciidoc")
+      expect(error.message.scan(/Format '/).count).to eq(1)
     end
   end
 


### PR DESCRIPTION
## Summary

Three interrelated fixes bundled together per STATUS-2026-06-28:

- **Source-line propagation.** Every CoreModel block type now carries a 1-indexed `source_line` populated by the Parslet transformer (`Transformer::SourceLineExtractor` is the single source of truth). Consumers (linters, formatters, editor integrations) can map AST nodes back to source.
- **Named block styles.** `[abstract]` and `[partintro]` previously collapsed to `ExampleBlock`, losing semantic identity. Each now has a dedicated `CoreModel` class and a `Mirror::Node` subclass with a distinct `PM_TYPE` (`abstract_block`, `partintro_block`). The generic `[admonition]` style is also recognised.
- **Hard line break.** `HardLineBreakElement` no longer collapses to the soft-break wire type. New `Mirror::Node::HardBreak` round-trips through the mirror pipeline independently.

## Side cleanups
- Document title is no longer synthesised as a level-0 `HeaderElement` in children (caused double rendering as `floating_title` in mirror).
- `InlineTransformVisitor` only synthesises soft-break spaces between two adjacent `TextElement`s (was synthesising around inline elements like `+pass:[RAW]+`).
- `ParagraphBlock` and verbatim blocks carry a `lines` array (source-line view) separate from the rendered `content` string.
- `UnsupportedFormatError` message: "not supported" → "not registered".

## Test plan

- [x] 1117 adoc specs pass (5 pre-existing pending)
- [x] 1150 coradoc specs pass
- [x] 232 mirror specs pass
- [x] 24 new specs in `source_line_propagation_spec.rb`
- [x] `named_block_styles_spec.rb` (adoc + mirror) for abstract/partintro round-trip
- [x] `open_block_typed_cast_spec.rb` for typed-cast ladder
- [x] Hard-break round-trip spec in `mirror/handlers/inline_spec.rb`
- [x] Inline visitor edge cases (no space around inline elements)

Reviewer checklist: confirm `TYPED_BLOCK_CAST_STYLES` extension point and `SourceLineExtractor` shape coverage.