### PR TITLE
refactor(adoc,mirror): deepen architectural seams

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/builder/detection.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/builder/detection.rb
@@ -70,10 +70,10 @@ module Coradoc
             return false
           end
 
-          key = "#{format_type}_constrained".to_sym
+          key = :"#{format_type}_constrained"
           return true if ast.key?(key)
 
-          unconstrained_key = "#{format_type}_unconstrained".to_sym
+          unconstrained_key = :"#{format_type}_unconstrained"
           return false if ast.key?(unconstrained_key)
 
           true
@@ -158,8 +158,8 @@ module Coradoc
         def extract_inline_content(ast, format_type)
           content_key = format_type.to_sym
           content = ast[content_key] ||
-                    ast["#{format_type}_constrained".to_sym] ||
-                    ast["#{format_type}_unconstrained".to_sym]
+                    ast[:"#{format_type}_constrained"] ||
+                    ast[:"#{format_type}_unconstrained"]
 
           extract_text_content(content)
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/attribute_list/matchers.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/attribute_list/matchers.rb
@@ -5,8 +5,8 @@ module Coradoc
     module Model
       class AttributeList < Base
         module Matchers
-          def one(*args)
-            One.new(*args)
+          def one(*)
+            One.new(*)
           end
 
           class One
@@ -19,8 +19,8 @@ module Coradoc
             end
           end
 
-          def many(*args)
-            Many.new(*args)
+          def many(*)
+            Many.new(*)
           end
 
           # NOTE: The Many matcher validates that all values in an array/string match

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/block/core.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/block/core.rb
@@ -54,7 +54,7 @@ module Coradoc
           include Coradoc::AsciiDoc::Model::Anchorable
 
           attribute :id, :string
-          attribute :title, :string, default: -> { nil } # Polymorphic: string or array of Model objects
+          attribute :title, :string, default: -> {} # Polymorphic: string or array of Model objects
           attribute :attributes, Coradoc::AsciiDoc::Model::AttributeList, default: lambda {
             Coradoc::AsciiDoc::Model::AttributeList.new
           }

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/content_list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/content_list.rb
@@ -86,8 +86,8 @@ module Coradoc
         # @example Iterate
         #   content.each { |item| puts item }
         #
-        def each(&block)
-          @items.each(&block)
+        def each(&)
+          @items.each(&)
         end
 
         # Add an item to the content
@@ -199,8 +199,8 @@ module Coradoc
         # @example Map
         #   content.map(&:class) # => [String, Bold, String]
         #
-        def map(&block)
-          @items.map(&block)
+        def map(&)
+          @items.map(&)
         end
 
         # Select items matching predicate
@@ -211,8 +211,8 @@ module Coradoc
         # @example Select strings
         #   content.select { |i| i.is_a?(String) }
         #
-        def select(&block)
-          @items.select(&block)
+        def select(&)
+          @items.select(&)
         end
 
         # Reject items matching predicate
@@ -220,8 +220,8 @@ module Coradoc
         # @yield [Object] Each item
         # @return [Array] Remaining items
         #
-        def reject(&block)
-          @items.reject(&block)
+        def reject(&)
+          @items.reject(&)
         end
 
         # Check if content includes an item

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/inline/bold.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/inline/bold.rb
@@ -25,7 +25,7 @@ module Coradoc
         class Bold < Base
           attribute :content,
                     Lutaml::Model::Serializable,
-                    default: -> { nil },
+                    default: -> {},
                     polymorphic: [
                       Lutaml::Model::Type::String,
                       :array

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/inline/highlight.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/inline/highlight.rb
@@ -23,7 +23,7 @@ module Coradoc
         class Highlight < Base
           attribute :content,
                     Lutaml::Model::Serializable,
-                    default: -> { nil },
+                    default: -> {},
                     polymorphic: [
                       Lutaml::Model::Type::String,
                       :array

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/inline/italic.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/inline/italic.rb
@@ -25,7 +25,7 @@ module Coradoc
         class Italic < Base
           attribute :content,
                     Lutaml::Model::Serializable,
-                    default: -> { nil },
+                    default: -> {},
                     polymorphic: [
                       Lutaml::Model::Type::String,
                       :array

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/inline/monospace.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/inline/monospace.rb
@@ -26,7 +26,7 @@ module Coradoc
         class Monospace < Base
           attribute :content,
                     Lutaml::Model::Serializable,
-                    default: -> { nil },
+                    default: -> {},
                     polymorphic: [
                       Lutaml::Model::Type::String,
                       :array

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/inline/strikethrough.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/inline/strikethrough.rb
@@ -25,12 +25,12 @@ module Coradoc
         class Strikethrough < Base
           attribute :content,
                     Lutaml::Model::Serializable,
-                    default: -> { nil },
+                    default: -> {},
                     polymorphic: [
                       Lutaml::Model::Type::String,
                       :array
                     ]
-          attribute :text, :string, default: -> { nil }
+          attribute :text, :string, default: -> {}
           attribute :unconstrained, :boolean, default: -> { false }
         end
       end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/inline/subscript.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/inline/subscript.rb
@@ -21,7 +21,7 @@ module Coradoc
         class Subscript < Base
           attribute :content,
                     Lutaml::Model::Serializable,
-                    default: -> { nil },
+                    default: -> {},
                     polymorphic: [
                       Lutaml::Model::Type::String,
                       :array

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/inline/superscript.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/inline/superscript.rb
@@ -21,7 +21,7 @@ module Coradoc
         class Superscript < Base
           attribute :content,
                     Lutaml::Model::Serializable,
-                    default: -> { nil },
+                    default: -> {},
                     polymorphic: [
                       Lutaml::Model::Type::String,
                       :array

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/serialization/asciidoc_mapping.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/serialization/asciidoc_mapping.rb
@@ -6,8 +6,7 @@ module Coradoc
       module Serialization
         # Define the DSL for defining mappings in Asciidoc format
         class AsciidocMapping < Lutaml::Model::Mapping
-          attr_reader :mappings
-          attr_writer :mappings
+          attr_accessor :mappings
 
           def initialize
             super
@@ -33,8 +32,8 @@ module Coradoc
 
           private
 
-          def add_mapping(name, to, **options)
-            @mappings << AsciidocMappingRule.new(name, to: to, **options)
+          def add_mapping(name, to, **)
+            @mappings << AsciidocMappingRule.new(name, to: to, **)
           end
         end
       end

--- a/coradoc-adoc/lib/coradoc/asciidoc/model/text_element.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/model/text_element.rb
@@ -3,6 +3,16 @@
 module Coradoc
   module AsciiDoc
     module Model
+      # Single source of truth for the markers AsciiDoc uses to terminate
+      # a TextElement. Exposed as a module so the transformer can compare
+      # against the constant without hand-writing string literals across
+      # the codebase (DRY), and so future markers (e.g. a hypothetical
+      # backslash-style hard break) extend one place.
+      module LineBreakMarker
+        HARD = '+'
+      end
+      private_constant :LineBreakMarker
+
       class TextElement < Base
         def inline?
           true
@@ -17,6 +27,18 @@ module Coradoc
                     :array
                   ]
         attribute :line_break, :string, default: -> { '' }
+
+        # Semantic predicates over the line-break marker. Consumers (the
+        # transformer, the serializer) call these instead of comparing
+        # line_break against literal strings, so the wire format for
+        # hard breaks is owned by the model layer (SRP).
+        def hard_break?
+          line_break == LineBreakMarker::HARD
+        end
+
+        def soft_break?
+          line_break.to_s.empty?
+        end
 
         def self.escape_keychars(string)
           subs = { '*' => '\*', '_' => '\_' }

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/block.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/block.rb
@@ -73,14 +73,14 @@ module Coradoc
           closing_fence = dynamic do |_s, c|
             str(c.captures[capture_key].to_s.strip)
           end
-          language = (space? >> match("[A-Za-z0-9_+.-]").repeat(1).as(:language)).maybe
+          language = (space? >> match('[A-Za-z0-9_+.-]').repeat(1).as(:language)).maybe
 
           block_content_with_closing = dynamic do |_s, c|
-            fence_str = c.captures[capture_key].to_s.strip
+            c.captures[capture_key].to_s.strip
             closing_pattern = closing_fence >> space? >> newline
 
             content = text_line(false, unguarded: true, verbatim: true) |
-                        empty_line.as(:line_break)
+                      empty_line.as(:line_break)
 
             (closing_pattern.absent? >> content).repeat(1)
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -300,8 +300,11 @@ module Coradoc
           end
 
           def transform_image(image)
-            target_class = image.inline ? Coradoc::AsciiDoc::Model::Image::InlineImage
-                                        : Coradoc::AsciiDoc::Model::Image::BlockImage
+            target_class = if image.inline
+                             Coradoc::AsciiDoc::Model::Image::InlineImage
+                           else
+                             Coradoc::AsciiDoc::Model::Image::BlockImage
+                           end
             target_class.new(**image_attributes(image))
           end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/inline_transform_visitor.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/inline_transform_visitor.rb
@@ -62,10 +62,15 @@ module Coradoc
           result
         end
 
+        # Two adjacent TextElements in the content array indicate the
+        # parser split a paragraph across source lines. Join them with a
+        # space (soft break) unless the second one carries a hard-break
+        # marker — the model owns that predicate, so this method does
+        # not reach into parser-specific line_break string values.
         def soft_break_before?(previous, current)
           previous.is_a?(Model::TextElement) &&
             current.is_a?(Model::TextElement) &&
-            current.line_break != '+'
+            !current.hard_break?
         end
 
         def visit_model(model)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer.rb
@@ -142,8 +142,7 @@ module Coradoc
 
           Model::TextElement.new(
             content: transformed,
-            line_break: line[:line_break],
-            source_line: SourceLineExtractor.extract(line)
+            line_break: line[:line_break]
           )
         end
       end
@@ -152,6 +151,31 @@ module Coradoc
       # @deprecated Use {.transform} instead
       def self.legacy_transform(syntax_tree)
         new.apply(syntax_tree)
+      end
+
+      # Single deepening seam for source_line propagation. Parslet's
+      # transform pipeline funnels every rule block through
+      # +call_on_match(bindings, block)+; overriding it lets us post-
+      # process the block's result and inject +source_line+ from the
+      # matched bindings, so individual rules no longer need to call
+      # SourceLineExtractor.extract themselves (DRY — was 47 call
+      # sites across 7 rule files).
+      #
+      # Safety:
+      #   * Only Model::Base results get an injection — Strings, Arrays,
+      #     and intermediate hashes pass through unchanged.
+      #   * Existing explicit source_line values are preserved — the
+      #     injection is fill-in-the-blank, never overwrite.
+      #   * No Slice in the bindings → SourceLineExtractor returns nil,
+      #     no injection (synthetic transformations stay clean).
+      def call_on_match(bindings, block)
+        result = super
+        return result unless result.is_a?(Model::Base)
+        return result if result.source_line
+
+        line = self.class::SourceLineExtractor.extract(bindings)
+        result.source_line = line if line
+        result
       end
     end
   end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_rules.rb
@@ -23,8 +23,7 @@ module Coradoc
                 title: title,
                 delimiter_len: delimiter.size,
                 lines: lines,
-                ordering: ordering,
-                source_line: SourceLineExtractor.extract(block)
+                ordering: ordering
               }
               # Markdown fences carry the language tag inline (```ruby);
               # pass it through so the SourceCode classifier entry can set
@@ -37,8 +36,7 @@ module Coradoc
             rule(example: sequence(:example)) do
               Model::Block::Example.new(
                 title: '',
-                lines: example,
-                source_line: SourceLineExtractor.extract(example)
+                lines: example
               )
             end
 
@@ -52,8 +50,7 @@ module Coradoc
               canonical = Coradoc::AsciiDoc::Transform::ElementTransformers::AdmonitionStyles.canonicalize(admonition_type.to_s)
               Model::Admonition.new(
                 content: content,
-                type: canonical,
-                source_line: SourceLineExtractor.extract(admonition_type)
+                type: canonical
               )
             end
 
@@ -72,7 +69,6 @@ module Coradoc
                 src: path,
                 attributes: residual,
                 line_break: "\n",
-                source_line: SourceLineExtractor.extract(block_image),
                 **promoted
               )
             end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_type_classifier.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/block_type_classifier.rb
@@ -16,23 +16,23 @@ module Coradoc
         # returning a Model::Block::* instance. `max_length` nil means
         # unbounded.
         DELIMITER_CLASSIFICATIONS = [
-          ['*', 4, nil, ->(opts, attrs) {
+          ['*', 4, nil, lambda { |opts, attrs|
             if attrs && attrs.positional == [] && attrs.named.first&.name == 'reviewer'
-              Model::Block::ReviewerComment.new(**opts.merge(attributes: attrs))
+              Model::Block::ReviewerComment.new(**opts, attributes: attrs)
             else
-              Model::Block::Side.new(**opts.merge(attributes: attrs))
+              Model::Block::Side.new(**opts, attributes: attrs)
             end
           }],
-          ['=', 4, nil, ->(opts, attrs) { Model::Block::Example.new(**opts.merge(attributes: attrs)) }],
-          ['+', 4, nil, ->(opts, attrs) { Model::Block::Pass.new(**opts.merge(attributes: attrs)) }],
-          ['.', 4, nil, ->(opts, attrs) { Model::Block::Literal.new(**opts.merge(attributes: attrs)) }],
-          ['_', 4, nil, ->(opts, attrs) { Model::Block::Quote.new(**opts.merge(attributes: attrs)) }],
-          ['-', 4, nil, ->(opts, attrs) { Model::Block::SourceCode.new(**opts.merge(attributes: attrs)) }],
-          ['-', 2, 2,  ->(opts, attrs) { Model::Block::Open.new(**opts.merge(attributes: attrs)) }],
+          ['=', 4, nil, ->(opts, attrs) { Model::Block::Example.new(**opts, attributes: attrs) }],
+          ['+', 4, nil, ->(opts, attrs) { Model::Block::Pass.new(**opts, attributes: attrs) }],
+          ['.', 4, nil, ->(opts, attrs) { Model::Block::Literal.new(**opts, attributes: attrs) }],
+          ['_', 4, nil, ->(opts, attrs) { Model::Block::Quote.new(**opts, attributes: attrs) }],
+          ['-', 4, nil, ->(opts, attrs) { Model::Block::SourceCode.new(**opts, attributes: attrs) }],
+          ['-', 2, 2, ->(opts, attrs) { Model::Block::Open.new(**opts, attributes: attrs) }],
           # Markdown-style triple-backtick fence: behaves as a SourceCode
           # block. The language tag parsed from the opening fence is passed
           # through opts[:lang]; extract_block_language prefers block.lang.
-          ['`', 3, nil, ->(opts, attrs) {
+          ['`', 3, nil, lambda { |opts, attrs|
             model_opts = opts.merge(attributes: attrs, delimiter_char: '`')
             model_opts[:lang] = opts[:lang] if opts.key?(:lang)
             Model::Block::SourceCode.new(**model_opts)

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/header_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/header_rules.rb
@@ -22,8 +22,7 @@ module Coradoc
               id = nil if id && id.empty?
 
               Model::Header.new(
-                id:, title:, author:, revision:,
-                source_line: SourceLineExtractor.extract(header)
+                id:, title:, author:, revision:
               )
             end
 
@@ -38,8 +37,7 @@ module Coradoc
               email: simple(:email)
             ) do
               Model::Author.new(
-                first_name:, last_name:, email:, middle_name: nil,
-                source_line: SourceLineExtractor.extract(first_name)
+                first_name:, last_name:, email:, middle_name: nil
               )
             end
 
@@ -50,8 +48,7 @@ module Coradoc
               remark: simple(:remark)
             ) do
               Model::Revision.new(
-                number:, date:, remark:,
-                source_line: SourceLineExtractor.extract(number)
+                number:, date:, remark:
               )
             end
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
@@ -10,8 +10,8 @@ module Coradoc
         # `span` is excluded because it carries `text:` + `attributes:`
         # rather than `content:`, so it gets its own pair of rules.
         FORMATTING_VARIANTS = [
-          %i[bold      Bold],
-          %i[italic    Italic],
+          %i[bold Bold],
+          %i[italic Italic],
           %i[highlight Highlight],
           %i[monospace Monospace]
         ].freeze
@@ -22,8 +22,7 @@ module Coradoc
             rule(link: subtree(:link)) do
               Model::Inline::Link.new(
                 path: link[:path].to_s,
-                name: link[:text]&.to_s,
-                source_line: SourceLineExtractor.extract(link)
+                name: link[:text]&.to_s
               )
             end
 
@@ -33,8 +32,7 @@ module Coradoc
               text = xref[:text]
               args = text ? [text.to_s] : []
               Model::Inline::CrossReference.new(
-                href:, args:,
-                source_line: SourceLineExtractor.extract(xref)
+                href:, args:
               )
             end
 
@@ -47,7 +45,6 @@ module Coradoc
               Model::Image::InlineImage.new(
                 src: inline_image[:path],
                 attributes: residual,
-                source_line: SourceLineExtractor.extract(inline_image),
                 **promoted
               )
             end
@@ -59,16 +56,14 @@ module Coradoc
             rule(inline_passthrough: subtree(:passthrough)) do
               Model::Inline::Passthrough.new(
                 content: passthrough[:raw].to_s,
-                form: 'triple',
-                source_line: SourceLineExtractor.extract(passthrough)
+                form: 'triple'
               )
             end
 
             # Attribute reference
             rule(attribute_reference: simple(:name)) do
               Model::Inline::AttributeReference.new(
-                name:,
-                source_line: SourceLineExtractor.extract(name)
+                name:
               )
             end
 
@@ -78,9 +73,7 @@ module Coradoc
             # blank lines. Hard breaks carry semantic meaning: HTML/Markdown
             # renderers map them to <br>.
             rule(hard_line_break: simple(:hard_line_break)) do
-              Model::Inline::HardLineBreak.new(
-                source_line: SourceLineExtractor.extract(hard_line_break)
-              )
+              Model::Inline::HardLineBreak.new
             end
 
             # Term
@@ -89,8 +82,7 @@ module Coradoc
               term: simple(:term)
             ) do
               Coradoc::AsciiDoc::Model::Term.new(
-                term:, type: term_type, lang: :en,
-                source_line: SourceLineExtractor.extract(term_type)
+                term:, type: term_type, lang: :en
               )
             end
 
@@ -98,16 +90,14 @@ module Coradoc
             rule(footnote: simple(:footnote)) do
               text_str = footnote.to_s
               Coradoc::AsciiDoc::Model::Inline::Footnote.new(
-                text: text_str,
-                source_line: SourceLineExtractor.extract(footnote)
+                text: text_str
               )
             end
 
             rule(footnote: simple(:footnote), id: simple(:id)) do
               text_str = footnote.to_s
               Coradoc::AsciiDoc::Model::Inline::Footnote.new(
-                text: text_str, id: id.to_s,
-                source_line: SourceLineExtractor.extract(footnote)
+                text: text_str, id: id.to_s
               )
             end
 
@@ -115,8 +105,7 @@ module Coradoc
             rule(footnote: sequence(:footnote), id: simple(:id)) do
               text_str = footnote.map(&:to_s).join
               Coradoc::AsciiDoc::Model::Inline::Footnote.new(
-                text: text_str, id: id.to_s,
-                source_line: SourceLineExtractor.extract(footnote)
+                text: text_str, id: id.to_s
               )
             end
 
@@ -124,8 +113,7 @@ module Coradoc
             rule(footnote: sequence(:footnote)) do
               text_str = footnote.map(&:to_s).join
               Coradoc::AsciiDoc::Model::Inline::Footnote.new(
-                text: text_str,
-                source_line: SourceLineExtractor.extract(footnote)
+                text: text_str
               )
             end
 
@@ -141,15 +129,13 @@ module Coradoc
               rule(constrained_key => subtree(:subtree)) do
                 content = Transformer.extract_inline_content(subtree)
                 klass.new(
-                  content: content, unconstrained: false,
-                  source_line: SourceLineExtractor.extract(subtree)
+                  content: content, unconstrained: false
                 )
               end
               rule(unconstrained_key => subtree(:subtree)) do
                 content = Transformer.extract_inline_content(subtree)
                 klass.new(
-                  content: content, unconstrained: true,
-                  source_line: SourceLineExtractor.extract(subtree)
+                  content: content, unconstrained: true
                 )
               end
             end
@@ -159,8 +145,7 @@ module Coradoc
               Model::Inline::Span.new(
                 text: span_constrained[:text],
                 unconstrained: false,
-                attributes: span_constrained[:attribute_list],
-                source_line: SourceLineExtractor.extract(span_constrained)
+                attributes: span_constrained[:attribute_list]
               )
             end
 
@@ -169,8 +154,7 @@ module Coradoc
               Model::Inline::Span.new(
                 text: span_unconstrained[:text],
                 unconstrained: true,
-                attributes: span_unconstrained[:attribute_list],
-                source_line: SourceLineExtractor.extract(span_unconstrained)
+                attributes: span_unconstrained[:attribute_list]
               )
             end
 
@@ -178,8 +162,7 @@ module Coradoc
             rule(superscript: subtree(:superscript)) do
               content = Transformer.extract_simple_inline_content(superscript)
               Model::Inline::Superscript.new(
-                content:,
-                source_line: SourceLineExtractor.extract(superscript)
+                content:
               )
             end
 
@@ -187,24 +170,21 @@ module Coradoc
             rule(subscript: subtree(:subscript)) do
               content = Transformer.extract_simple_inline_content(subscript)
               Model::Inline::Subscript.new(
-                content:,
-                source_line: SourceLineExtractor.extract(subscript)
+                content:
               )
             end
 
             # Highlight (simple)
             rule(highlight: simple(:text)) do
               Model::Highlight.new(
-                content: text,
-                source_line: SourceLineExtractor.extract(text)
+                content: text
               )
             end
             # Stem
             rule(stem: subtree(:stem)) do
               Coradoc::AsciiDoc::Model::Inline::Stem.new(
                 type: stem[:stem_type],
-                content: stem[:content],
-                source_line: SourceLineExtractor.extract(stem)
+                content: stem[:content]
               )
             end
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/list_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/list_rules.rb
@@ -74,8 +74,7 @@ module Coradoc
               end
 
               Model::List::Item.new(
-                content: content, id:, marker:, attached:, nested:, line_break:,
-                source_line: SourceLineExtractor.extract(list_item)
+                content: content, id:, marker:, attached:, nested:, line_break:
               )
             end
 
@@ -87,8 +86,7 @@ module Coradoc
             # Unordered list
             rule(unordered: sequence(:list_items)) do
               Model::List::Unordered.new(
-                items: list_items,
-                source_line: SourceLineExtractor.extract(list_items)
+                items: list_items
               )
             end
 
@@ -98,16 +96,14 @@ module Coradoc
             ) do
               Model::List::Unordered.new(
                 items: list_items,
-                attrs: attribute_list,
-                source_line: SourceLineExtractor.extract(attribute_list)
+                attrs: attribute_list
               )
             end
 
             # Ordered list
             rule(ordered: sequence(:list_items)) do
               Model::List::Ordered.new(
-                items: list_items,
-                source_line: SourceLineExtractor.extract(list_items)
+                items: list_items
               )
             end
 
@@ -117,8 +113,7 @@ module Coradoc
             ) do
               Model::List::Ordered.new(
                 items: list_items,
-                attrs: attribute_list,
-                source_line: SourceLineExtractor.extract(attribute_list)
+                attrs: attribute_list
               )
             end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/misc_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/misc_rules.rb
@@ -14,23 +14,19 @@ module Coradoc
                  }) do
               Model::CommentLine.new(
                 text: comment_text,
-                line_break: line_break,
-                source_line: SourceLineExtractor.extract(comment_text)
+                line_break: line_break
               )
             end
 
             rule(comment_block: { comment_text: simple(:comment_text) }) do
               Model::CommentBlock.new(
-                text: comment_text,
-                source_line: SourceLineExtractor.extract(comment_text)
+                text: comment_text
               )
             end
 
             # Page break
             rule(page_break: simple(:page_break)) do
-              Model::Break::PageBreak.new(
-                source_line: SourceLineExtractor.extract(page_break)
-              )
+              Model::Break::PageBreak.new
             end
 
             # Tag
@@ -39,8 +35,7 @@ module Coradoc
                 name: tag[:name],
                 attrs: tag[:attribute_list],
                 line_break: tag[:line_break],
-                prefix: tag[:prefix],
-                source_line: SourceLineExtractor.extract(tag)
+                prefix: tag[:prefix]
               )
             end
 
@@ -63,9 +58,8 @@ module Coradoc
             end
 
             rule(attribute_array: sequence(:attributes)) do
-              attr_list = Model::AttributeList.new(
-                source_line: SourceLineExtractor.extract(attributes)
-              )
+              attr_list = Model::AttributeList.new
+
               attributes.each do |a|
                 case a
                 when Parslet::Slice
@@ -119,8 +113,7 @@ module Coradoc
               Model::Include.new(
                 path: path.to_s,
                 attributes: attribute_list,
-                line_break: line_break,
-                source_line: SourceLineExtractor.extract(path)
+                line_break: line_break
               )
             end
 
@@ -135,8 +128,7 @@ module Coradoc
               Model::Audio.new(
                 src: path.to_s,
                 attributes: attribute_list,
-                line_break: line_break,
-                source_line: SourceLineExtractor.extract(path)
+                line_break: line_break
               )
             end
 
@@ -151,8 +143,7 @@ module Coradoc
               Model::Video.new(
                 src: path.to_s,
                 attributes: attribute_list,
-                line_break: line_break,
-                source_line: SourceLineExtractor.extract(path)
+                line_break: line_break
               )
             end
 
@@ -180,8 +171,7 @@ module Coradoc
                 date: attrs[:date],
                 from: attrs[:from],
                 to: attrs[:to],
-                content: Transformer.lines_to_text_elements(lines),
-                source_line: SourceLineExtractor.extract(reviewer_note)
+                content: Transformer.lines_to_text_elements(lines)
               )
             end
           end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/source_line_extractor.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/source_line_extractor.rb
@@ -37,7 +37,6 @@ module Coradoc
           when Coradoc::AsciiDoc::Model::Base then node.source_line
           when Hash then extract_from_hash(node)
           when Array then extract_from_array(node)
-          else nil
           end
         end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/structural_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/structural_rules.rb
@@ -72,7 +72,6 @@ module Coradoc
               opts = { rows: Transformer.regroup_table_rows(rows, attrs), attrs: attrs }
               opts[:id] = id if id
               opts[:title] = title unless title.nil? || title.empty?
-              opts[:source_line] = SourceLineExtractor.extract(table)
               Model::Table.new(**opts)
             end
 
@@ -85,8 +84,7 @@ module Coradoc
               Model::Title.new(
                 content: text,
                 level_int: level.size - 1,
-                line_break: line_break,
-                source_line: SourceLineExtractor.extract(level)
+                line_break: line_break
               )
             end
 
@@ -100,8 +98,7 @@ module Coradoc
                 content: text,
                 level_int: level.size - 1,
                 line_break: line_break,
-                id: name,
-                source_line: SourceLineExtractor.extract(name)
+                id: name
               )
             end
 
@@ -120,8 +117,7 @@ module Coradoc
                 id: id,
                 attribute_list: attribute_list,
                 contents: contents,
-                sections: sections,
-                source_line: SourceLineExtractor.extract(section)
+                sections: sections
               )
             end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/table_layout.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/table_layout.rb
@@ -46,9 +46,7 @@ module Coradoc
           normalized_cells = cells.map { |cell| TableCellBuilder.normalize_cell(cell) }
 
           col_count = explicit_col_count
-          if col_count.nil? || col_count.zero?
-            col_count = infer_column_count(normalized_cells)
-          end
+          col_count = infer_column_count(normalized_cells) if col_count.nil? || col_count.zero?
           col_count = normalized_cells.size if col_count.nil? || col_count.zero?
 
           rows = []

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/text_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/text_rules.rb
@@ -10,8 +10,7 @@ module Coradoc
             # Text Model
             rule(text: simple(:text)) do
               Model::TextElement.new(
-                content: text.to_s,
-                source_line: Transformer::SourceLineExtractor.extract(text)
+                content: text.to_s
               )
             end
 
@@ -22,31 +21,27 @@ module Coradoc
             rule(text: simple(:text), line_break: simple(:line_break)) do
               Model::TextElement.new(
                 content: text.to_s,
-                line_break: line_break,
-                source_line: Transformer::SourceLineExtractor.extract(text)
+                line_break: line_break
               )
             end
 
             rule(text: sequence(:text), line_break: simple(:line_break)) do
               Model::TextElement.new(
                 content: text,
-                line_break: line_break,
-                source_line: Transformer::SourceLineExtractor.extract(text)
+                line_break: line_break
               )
             end
 
             rule(id: simple(:id), text: simple(:text)) do
               Model::TextElement.new(
                 content: text.to_s,
-                id: id.to_s,
-                source_line: Transformer::SourceLineExtractor.extract(id)
+                id: id.to_s
               )
             end
 
             rule(text: sequence(:text)) do
               Model::TextElement.new(
-                content: text,
-                source_line: Transformer::SourceLineExtractor.extract(text)
+                content: text
               )
             end
 
@@ -58,8 +53,7 @@ module Coradoc
               Model::TextElement.new(
                 content: text.to_s,
                 id: id.to_s,
-                line_break: line_break,
-                source_line: Transformer::SourceLineExtractor.extract(id)
+                line_break: line_break
               )
             end
 
@@ -71,16 +65,14 @@ module Coradoc
               Model::TextElement.new(
                 content: text,
                 id: id.to_s,
-                line_break: line_break,
-                source_line: Transformer::SourceLineExtractor.extract(id)
+                line_break: line_break
               )
             end
 
             # Line break
             rule(line_break: simple(:line_break)) do
               Model::LineBreak.new(
-                line_break:,
-                source_line: Transformer::SourceLineExtractor.extract(line_break)
+                line_break:
               )
             end
 
@@ -95,8 +87,7 @@ module Coradoc
                 content: Transformer.lines_to_text_elements(paragraph[:lines]),
                 id: paragraph[:id],
                 attributes: paragraph[:attribute_list],
-                title: paragraph[:title],
-                source_line: Transformer::SourceLineExtractor.extract(paragraph)
+                title: paragraph[:title]
               )
             end
           end

--- a/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
@@ -688,15 +688,15 @@ RSpec.describe 'Integration pipeline fixes' do
     end
 
     it 'round-trips through mirror_json with image as direct child of example' do
-      require "coradoc-mirror"
+      require 'coradoc-mirror'
 
       adoc = "====\nimage::foo.png[Alt text]\n====\n"
       core = parse_to_core(adoc)
       json = JSON.parse(Coradoc.serialize(core, to: :mirror_json))
 
-      example = json["content"].find { |n| n["type"] == "example" }
-      expect(example["content"].map { |n| n["type"] }).to eq(["image"])
-      expect(example["content"].none? { |n| n["type"] == "paragraph" }).to eq(true)
+      example = json['content'].find { |n| n['type'] == 'example' }
+      expect(example['content'].map { |n| n['type'] }).to eq(['image'])
+      expect(example['content'].none? { |n| n['type'] == 'paragraph' }).to eq(true)
     end
   end
 
@@ -753,15 +753,15 @@ RSpec.describe 'Integration pipeline fixes' do
     end
 
     it 'round-trips through mirror_json as a sourcecode node' do
-      require "coradoc-mirror"
+      require 'coradoc-mirror'
 
       adoc = "```ruby\nputs 'hi'\n```\n"
       core = parse_to_core(adoc)
       json = JSON.parse(Coradoc.serialize(core, to: :mirror_json))
 
-      source = json["content"].find { |n| n["type"] == "sourcecode" }
+      source = json['content'].find { |n| n['type'] == 'sourcecode' }
       expect(source).not_to be_nil
-      expect(source["attrs"]["language"]).to eq("ruby")
+      expect(source['attrs']['language']).to eq('ruby')
     end
   end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/attribute_list/matchers_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/attribute_list/matchers_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::AsciiDoc::Model::AttributeList::Matchers do
   let(:dummy_class) do
@@ -7,68 +7,68 @@ RSpec.describe Coradoc::AsciiDoc::Model::AttributeList::Matchers do
     end
   end
 
-  describe ".one" do
-    it "creates a One matcher" do
-      matcher = dummy_class.one("test", "other")
+  describe '.one' do
+    it 'creates a One matcher' do
+      matcher = dummy_class.one('test', 'other')
       expect(matcher).to be_a(Coradoc::AsciiDoc::Model::AttributeList::Matchers::One)
     end
   end
 
-  describe ".many" do
-    it "creates a Many matcher" do
-      matcher = dummy_class.many("test", "other")
+  describe '.many' do
+    it 'creates a Many matcher' do
+      matcher = dummy_class.many('test', 'other')
       expect(matcher).to be_a(Coradoc::AsciiDoc::Model::AttributeList::Matchers::Many)
     end
   end
 end
 
 RSpec.describe Coradoc::AsciiDoc::Model::AttributeList::Matchers::One do
-  describe "#===" do
-    let(:matcher) { described_class.new("yes", "true", 1) }
+  describe '#===' do
+    let(:matcher) { described_class.new('yes', 'true', 1) }
 
-    it "matches if any possibility matches" do
-      expect(matcher === "yes").to be true
-      expect(matcher === "true").to be true
+    it 'matches if any possibility matches' do
+      expect(matcher === 'yes').to be true
+      expect(matcher === 'true').to be true
       expect(matcher === 1).to be true
     end
 
-    it "does not match if no possibility matches" do
-      expect(matcher === "no").to be false
-      expect(matcher === "false").to be false
+    it 'does not match if no possibility matches' do
+      expect(matcher === 'no').to be false
+      expect(matcher === 'false').to be false
       expect(matcher === 0).to be false
     end
-    
-    it "works with regex possibilities" do
-      regex_matcher = described_class.new(/^test/, "other")
-      expect(regex_matcher === "testing").to be true
-      expect(regex_matcher === "other").to be true
-      expect(regex_matcher === "foo").to be false
+
+    it 'works with regex possibilities' do
+      regex_matcher = described_class.new(/^test/, 'other')
+      expect(regex_matcher === 'testing').to be true
+      expect(regex_matcher === 'other').to be true
+      expect(regex_matcher === 'foo').to be false
     end
   end
 end
 
 RSpec.describe Coradoc::AsciiDoc::Model::AttributeList::Matchers::Many do
-  describe "#===" do
-    let(:matcher) { described_class.new("red", "blue", "green") }
+  describe '#===' do
+    let(:matcher) { described_class.new('red', 'blue', 'green') }
 
-    it "matches if all values in an array match a possibility" do
-      expect(matcher === ["red", "blue"]).to be true
-      expect(matcher === ["green"]).to be true
+    it 'matches if all values in an array match a possibility' do
+      expect(matcher === %w[red blue]).to be true
+      expect(matcher === ['green']).to be true
     end
 
     it "does not match if any value in an array doesn't match" do
-      expect(matcher === ["red", "yellow"]).to be false
+      expect(matcher === %w[red yellow]).to be false
     end
 
-    it "splits string input by comma and matches" do
-      expect(matcher === "red,blue").to be true
-      expect(matcher === "green,red,blue").to be true
-      expect(matcher === "red,yellow").to be false
+    it 'splits string input by comma and matches' do
+      expect(matcher === 'red,blue').to be true
+      expect(matcher === 'green,red,blue').to be true
+      expect(matcher === 'red,yellow').to be false
     end
 
-    it "returns false for non-string/non-array input" do
+    it 'returns false for non-string/non-array input' do
       expect(matcher === 1).to be false
-      expect(matcher === nil).to be false
+      expect(matcher.nil?).to be false
     end
   end
 end

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/bibliography_entry_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/bibliography_entry_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Coradoc::AsciiDoc::Model::BibliographyEntry do
     end
 
     it 'recurses through nested arrays' do
-      expect(described_class.coerce_ref_text(['a', ['b', 'c']])).to eq('abc')
+      expect(described_class.coerce_ref_text(['a', %w[b c]])).to eq('abc')
     end
   end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/content_list_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/content_list_spec.rb
@@ -1,113 +1,113 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::AsciiDoc::Model::ContentList do
-  describe ".new" do
-    it "initializes with items" do
-      content = described_class.new("Hello", "World")
+  describe '.new' do
+    it 'initializes with items' do
+      content = described_class.new('Hello', 'World')
       expect(content.items).to all(be_a(Coradoc::AsciiDoc::Model::TextElement))
-      expect(content.text).to eq("HelloWorld")
+      expect(content.text).to eq('HelloWorld')
     end
 
-    it "flattens array inputs" do
-      content = described_class.new(["Hello", [" ", "World"]])
-      expect(content.text).to eq("Hello World")
+    it 'flattens array inputs' do
+      content = described_class.new(['Hello', [' ', 'World']])
+      expect(content.text).to eq('Hello World')
       expect(content.size).to eq(3)
     end
   end
 
-  describe ".from" do
-    it "returns the same instance if it is already a ContentList" do
-      content = described_class.new("Hello")
+  describe '.from' do
+    it 'returns the same instance if it is already a ContentList' do
+      content = described_class.new('Hello')
       expect(described_class.from(content)).to be(content)
     end
 
-    it "creates a new ContentList from an array" do
-      content = described_class.from(["Hello", "World"])
+    it 'creates a new ContentList from an array' do
+      content = described_class.from(%w[Hello World])
       expect(content).to be_a(described_class)
-      expect(content.text).to eq("HelloWorld")
+      expect(content.text).to eq('HelloWorld')
     end
 
-    it "creates an empty ContentList from nil" do
+    it 'creates an empty ContentList from nil' do
       content = described_class.from(nil)
       expect(content).to be_empty
     end
 
-    it "creates a new ContentList from a single value" do
-      content = described_class.from("Hello")
-      expect(content.text).to eq("Hello")
+    it 'creates a new ContentList from a single value' do
+      content = described_class.from('Hello')
+      expect(content.text).to eq('Hello')
     end
   end
 
-  describe "#each" do
-    it "iterates over items" do
-      content = described_class.new("Hello", "World")
+  describe '#each' do
+    it 'iterates over items' do
+      content = described_class.new('Hello', 'World')
       items = []
       content.each { |item| items << item.content }
-      expect(items).to eq(["Hello", "World"])
+      expect(items).to eq(%w[Hello World])
     end
   end
 
-  describe "#<<" do
-    it "returns a new ContentList with the appended item" do
-      content = described_class.new("Hello")
-      new_content = content << " World"
+  describe '#<<' do
+    it 'returns a new ContentList with the appended item' do
+      content = described_class.new('Hello')
+      new_content = content << ' World'
       expect(new_content).to be_a(described_class)
-      expect(new_content.text).to eq("Hello World")
-      expect(content.text).to eq("Hello") # Immutability check
+      expect(new_content.text).to eq('Hello World')
+      expect(content.text).to eq('Hello') # Immutability check
     end
   end
 
-  describe "#find_type" do
-    it "returns items of the specified type" do
-      bold = Coradoc::AsciiDoc::Model::Inline::Bold.new(content: described_class.new("World"))
-      content = described_class.new("Hello ", bold)
-      
+  describe '#find_type' do
+    it 'returns items of the specified type' do
+      bold = Coradoc::AsciiDoc::Model::Inline::Bold.new(content: described_class.new('World'))
+      content = described_class.new('Hello ', bold)
+
       found = content.find_type(Coradoc::AsciiDoc::Model::Inline::Bold)
       expect(found).to eq([bold])
     end
   end
 
-  describe "#[]" do
-    it "returns the item at the given index" do
-      content = described_class.new("Hello", "World")
-      expect(content[0].content).to eq("Hello")
-      expect(content[1].content).to eq("World")
+  describe '#[]' do
+    it 'returns the item at the given index' do
+      content = described_class.new('Hello', 'World')
+      expect(content[0].content).to eq('Hello')
+      expect(content[1].content).to eq('World')
       expect(content[2]).to be_nil
     end
   end
 
-  describe "#join" do
-    it "joins items with the specified separator" do
-      content = described_class.new("Hello", "World")
-      expect(content.join(" ")).to eq("Hello World")
+  describe '#join' do
+    it 'joins items with the specified separator' do
+      content = described_class.new('Hello', 'World')
+      expect(content.join(' ')).to eq('Hello World')
     end
   end
 
-  describe "#+" do
-    it "concatenates two ContentLists" do
-      content1 = described_class.new("Hello")
-      content2 = described_class.new("World")
+  describe '#+' do
+    it 'concatenates two ContentLists' do
+      content1 = described_class.new('Hello')
+      content2 = described_class.new('World')
       combined = content1 + content2
-      expect(combined.text).to eq("HelloWorld")
+      expect(combined.text).to eq('HelloWorld')
     end
 
-    it "concatenates with an array" do
-      content1 = described_class.new("Hello")
-      combined = content1 + ["World"]
-      expect(combined.text).to eq("HelloWorld")
+    it 'concatenates with an array' do
+      content1 = described_class.new('Hello')
+      combined = content1 + ['World']
+      expect(combined.text).to eq('HelloWorld')
     end
   end
-  
-  describe "#==" do
-    it "is equal to another ContentList with the same items" do
-      content1 = described_class.new("Hello")
-      content2 = described_class.new("Hello")
+
+  describe '#==' do
+    it 'is equal to another ContentList with the same items' do
+      content1 = described_class.new('Hello')
+      content2 = described_class.new('Hello')
       expect(content1).to eq(content2)
     end
-    
-    it "is not equal to another type" do
-      content = described_class.new("Hello")
-      expect(content).not_to eq("Hello")
+
+    it 'is not equal to another type' do
+      content = described_class.new('Hello')
+      expect(content).not_to eq('Hello')
     end
   end
 end

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/glossaries_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/glossaries_spec.rb
@@ -1,13 +1,13 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::AsciiDoc::Model::Glossaries do
-  describe ".new" do
-    it "initializes with items" do
-      glossaries = described_class.new(items: ["term1", "term2"])
-      expect(glossaries.items).to eq(["term1", "term2"])
+  describe '.new' do
+    it 'initializes with items' do
+      glossaries = described_class.new(items: %w[term1 term2])
+      expect(glossaries.items).to eq(%w[term1 term2])
     end
 
-    it "initializes with default empty array for items" do
+    it 'initializes with default empty array for items' do
       glossaries = described_class.new
       expect(glossaries.items).to eq([])
     end

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/inline/cross_reference_arg_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/inline/cross_reference_arg_spec.rb
@@ -1,15 +1,15 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::AsciiDoc::Model::Inline::CrossReferenceArg do
-  describe ".new" do
-    it "initializes with key, delimiter, and value" do
-      arg = described_class.new(key: "text", delimiter: "=", value: "Reference")
-      expect(arg.key).to eq("text")
-      expect(arg.delimiter).to eq("=")
-      expect(arg.value).to eq("Reference")
+  describe '.new' do
+    it 'initializes with key, delimiter, and value' do
+      arg = described_class.new(key: 'text', delimiter: '=', value: 'Reference')
+      expect(arg.key).to eq('text')
+      expect(arg.delimiter).to eq('=')
+      expect(arg.value).to eq('Reference')
     end
 
-    it "initializes with defaults" do
+    it 'initializes with defaults' do
       arg = described_class.new
       expect(arg.key).to be_nil
       expect(arg.delimiter).to be_nil

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/list/nestable_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/list/nestable_spec.rb
@@ -1,10 +1,10 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::AsciiDoc::Model::List::Nestable do
   # Since Nestable is just a subclass of Base providing a common type
   # we test instantiation and inheritance.
-  describe ".new" do
-    it "can be instantiated" do
+  describe '.new' do
+    it 'can be instantiated' do
       nestable = described_class.new
       expect(nestable).to be_a(Coradoc::AsciiDoc::Model::Base)
     end

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/rejected_positional_attribute_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/rejected_positional_attribute_spec.rb
@@ -1,14 +1,14 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::AsciiDoc::Model::RejectedPositionalAttribute do
-  describe ".new" do
-    it "initializes with position and value" do
-      attr = described_class.new(position: 1, value: "test")
+  describe '.new' do
+    it 'initializes with position and value' do
+      attr = described_class.new(position: 1, value: 'test')
       expect(attr.position).to eq(1)
-      expect(attr.value).to eq("test")
+      expect(attr.value).to eq('test')
     end
 
-    it "initializes with defaults" do
+    it 'initializes with defaults' do
       attr = described_class.new
       expect(attr.position).to be_nil
       expect(attr.value).to be_nil

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/resolvable_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/resolvable_spec.rb
@@ -1,16 +1,16 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Coradoc::AsciiDoc::Model::Resolvable do
   let(:test_class) do
     Class.new(Coradoc::AsciiDoc::Model::Base) do
       include Coradoc::AsciiDoc::Model::Resolvable
-      
+
       attr_accessor :custom_path
-      
+
       def reference_path
         custom_path
       end
-      
+
       def reference_type
         :test
       end
@@ -23,59 +23,59 @@ RSpec.describe Coradoc::AsciiDoc::Model::Resolvable do
     end
   end
 
-  describe "interface requirements" do
-    it "raises NotImplementedError if #reference_path is not defined" do
+  describe 'interface requirements' do
+    it 'raises NotImplementedError if #reference_path is not defined' do
       expect { unimplemented_class.new.reference_path }.to raise_error(NotImplementedError)
     end
 
-    it "raises NotImplementedError if #reference_type is not defined" do
+    it 'raises NotImplementedError if #reference_type is not defined' do
       expect { unimplemented_class.new.reference_type }.to raise_error(NotImplementedError)
     end
   end
 
-  describe "#reference_options" do
-    it "returns an empty hash by default" do
+  describe '#reference_options' do
+    it 'returns an empty hash by default' do
       instance = test_class.new
       expect(instance.reference_options).to eq({})
     end
   end
 
-  describe "#local_reference?" do
-    it "returns true for local paths" do
+  describe '#local_reference?' do
+    it 'returns true for local paths' do
       instance = test_class.new
-      instance.custom_path = "/path/to/file.png"
+      instance.custom_path = '/path/to/file.png'
       expect(instance.local_reference?).to be true
-      
-      instance.custom_path = "relative/file.txt"
+
+      instance.custom_path = 'relative/file.txt'
       expect(instance.local_reference?).to be true
     end
 
-    it "returns false for remote URLs" do
+    it 'returns false for remote URLs' do
       instance = test_class.new
-      instance.custom_path = "https://example.com/file.png"
+      instance.custom_path = 'https://example.com/file.png'
       expect(instance.local_reference?).to be false
-      
-      instance.custom_path = "http://example.com/file"
+
+      instance.custom_path = 'http://example.com/file'
       expect(instance.local_reference?).to be false
-      
-      instance.custom_path = "ftp://example.com/file"
+
+      instance.custom_path = 'ftp://example.com/file'
       expect(instance.local_reference?).to be false
     end
-    
-    it "returns false when path is nil" do
+
+    it 'returns false when path is nil' do
       instance = test_class.new
       instance.custom_path = nil
       expect(instance.local_reference?).to be false
     end
   end
 
-  describe "#remote_reference?" do
-    it "returns opposite of local_reference?" do
+  describe '#remote_reference?' do
+    it 'returns opposite of local_reference?' do
       instance = test_class.new
-      instance.custom_path = "https://example.com/file.png"
+      instance.custom_path = 'https://example.com/file.png'
       expect(instance.remote_reference?).to be true
-      
-      instance.custom_path = "local/file.png"
+
+      instance.custom_path = 'local/file.png'
       expect(instance.remote_reference?).to be false
     end
   end

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/resolver_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/resolver_spec.rb
@@ -1,9 +1,9 @@
-require "spec_helper"
-require "fileutils"
+require 'spec_helper'
+require 'fileutils'
 
 RSpec.describe Coradoc::AsciiDoc::Model::Resolver do
-  describe ".new" do
-    it "initializes with default options" do
+  describe '.new' do
+    it 'initializes with default options' do
       resolver = described_class.new
       expect(resolver.include_resolver).to be_nil
       expect(resolver.image_resolver.strategy).to eq(:reference)
@@ -11,23 +11,23 @@ RSpec.describe Coradoc::AsciiDoc::Model::Resolver do
       expect(resolver.output_dir).to be_nil
     end
 
-    it "initializes with custom options" do
+    it 'initializes with custom options' do
       resolver = described_class.new(
         includes: true,
         images: :copy,
         media: :embed,
-        output_dir: "/tmp/output"
+        output_dir: '/tmp/output'
       )
       expect(resolver.include_resolver).to be_a(Coradoc::AsciiDoc::Model::IncludeResolver)
       expect(resolver.image_resolver.strategy).to eq(:copy)
       expect(resolver.media_resolver.strategy).to eq(:embed)
-      expect(resolver.output_dir).to eq("/tmp/output")
+      expect(resolver.output_dir).to eq('/tmp/output')
     end
   end
 
-  describe "resolving models" do
+  describe 'resolving models' do
     let(:resolver) { described_class.new }
-    let(:base_dir) { "/tmp" }
+    let(:base_dir) { '/tmp' }
 
     it "returns the node if it's not a reference" do
       node = Coradoc::AsciiDoc::Model::Paragraph.new
@@ -39,10 +39,10 @@ end
 RSpec.describe Coradoc::AsciiDoc::Model::IncludeResolver do
   let(:resolver) { described_class.new }
   let(:base_dir) { __dir__ }
-  
-  describe "#resolve" do
-    it "returns original node if file not found" do
-      node = Coradoc::AsciiDoc::Model::Include.new(path: "missing_file.adoc")
+
+  describe '#resolve' do
+    it 'returns original node if file not found' do
+      node = Coradoc::AsciiDoc::Model::Include.new(path: 'missing_file.adoc')
       result = resolver.resolve(node, base_dir)
       expect(result).to eq([node])
     end
@@ -50,22 +50,22 @@ RSpec.describe Coradoc::AsciiDoc::Model::IncludeResolver do
 end
 
 RSpec.describe Coradoc::AsciiDoc::Model::ImageResolver do
-  describe "#resolve" do
-    it "returns original node by default for :reference strategy" do
+  describe '#resolve' do
+    it 'returns original node by default for :reference strategy' do
       resolver = described_class.new(strategy: :reference)
-      node = Coradoc::AsciiDoc::Model::Image::BlockImage.new(src: "test.png")
-      result = resolver.resolve(node, "/tmp")
+      node = Coradoc::AsciiDoc::Model::Image::BlockImage.new(src: 'test.png')
+      result = resolver.resolve(node, '/tmp')
       expect(result).to eq(node)
     end
   end
 end
 
 RSpec.describe Coradoc::AsciiDoc::Model::MediaResolver do
-  describe "#resolve" do
-    it "returns original node by default for :reference strategy" do
+  describe '#resolve' do
+    it 'returns original node by default for :reference strategy' do
       resolver = described_class.new(strategy: :reference)
-      node = Coradoc::AsciiDoc::Model::Video.new(src: "test.mp4")
-      result = resolver.resolve(node, "/tmp")
+      node = Coradoc::AsciiDoc::Model::Video.new(src: 'test.mp4')
+      result = resolver.resolve(node, '/tmp')
       expect(result).to eq(node)
     end
   end

--- a/coradoc-adoc/spec/coradoc/asciidoc/model/text_element_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/model/text_element_spec.rb
@@ -23,6 +23,25 @@ RSpec.describe Coradoc::AsciiDoc::Model::TextElement do
     end
   end
 
+  describe 'line-break predicates' do
+    it 'reports a hard break when line_break is +', :aggregate_failures do
+      text = described_class.new(content: 'x', line_break: '+')
+      expect(text.hard_break?).to be(true)
+      expect(text.soft_break?).to be(false)
+    end
+
+    it 'reports a soft break when line_break is empty', :aggregate_failures do
+      text = described_class.new(content: 'x', line_break: '')
+      expect(text.soft_break?).to be(true)
+      expect(text.hard_break?).to be(false)
+    end
+
+    it 'reports a soft break when line_break is unset' do
+      text = described_class.new(content: 'x')
+      expect(text.soft_break?).to be(true)
+    end
+  end
+
   describe '#to_s' do
     it 'returns content as string' do
       text = described_class.new(content: 'Hello World')

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/block_assembler_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/block_assembler_spec.rb
@@ -1,8 +1,8 @@
-require "spec_helper"
-require "coradoc/asciidoc/parser/block_assembler"
+require 'spec_helper'
+require 'coradoc/asciidoc/parser/block_assembler'
 
 RSpec.describe Coradoc::AsciiDoc::Parser::BlockAssembler do
-  describe ".assemble" do
+  describe '.assemble' do
     let(:input) do
       <<~ADOC
         ----
@@ -11,54 +11,54 @@ RSpec.describe Coradoc::AsciiDoc::Parser::BlockAssembler do
       ADOC
     end
 
-    it "returns nil when metadata is nil" do
+    it 'returns nil when metadata is nil' do
       expect(described_class.assemble(input, nil)).to be_nil
     end
 
-    it "includes only delimiter and lines when no title or attributes present" do
+    it 'includes only delimiter and lines when no title or attributes present' do
       metadata = {
         delimiter_line: 0,
-        delimiter: { delimiter: "----" }
+        delimiter: { delimiter: '----' }
       }
       result = described_class.assemble(input, metadata)
       expect(result.keys).to contain_exactly(:delimiter, :lines)
-      expect(result[:delimiter]).to eq("----")
+      expect(result[:delimiter]).to eq('----')
     end
 
-    it "includes title when metadata has :title" do
+    it 'includes title when metadata has :title' do
       metadata = {
         delimiter_line: 0,
-        delimiter: { delimiter: "----" },
-        title: { text: "My Code" }
+        delimiter: { delimiter: '----' },
+        title: { text: 'My Code' }
       }
       result = described_class.assemble(input, metadata)
-      expect(result[:title]).to eq("My Code")
+      expect(result[:title]).to eq('My Code')
     end
 
-    it "includes attribute_list when metadata has :attributes" do
+    it 'includes attribute_list when metadata has :attributes' do
       metadata = {
         delimiter_line: 0,
-        delimiter: { delimiter: "----" },
-        attributes: { content: "[source,ruby]", attributes: ["source", "ruby"] }
+        delimiter: { delimiter: '----' },
+        attributes: { content: '[source,ruby]', attributes: %w[source ruby] }
       }
       result = described_class.assemble(input, metadata)
       expect(result[:attribute_list]).not_to be_nil
     end
 
-    it "includes both title and attribute_list when both are present" do
+    it 'includes both title and attribute_list when both are present' do
       metadata = {
         delimiter_line: 0,
-        delimiter: { delimiter: "----" },
-        title: { text: "T" },
-        attributes: { content: "[source]", attributes: ["source"] }
+        delimiter: { delimiter: '----' },
+        title: { text: 'T' },
+        attributes: { content: '[source]', attributes: ['source'] }
       }
       result = described_class.assemble(input, metadata)
       expect(result.keys).to contain_exactly(:delimiter, :lines, :title, :attribute_list)
     end
   end
 
-  describe ".extract_block_lines" do
-    it "handles plain text" do
+  describe '.extract_block_lines' do
+    it 'handles plain text' do
       input = <<~ADOC
         --
         plain text
@@ -66,13 +66,13 @@ RSpec.describe Coradoc::AsciiDoc::Parser::BlockAssembler do
       ADOC
 
       lines = input.lines
-      result = described_class.extract_block_lines(lines, 0, "--")
+      result = described_class.extract_block_lines(lines, 0, '--')
       expect(result).to eq([
-        { text: "plain text", line_break: "\n" }
-      ])
+                             { text: 'plain text', line_break: "\n" }
+                           ])
     end
 
-    it "handles nested code blocks" do
+    it 'handles nested code blocks' do
       input = <<~ADOC
         --
         [source,console]
@@ -83,38 +83,38 @@ RSpec.describe Coradoc::AsciiDoc::Parser::BlockAssembler do
       ADOC
 
       lines = input.lines
-      result = described_class.extract_block_lines(lines, 0, "--")
+      result = described_class.extract_block_lines(lines, 0, '--')
 
-      expect(result[0]).to eq({ text: "[source,console]", line_break: "\n" })
-      expect(result[1][:block][:delimiter]).to eq("----")
-      expect(result[1][:block][:lines]).to eq([{ text: "brew install metanorma", line_break: "\n" }])
+      expect(result[0]).to eq({ text: '[source,console]', line_break: "\n" })
+      expect(result[1][:block][:delimiter]).to eq('----')
+      expect(result[1][:block][:lines]).to eq([{ text: 'brew install metanorma', line_break: "\n" }])
     end
   end
 
-  describe ".nested_delimiter?" do
-    it "returns true for 4+ identical valid chars" do
-      expect(described_class.nested_delimiter?("----")).to be true
-      expect(described_class.nested_delimiter?("====")).to be true
-      expect(described_class.nested_delimiter?("****")).to be true
+  describe '.nested_delimiter?' do
+    it 'returns true for 4+ identical valid chars' do
+      expect(described_class.nested_delimiter?('----')).to be true
+      expect(described_class.nested_delimiter?('====')).to be true
+      expect(described_class.nested_delimiter?('****')).to be true
     end
 
-    it "returns true for exactly 2 dashes (open block)" do
-      expect(described_class.nested_delimiter?("--")).to be true
+    it 'returns true for exactly 2 dashes (open block)' do
+      expect(described_class.nested_delimiter?('--')).to be true
     end
 
-    it "returns false for 3 dashes (ambiguous)" do
-      expect(described_class.nested_delimiter?("---")).to be false
+    it 'returns false for 3 dashes (ambiguous)' do
+      expect(described_class.nested_delimiter?('---')).to be false
     end
 
-    it "returns false for 2 of any other valid char" do
-      expect(described_class.nested_delimiter?("==")).to be false
-      expect(described_class.nested_delimiter?("**")).to be false
+    it 'returns false for 2 of any other valid char' do
+      expect(described_class.nested_delimiter?('==')).to be false
+      expect(described_class.nested_delimiter?('**')).to be false
     end
 
-    it "returns false for non-delimiter characters" do
-      expect(described_class.nested_delimiter?("xy")).to be false
-      expect(described_class.nested_delimiter?("a")).to be false
-      expect(described_class.nested_delimiter?("")).to be false
+    it 'returns false for non-delimiter characters' do
+      expect(described_class.nested_delimiter?('xy')).to be false
+      expect(described_class.nested_delimiter?('a')).to be false
+      expect(described_class.nested_delimiter?('')).to be false
     end
   end
 end

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/block_header_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/block_header_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Coradoc::AsciiDoc::Parser::BlockHeader do
   describe 'on a source block' do
     describe 'with no header' do
       let(:input) { "----\nplain code\n----\n" }
+
       include_examples 'no duplicate-subtree warning'
 
       it 'builds a SourceCode with nil attributes' do
@@ -47,6 +48,7 @@ RSpec.describe Coradoc::AsciiDoc::Parser::BlockHeader do
 
     describe 'with a single attribute list' do
       let(:input) { "[source,ruby]\n----\nputs 'hi'\n----\n" }
+
       include_examples 'no duplicate-subtree warning'
 
       it 'captures every positional value' do
@@ -58,6 +60,7 @@ RSpec.describe Coradoc::AsciiDoc::Parser::BlockHeader do
 
     describe 'with multiple stacked attribute lists' do
       let(:input) { "[role=quote]\n[source,ruby]\n----\nputs 'hi'\n----\n" }
+
       include_examples 'no duplicate-subtree warning'
 
       it 'merges positional and named values across both lists' do
@@ -71,6 +74,7 @@ RSpec.describe Coradoc::AsciiDoc::Parser::BlockHeader do
 
     describe 'with title, id, and a single attribute list' do
       let(:input) { ".My Title\n[#demo]\n[source,ruby]\n----\ncode\n----\n" }
+
       include_examples 'no duplicate-subtree warning'
 
       it 'captures title, id, and attributes' do
@@ -93,6 +97,7 @@ RSpec.describe Coradoc::AsciiDoc::Parser::BlockHeader do
         |===
       ADOC
     end
+
     include_examples 'no duplicate-subtree warning'
 
     it 'merges both attribute lists into one AttributeList on the Table' do
@@ -108,6 +113,7 @@ RSpec.describe Coradoc::AsciiDoc::Parser::BlockHeader do
 
   describe 'on a block image' do
     let(:input) { "[#img1]\nimage::diagram.png[Diagram]\n" }
+
     include_examples 'no duplicate-subtree warning'
 
     it 'captures id and attributes' do
@@ -151,7 +157,7 @@ RSpec.describe Coradoc::AsciiDoc::Transformer::AttributeListNormalizer do
   end
 
   it 'merges multiple AttributeLists into a single one' do
-    first = build_list(positional: %w[source], named: [['role', 'quote']])
+    first = build_list(positional: %w[source], named: [%w[role quote]])
     second = build_list(positional: %w[ruby])
 
     merged = normalizer.coerce([first, second])

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/callout_merger_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/callout_merger_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Coradoc::AsciiDoc::Transform::CalloutMerger do
     end
 
     it 'attaches a single callout paragraph to a preceding ListingBlock' do
-      src = Coradoc::CoreModel::ListingBlock.new(content: "line <1>")
+      src = Coradoc::CoreModel::ListingBlock.new(content: 'line <1>')
       para = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> annotation')
 
       result = described_class.call([src, para])
@@ -60,7 +60,7 @@ RSpec.describe Coradoc::AsciiDoc::Transform::CalloutMerger do
     end
 
     it 'collects callouts across multiple consecutive paragraphs' do
-      src = Coradoc::CoreModel::SourceBlock.new(content: "code <1>")
+      src = Coradoc::CoreModel::SourceBlock.new(content: 'code <1>')
       first = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> First')
       second = Coradoc::CoreModel::ParagraphBlock.new(content: '<2> Second')
 
@@ -73,7 +73,7 @@ RSpec.describe Coradoc::AsciiDoc::Transform::CalloutMerger do
     end
 
     it 'stops merging when a non-callout paragraph appears' do
-      src = Coradoc::CoreModel::SourceBlock.new(content: "code <1>")
+      src = Coradoc::CoreModel::SourceBlock.new(content: 'code <1>')
       callout = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> note')
       regular = Coradoc::CoreModel::ParagraphBlock.new(content: 'Just text')
 
@@ -87,7 +87,7 @@ RSpec.describe Coradoc::AsciiDoc::Transform::CalloutMerger do
 
     it 'preserves order of unrelated children' do
       para1 = Coradoc::CoreModel::ParagraphBlock.new(content: 'Intro')
-      src = Coradoc::CoreModel::SourceBlock.new(content: "code <1>")
+      src = Coradoc::CoreModel::SourceBlock.new(content: 'code <1>')
       callout = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> note')
       para2 = Coradoc::CoreModel::ParagraphBlock.new(content: 'Outro')
 
@@ -101,7 +101,7 @@ RSpec.describe Coradoc::AsciiDoc::Transform::CalloutMerger do
     end
 
     it 'does not attach a callout paragraph to a non-verbatim block' do
-      quote = Coradoc::CoreModel::QuoteBlock.new(content: "quoted <1>")
+      quote = Coradoc::CoreModel::QuoteBlock.new(content: 'quoted <1>')
       para = Coradoc::CoreModel::ParagraphBlock.new(content: '<1> note')
 
       result = described_class.call([quote, para])

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/document_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/document_transformer_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::DocumentTransf
       header = Coradoc::AsciiDoc::Model::Header.new(
         title: Coradoc::AsciiDoc::Model::Title.new(content: [Coradoc::AsciiDoc::Model::TextElement.new(content: 'My Document')])
       )
-      
+
       para = Coradoc::AsciiDoc::Model::Paragraph.new(
         content: [Coradoc::AsciiDoc::Model::TextElement.new(content: 'Content')]
       )
-      
+
       doc = Coradoc::AsciiDoc::Model::Document.new(
         id: 'doc-1',
         header: header,
         sections: [para]
       )
-      
+
       # We mock the attribute extraction since ToCoreModel might not have a proper Document with attribute lists
       # Wait, no doubles! We just let ToCoreModel.extract_document_attributes run.
 
@@ -55,9 +55,9 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::DocumentTransf
       para = Coradoc::AsciiDoc::Model::Paragraph.new(
         content: [Coradoc::AsciiDoc::Model::TextElement.new(content: 'Section Content')]
       )
-      
+
       title = Coradoc::AsciiDoc::Model::Title.new(content: [Coradoc::AsciiDoc::Model::TextElement.new(content: 'Section One')])
-      
+
       section = Coradoc::AsciiDoc::Model::Section.new(
         id: 'sec-1',
         level: 1,

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/inline_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/inline_transformer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::InlineTransfor
       result = described_class.transform_inline(inline, 'mark')
 
       expect(result).to be_a(Coradoc::CoreModel::InlineElement)
-      
+
       expect(result.content).to eq('highlight')
     end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/other_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/other_transformer_spec.rb
@@ -5,12 +5,19 @@ require 'spec_helper'
 RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::OtherTransformer do
   describe '.transform_term' do
     it 'transforms a term' do
-      # Note: Coradoc::AsciiDoc::Model::Term might be defined slightly differently
+      # NOTE: Coradoc::AsciiDoc::Model::Term might be defined slightly differently
       # We just stub an OpenStruct-like object if it's missing, but we assume it exists as per model
       # actually we should use the real model if it exists, let's use OpenStruct if it's not a real AsciiDoc model
       # wait, the instructions say use real model objects, never double.
       # Let's see if Coradoc::AsciiDoc::Model::Term exists.
-      term = defined?(Coradoc::AsciiDoc::Model::Term) ? Coradoc::AsciiDoc::Model::Term.new(term: 'Apple', type: 'preferred', lang: 'en') : Struct.new(:term, :type, :lang).new('Apple', 'preferred', 'en')
+      term = if defined?(Coradoc::AsciiDoc::Model::Term)
+               Coradoc::AsciiDoc::Model::Term.new(term: 'Apple',
+                                                  type: 'preferred', lang: 'en')
+             else
+               Struct.new(:term, :type, :lang).new(
+                 'Apple', 'preferred', 'en'
+               )
+             end
 
       result = described_class.transform_term(term)
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/transformer/helpers_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transformer/helpers_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Coradoc::AsciiDoc::Transformer do
     end
 
     it 'merges multiple AttributeLists into a single one' do
-      first = build_list(positional: %w[source], named: [['role', 'quote']])
+      first = build_list(positional: %w[source], named: [%w[role quote]])
       second = build_list(positional: %w[ruby])
 
       merged = normalizer.coerce([first, second])
@@ -55,8 +55,8 @@ RSpec.describe Coradoc::AsciiDoc::Transformer do
     end
 
     it 'lets later named keys override earlier ones' do
-      first = build_list(named: [['role', 'a']])
-      second = build_list(named: [['role', 'b']])
+      first = build_list(named: [%w[role a]])
+      second = build_list(named: [%w[role b]])
 
       merged = normalizer.coerce([first, second])
       role_values = merged.named.select { |n| n.name == 'role' }.flat_map(&:value)
@@ -68,8 +68,8 @@ RSpec.describe Coradoc::AsciiDoc::Transformer do
     let(:normalizer) { Coradoc::AsciiDoc::Transformer::AttributeListNormalizer }
 
     it 'concatenates positional and named across lists' do
-      a = build_list(positional: %w[x], named: [['k1', 'v1']])
-      b = build_list(positional: %w[y], named: [['k2', 'v2']])
+      a = build_list(positional: %w[x], named: [%w[k1 v1]])
+      b = build_list(positional: %w[y], named: [%w[k2 v2]])
 
       merged = normalizer.merge([a, b])
       expect(merged.positional.map(&:value)).to eq(%w[x y])

--- a/coradoc-mirror/lib/coradoc/mirror/core_model_to_mirror.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/core_model_to_mirror.rb
@@ -164,7 +164,24 @@ module Coradoc
         value, concat = result
         return unless value
 
+        propagate_source_line(value, element)
         concat ? content.concat(Array(value)) : content << value
+      end
+
+      # Copy parser-attached source_line from the CoreModel element onto
+      # every Mirror node the handler produced. Single touchpoint for the
+      # entire CoreModel → Mirror direction — handlers stay focused on
+      # per-type mapping and don't repeat this concern (DRY).
+      def propagate_source_line(value, element)
+        line = element.source_line
+        return unless line
+
+        Array(value).each do |node|
+          next unless node.is_a?(Node)
+          next if node.source_line
+
+          node.source_line = line
+        end
       end
 
       def build_document_attrs(document)

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
@@ -208,7 +208,11 @@ module Coradoc
           def extract_inline_text(element)
             return element.content.to_s if element.content && !element.content.to_s.empty?
 
-            return element.nested_elements.map { |nested| extract_inline_text(nested) }.join if element.is_a?(CoreModel::InlineElement) && element.nested_elements
+            if element.is_a?(CoreModel::InlineElement) && element.nested_elements
+              return element.nested_elements.map do |nested|
+                extract_inline_text(nested)
+              end.join
+            end
 
             if (element.is_a?(CoreModel::InlineElement) || element.is_a?(CoreModel::Block)) && element.children && !element.children.empty?
               return element.children.map do |child|

--- a/coradoc-mirror/lib/coradoc/mirror/mirror_to_core_model.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/mirror_to_core_model.rb
@@ -19,7 +19,27 @@ module Coradoc
         builder_class = ReverseBuilder.lookup(node.type)
         raise Error, "Unknown mirror node type: #{node.type}" unless builder_class
 
-        builder_class.new(self).build(node)
+        result = builder_class.new(self).build(node)
+        propagate_source_line(result, node)
+        result
+      end
+
+      # Copy parser-attached source_line from the Mirror node onto every
+      # CoreModel node the builder produced. Single touchpoint for the
+      # entire Mirror → CoreModel direction — builders stay focused on
+      # per-type mapping and don't repeat this concern (DRY).
+      def propagate_source_line(result, node)
+        return unless node.is_a?(Node)
+
+        line = node.source_line
+        return unless line
+
+        Array(result).each do |built|
+          next unless built.is_a?(CoreModel::Base)
+          next if built.source_line
+
+          built.source_line = line
+        end
       end
 
       # ── Shared helpers (single source of truth — used by every

--- a/coradoc-mirror/lib/coradoc/mirror/node.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/node.rb
@@ -29,6 +29,13 @@ module Coradoc
       attribute :type, :string, default: -> { self.class::PM_TYPE }
       attribute :content, Node, collection: true
       attribute :marks, Mark, collection: true
+      # Parser metadata, single source of truth on the wire side too.
+      # Carried in memory so CoreModel → Mirror → CoreModel round-trips
+      # preserve the source location. Intentionally absent from every
+      # subclass `key_value` block: source_line is not part of the
+      # ProseMirror JSON contract — editor consumers don't need it, and
+      # serializing it would leak parser internals onto the wire.
+      attribute :source_line, :integer
 
       key_value do
         map 'type', to: :type, render_default: true

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder.rb
@@ -2,34 +2,117 @@
 
 module Coradoc
   module Mirror
-    # OCP-compliant registry for Mirror node -> CoreModel transformation.
+    # OCP-compliant registry for Mirror node → CoreModel transformation.
     #
-    # Adding support for a new Mirror node type is purely additive:
+    # Single source of truth: the TYPE_TO_FILE table below maps every
+    # Mirror wire type string (and its aliases) to the file that
+    # implements its builder. Two things derive from this one table:
     #
-    #   # reverse_builder/<name>.rb
-    #   require_relative 'base'
-    #   module Coradoc::Mirror::ReverseBuilder
-    #     class Figure < Base
-    #       registers 'figure'
-    #       def build(node) = CoreModel::Image.new(...)
-    #     end
-    #   end
+    #   1. autoload declarations — one per unique file, so builders
+    #      load lazily on first lookup (no 47-file eager load at boot).
+    #   2. lookup() — type → file → const_get, which triggers autoload.
     #
-    # Then add a single `require_relative` for the new file below. No edits
-    # to MirrorToCoreModel or any other existing class — the registry is
-    # the single source of truth for "which type string maps to which
-    # builder" (MECE).
+    # Adding a new built-in builder is purely additive:
     #
-    # This file is the autoload target for the ReverseBuilder constant
-    # (see coradoc/mirror.rb). Each Builder subclass lives in its own
-    # file under reverse_builder/; eager-requiring them here populates
-    # the REGISTRY at load time so every caller sees a full registry.
-    # Mirror-level mark dispatch lives in MarkReverseBuilder
-    # (mark_reverse_builder.rb).
+    #   1. Add `'<wire_type>' => '<file_basename>'` to TYPE_TO_FILE.
+    #   2. Create `reverse_builder/<file_basename>.rb` defining
+    #      `class <CamelizedName> < Base; def build(node); ...; end; end`.
+    #
+    # No edits to this file beyond the table — autoload and lookup
+    # adapt automatically. Mirror-level mark dispatch lives in
+    # MarkReverseBuilder (mark_reverse_builder.rb).
+    #
+    # Third-party / runtime builders can still register via
+    # `ReverseBuilder.register(type, klass)`; they take precedence over
+    # built-in autoload entries.
     module ReverseBuilder
-      # Not frozen: subclasses call `register` from their class body at
-      # load time, and `registers` may fire late via autoload. Freezing
-      # here breaks the first mirror-to-core round-trip after load.
+      autoload :Base, "#{__dir__}/reverse_builder/base"
+
+      # Wire type string → file basename under reverse_builder/.
+      # Aliases (e.g. 'clause' and 'annex' both route to section) are
+      # expressed by mapping multiple type strings to the same file.
+      TYPE_TO_FILE = {
+        'doc' => 'document',
+        'section' => 'section',
+        'clause' => 'section',
+        'annex' => 'section',
+        'content_section' => 'section',
+        'abstract' => 'section',
+        'foreword' => 'section',
+        'introduction' => 'section',
+        'acknowledgements' => 'section',
+        'terms' => 'section',
+        'definitions' => 'section',
+        'references' => 'section',
+        'sections' => 'sections',
+        'preface' => 'preamble',
+        'floating_title' => 'header',
+        'heading' => 'header',
+        'paragraph' => 'paragraph',
+        'sourcecode' => 'code_block',
+        'literal' => 'literal_block',
+        'pass' => 'pass_block',
+        'stem' => 'stem_block',
+        'quote' => 'blockquote',
+        'example' => 'example',
+        'sidebar' => 'sidebar',
+        'abstract_block' => 'abstract',
+        'partintro_block' => 'partintro',
+        'open_block' => 'open_block',
+        'verse' => 'verse',
+        'horizontal_rule' => 'horizontal_rule',
+        'thematic_break' => 'horizontal_rule',
+        'soft_break' => 'soft_break',
+        'hard_break' => 'hard_break',
+        'admonition' => 'admonition',
+        'bullet_list' => 'bullet_list',
+        'ordered_list' => 'ordered_list',
+        'list_item' => 'list_item',
+        'dl' => 'definition_list',
+        'dt' => 'inline_text',
+        'dd' => 'inline_text',
+        'image' => 'image',
+        'figure' => 'figure',
+        'caption' => 'caption',
+        'include' => 'include',
+        'table' => 'table',
+        'table_head' => 'table_head',
+        'table_body' => 'table_body',
+        'table_row' => 'table_row',
+        'table_cell' => 'table_cell',
+        'bibliography' => 'bibliography',
+        'biblio_entry' => 'biblio_entry',
+        'footnotes' => 'footnotes',
+        'footnote_entry' => 'footnote_entry',
+        'footnote_marker' => 'footnote_marker',
+        'toc' => 'toc',
+        'toc_entry' => 'toc_entry',
+        'text' => 'text',
+        'raw_inline' => 'raw_inline',
+        'frontmatter' => 'frontmatter',
+        'generic_block' => 'generic_block'
+      }.freeze
+
+      # File basename → Ruby constant name. Derived from the file name
+      # using the project-wide snake_case → CamelCase convention
+      # (every existing builder follows it). Declared once here so
+      # adding a builder that follows convention requires no extra
+      # wiring.
+      FILE_TO_CLASS = TYPE_TO_FILE.each_value.each_with_object({}) do |file, acc|
+        next if acc.key?(file)
+
+        acc[file] = file.split('_').map(&:capitalize).join
+      end.freeze
+
+      # Lazy-load each builder. Lookup triggers autoload via const_get.
+      FILE_TO_CLASS.each do |file, const_name|
+        autoload const_name.to_sym, "#{__dir__}/reverse_builder/#{file}"
+      end
+
+      # Runtime registrations from third-party / external builders.
+      # Takes precedence over built-in autoload entries so external
+      # code can override built-in behaviour (e.g. a custom Paragraph).
+      # Not frozen: register() writes here at runtime.
       REGISTRY = {}
 
       module_function
@@ -38,63 +121,27 @@ module Coradoc
         REGISTRY[type] = builder_class
       end
 
+      # DSL for subclasses to self-register at load time. Kept for
+      # backward compatibility with the existing OCP test pattern that
+      # creates synthetic builders via `Class.new(Base) { registers(...) }`.
+      # Built-in builders no longer call this — their dispatch is
+      # derived from TYPE_TO_FILE.
+      def registers(*types)
+        types.each { |t| register(t, self) }
+      end
+
       def lookup(type)
-        REGISTRY[type]
+        return REGISTRY[type] if REGISTRY.key?(type)
+
+        file = TYPE_TO_FILE[type]
+        return nil unless file
+
+        const_get(FILE_TO_CLASS[file])
       end
 
       def registered_types
-        REGISTRY.keys
+        (REGISTRY.keys + TYPE_TO_FILE.keys).uniq
       end
-
-      # Base must load first — every subclass inherits from it. Then
-      # eager-load each Builder so its `registers` call runs.
-      require_relative 'reverse_builder/base'
-      require_relative 'reverse_builder/document'
-      require_relative 'reverse_builder/section'
-      require_relative 'reverse_builder/header'
-      require_relative 'reverse_builder/preamble'
-      require_relative 'reverse_builder/sections'
-      require_relative 'reverse_builder/paragraph'
-      require_relative 'reverse_builder/code_block'
-      require_relative 'reverse_builder/literal_block'
-      require_relative 'reverse_builder/pass_block'
-      require_relative 'reverse_builder/stem_block'
-      require_relative 'reverse_builder/blockquote'
-      require_relative 'reverse_builder/example'
-      require_relative 'reverse_builder/sidebar'
-      require_relative 'reverse_builder/abstract'
-      require_relative 'reverse_builder/partintro'
-      require_relative 'reverse_builder/open_block'
-      require_relative 'reverse_builder/verse'
-      require_relative 'reverse_builder/horizontal_rule'
-      require_relative 'reverse_builder/frontmatter'
-      require_relative 'reverse_builder/admonition'
-      require_relative 'reverse_builder/bullet_list'
-      require_relative 'reverse_builder/ordered_list'
-      require_relative 'reverse_builder/list_item'
-      require_relative 'reverse_builder/definition_list'
-      require_relative 'reverse_builder/inline_text'
-      require_relative 'reverse_builder/image'
-      require_relative 'reverse_builder/figure'
-      require_relative 'reverse_builder/caption'
-      require_relative 'reverse_builder/include'
-      require_relative 'reverse_builder/table'
-      require_relative 'reverse_builder/table_head'
-      require_relative 'reverse_builder/table_body'
-      require_relative 'reverse_builder/table_row'
-      require_relative 'reverse_builder/table_cell'
-      require_relative 'reverse_builder/bibliography'
-      require_relative 'reverse_builder/biblio_entry'
-      require_relative 'reverse_builder/footnotes'
-      require_relative 'reverse_builder/footnote_entry'
-      require_relative 'reverse_builder/footnote_marker'
-      require_relative 'reverse_builder/toc'
-      require_relative 'reverse_builder/toc_entry'
-      require_relative 'reverse_builder/text'
-      require_relative 'reverse_builder/raw_inline'
-      require_relative 'reverse_builder/soft_break'
-      require_relative 'reverse_builder/hard_break'
-      require_relative 'reverse_builder/generic_block'
     end
   end
 end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/abstract.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/abstract.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Abstract < Base
-        registers 'abstract_block'
-
         def build(node)
           CoreModel::AbstractBlock.new(
             title: node.attrs&.title,

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/admonition.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/admonition.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Admonition < Base
-        registers 'admonition'
-
         def build(node)
           CoreModel::AnnotationBlock.new(
             annotation_type: node.attrs&.admonition_type,

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/biblio_entry.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/biblio_entry.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class BiblioEntry < Base
-        registers 'biblio_entry'
-
         def build(node)
           attrs = node.attrs
           CoreModel::BibliographyEntry.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/bibliography.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/bibliography.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Bibliography < Base
-        registers 'bibliography'
-
         def build(node)
           entries = build_content(node).select { |c| c.is_a?(CoreModel::BibliographyEntry) }
           CoreModel::Bibliography.new(title: node.attrs&.title, entries: entries)

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/blockquote.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/blockquote.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Blockquote < Base
-        registers 'quote'
-
         def build(node)
           CoreModel::QuoteBlock.new(
             attribution: node.attrs&.attribution,

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/bullet_list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/bullet_list.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class BulletList < Base
-        registers 'bullet_list'
-
         def build(node)
           items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
           CoreModel::ListBlock.new(marker_type: 'unordered', items: items)

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/caption.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/caption.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       # Caption only appears as a Figure child. If encountered standalone,
       # extract its text as an inline element so it isn't lost.
       class Caption < Base
-        registers 'caption'
-
         def build(node)
           CoreModel::InlineElement.new(content: extract_text(node))
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/code_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/code_block.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class CodeBlock < Base
-        registers 'sourcecode'
-
         def build(node)
           attrs = node.attrs
           CoreModel::SourceBlock.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/definition_list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/definition_list.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class DefinitionList < Base
-        registers 'dl'
-
         def build(node)
           terms = []
           descriptions = []

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/document.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/document.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Document < Base
-        registers 'doc'
-
         def build(node)
           attrs = node.attrs
           CoreModel::DocumentElement.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/example.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/example.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Example < Base
-        registers 'example'
-
         def build(node)
           CoreModel::ExampleBlock.new(
             title: node.attrs&.title,

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/figure.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/figure.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
@@ -9,8 +7,6 @@ module Coradoc
       # caption. Reverse: collapse back to a single CoreModel::Image,
       # promoting the caption child to `caption:` if present.
       class Figure < Base
-        registers 'figure'
-
         def build(node)
           image_child = node.content&.find { |c| c.is_a?(Node) && c.type == 'image' }
           return nil unless image_child

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnote_entry.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnote_entry.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class FootnoteEntry < Base
-        registers 'footnote_entry'
-
         def build(node)
           attrs = node.attrs
           CoreModel::Footnote.new(id: attrs&.id, content: extract_text(node))

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnote_marker.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnote_marker.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       # Inline footnote marker (JS `footnote_marker`). The CoreModel
       # FootnoteReference holds the same id/ref/number triple.
       class FootnoteMarker < Base
-        registers 'footnote_marker'
-
         def build(node)
           attrs = node.attrs
           CoreModel::FootnoteReference.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnotes.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/footnotes.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
@@ -9,8 +7,6 @@ module Coradoc
       # no CoreModel equivalent (each entry is built separately). Returns
       # nil so build_content filters it out.
       class Footnotes < Base
-        registers 'footnotes'
-
         def build(_node)
           nil
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/frontmatter.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/frontmatter.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Frontmatter < Base
-        registers 'frontmatter'
-
         def build(node)
           attrs = node.attrs
           CoreModel::FrontmatterBlock.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/generic_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/generic_block.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
@@ -9,8 +7,6 @@ module Coradoc
       # direction (`Node::GenericBlock`). Preserves the semantic_type so
       # downstream consumers can dispatch on it.
       class GenericBlock < Base
-        registers 'generic_block'
-
         def build(node)
           attrs = node.attrs
           CoreModel::Block.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/hard_break.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/hard_break.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class HardBreak < Base
-        registers 'hard_break'
-
         def build(_node)
           CoreModel::HardLineBreakElement.new(content: '')
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/header.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/header.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Header < Base
-        registers 'floating_title', 'heading'
-
         def build(node)
           attrs = node.attrs
           CoreModel::HeaderElement.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/horizontal_rule.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/horizontal_rule.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class HorizontalRule < Base
-        registers 'horizontal_rule', 'thematic_break'
-
         def build(_node)
           CoreModel::HorizontalRuleBlock.new
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/image.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/image.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Image < Base
-        registers 'image'
-
         def build(node)
           attrs = node.attrs
           CoreModel::Image.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/include.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/include.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       # Include directive: round-trips back to a CoreModel::Include link
       # node. The text graph is preserved through mirror_json → core.
       class Include < Base
-        registers 'include'
-
         def build(node)
           attrs = node.attrs
           CoreModel::Include.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/inline_text.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/inline_text.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class InlineText < Base
-        registers 'dt', 'dd'
-
         def build(node)
           children = build_inline_children(node)
           text = children.map { |c| c.is_a?(CoreModel::TextContent) ? c.text : '' }.join

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/list_item.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/list_item.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class ListItem < Base
-        registers 'list_item'
-
         LIST_TYPES = %w[bullet_list ordered_list].freeze
         private_constant :LIST_TYPES
 

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/literal_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/literal_block.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class LiteralBlock < Base
-        registers 'literal'
-
         def build(node)
           attrs = node.attrs
           CoreModel::LiteralBlock.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/open_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/open_block.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class OpenBlock < Base
-        registers 'open_block'
-
         def build(node)
           CoreModel::OpenBlock.new(children: build_content(node))
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/ordered_list.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/ordered_list.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class OrderedList < Base
-        registers 'ordered_list'
-
         def build(node)
           items = build_content(node).select { |c| c.is_a?(CoreModel::ListItem) }
           CoreModel::ListBlock.new(marker_type: 'ordered', items: items)

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/paragraph.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/paragraph.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Paragraph < Base
-        registers 'paragraph'
-
         def build(node)
           CoreModel::ParagraphBlock.new(children: build_inline_children(node))
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/partintro.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/partintro.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Partintro < Base
-        registers 'partintro_block'
-
         def build(node)
           CoreModel::PartintroBlock.new(
             title: node.attrs&.title,

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/pass_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/pass_block.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class PassBlock < Base
-        registers 'pass'
-
         def build(node)
           attrs = node.attrs
           CoreModel::PassBlock.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/preamble.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/preamble.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Preamble < Base
-        registers 'preface'
-
         def build(node)
           CoreModel::PreambleElement.new(children: build_content(node))
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/raw_inline.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/raw_inline.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class RawInline < Base
-        registers 'raw_inline'
-
         def build(node)
           CoreModel::RawInlineElement.new(content: node.text.to_s)
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/section.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/section.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
@@ -9,10 +7,6 @@ module Coradoc
       # information lives in the original AsciiDoc and is preserved only
       # on the forward side; the reverse side collapses them.
       class Section < Base
-        registers 'section', 'clause', 'annex', 'content_section',
-                  'abstract', 'foreword', 'introduction',
-                  'acknowledgements', 'terms', 'definitions', 'references'
-
         def build(node)
           attrs = node.attrs
           CoreModel::SectionElement.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/sections.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/sections.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       # `sections` is a structural container only — unwrap directly into
       # an array. MirrorToCoreModel#build_content flattens arrays.
       class Sections < Base
-        registers 'sections'
-
         def build(node)
           build_content(node)
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/sidebar.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/sidebar.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Sidebar < Base
-        registers 'sidebar'
-
         def build(node)
           CoreModel::SidebarBlock.new(
             title: node.attrs&.title,

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/soft_break.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/soft_break.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class SoftBreak < Base
-        registers 'soft_break'
-
         def build(_node)
           CoreModel::LineBreakElement.new
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/stem_block.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/stem_block.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class StemBlock < Base
-        registers 'stem'
-
         def build(node)
           attrs = node.attrs
           CoreModel::StemBlock.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Table < Base
-        registers 'table'
-
         def build(node)
           rows = []
           node.content&.each do |child|

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_body.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_body.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class TableBody < Base
-        registers 'table_body'
-
         def build(node)
           build_content(node).first || CoreModel::TableRow.new
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_cell.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_cell.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class TableCell < Base
-        registers 'table_cell'
-
         def build(node)
           attrs = node.attrs
           CoreModel::TableCell.new(

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_head.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_head.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class TableHead < Base
-        registers 'table_head'
-
         def build(node)
           build_content(node).first || CoreModel::TableRow.new
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_row.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/table_row.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class TableRow < Base
-        registers 'table_row'
-
         def build(node)
           cells = build_content(node).select { |c| c.is_a?(CoreModel::TableCell) }
           CoreModel::TableRow.new(cells: cells)

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/text.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/text.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Text < Base
-        registers 'text'
-
         def build(node)
           text = node.text || ''
           marks = node.marks || []

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/toc.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/toc.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Toc < Base
-        registers 'toc'
-
         def build(_node)
           CoreModel::Toc.new
         end

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/toc_entry.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/toc_entry.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class TocEntry < Base
-        registers 'toc_entry'
-
         def build(node)
           attrs = node.attrs
           CoreModel::TocEntry.new(id: attrs&.id, title: attrs&.title)

--- a/coradoc-mirror/lib/coradoc/mirror/reverse_builder/verse.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/reverse_builder/verse.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Coradoc
   module Mirror
     module ReverseBuilder
       class Verse < Base
-        registers 'verse'
-
         def build(node)
           CoreModel::VerseBlock.new(
             content: extract_text(node),

--- a/coradoc-mirror/spec/coradoc/mirror/frontmatter_query_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/frontmatter_query_spec.rb
@@ -41,12 +41,12 @@ RSpec.describe Coradoc::Mirror::FrontmatterQuery do
 
     it 'preserves nested maps, arrays, integers, booleans, dates' do
       data = {
-        'title'    => 'Doc',
-        'tags'     => %w[a b c],
-        'count'    => 7,
-        'draft'    => false,
-        'published'=> Date.new(2026, 6, 24),
-        'author'   => { 'name' => 'Ada', 'email' => 'ada@example.com' }
+        'title' => 'Doc',
+        'tags' => %w[a b c],
+        'count' => 7,
+        'draft' => false,
+        'published' => Date.new(2026, 6, 24),
+        'author' => { 'name' => 'Ada', 'email' => 'ada@example.com' }
       }
       core = Coradoc::CoreModel::DocumentElement.new(
         children: [Coradoc::CoreModel::FrontmatterBlock.new(data: data)]

--- a/coradoc-mirror/spec/coradoc/mirror/mirror_json_format_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/mirror_json_format_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'json'
 

--- a/coradoc-mirror/spec/coradoc/mirror/partitioner_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/partitioner_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe Coradoc::Mirror::Partitioner do
   describe '.partition' do
     it 'places frontmatter in the metadata bucket, NOT preface' do
       fm = frontmatter_with([
-        Coradoc::Mirror::Node::FrontmatterEntry.new(
-          key: 'title',
-          value: Coradoc::Mirror::Node::FrontmatterValue.new(
-            value_type: 'string', string_value: 'Doc'
-          )
-        )
-      ])
+                              Coradoc::Mirror::Node::FrontmatterEntry.new(
+                                key: 'title',
+                                value: Coradoc::Mirror::Node::FrontmatterValue.new(
+                                  value_type: 'string', string_value: 'Doc'
+                                )
+                              )
+                            ])
       buckets = described_class.partition([fm, para, clause])
 
       expect(buckets[:metadata]).to eq([fm])

--- a/coradoc-mirror/spec/coradoc/mirror/source_line_propagation_spec.rb
+++ b/coradoc-mirror/spec/coradoc/mirror/source_line_propagation_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+# Round-trip coverage for source_line across the Mirror seam.
+# CoreModel sets source_line via the AsciiDoc parser; the Mirror layer
+# must preserve it in memory on both legs of the round-trip so editor
+# integrations (linters, formatters) can still map AST nodes back to
+# source text after a CoreModel → Mirror → CoreModel hop.
+#
+# Wire format note: source_line is intentionally absent from every
+# Mirror Node `key_value` mapping. It is parser metadata, not part of
+# the ProseMirror JSON contract. Memory round-trips preserve it; JSON
+# serialization omits it.
+RSpec.describe 'Mirror source_line propagation', :asciidoc do
+  let(:reverse) { Coradoc::Mirror::MirrorToCoreModel.new }
+  let(:forward) { Coradoc::Mirror::CoreModelToMirror.new }
+
+  describe 'CoreModel → Mirror (forward)' do
+    let(:paragraph) do
+      Coradoc::CoreModel::ParagraphBlock.new(content: 'hello', source_line: 42)
+    end
+    let(:doc) { Coradoc::CoreModel::DocumentElement.new(children: [paragraph]) }
+    let(:node) { Coradoc::Mirror.transform(doc).content.first }
+
+    it 'copies source_line onto the produced Mirror node' do
+      expect(node.source_line).to eq(42)
+    end
+
+    it 'does not serialise source_line into the JSON wire format' do
+      json = Coradoc.serialize(doc, to: :mirror_json)
+      parsed = JSON.parse(json)
+      paragraph_node = parsed.dig('content', 0)
+
+      expect(paragraph_node.key?('source_line')).to be(false)
+    end
+  end
+
+  describe 'Mirror → CoreModel (reverse)' do
+    let(:mirror_node) do
+      Coradoc::Mirror::Node::Paragraph.new(source_line: 7)
+    end
+    let(:mirror_doc) { Coradoc::Mirror::Node::Document.new(content: [mirror_node]) }
+    let(:rebuilt) { reverse.call(mirror_doc).children.first }
+
+    it 'copies source_line onto the rebuilt CoreModel node' do
+      expect(rebuilt.source_line).to eq(7)
+    end
+  end
+
+  describe 'full round-trip preserves source_line' do
+    let(:original) do
+      Coradoc::CoreModel::DocumentElement.new(
+        children: [
+          Coradoc::CoreModel::ParagraphBlock.new(content: 'first', source_line: 3),
+          Coradoc::CoreModel::ParagraphBlock.new(content: 'second', source_line: 5)
+        ]
+      )
+    end
+    let(:mirror_doc) { forward.call(original) }
+    let(:rebuilt) { reverse.call(mirror_doc) }
+
+    it 'preserves source_line on the first paragraph' do
+      expect(rebuilt.children[0].source_line).to eq(3)
+    end
+
+    it 'preserves source_line on the second paragraph' do
+      expect(rebuilt.children[1].source_line).to eq(5)
+    end
+  end
+
+  describe 'source_line absent on input' do
+    let(:paragraph) do
+      Coradoc::CoreModel::ParagraphBlock.new(content: 'x')
+    end
+    let(:doc) { Coradoc::CoreModel::DocumentElement.new(children: [paragraph]) }
+    let(:node) { Coradoc::Mirror.transform(doc).content.first }
+
+    it 'leaves the Mirror node source_line unset' do
+      expect(node.source_line).to be_nil
+    end
+  end
+
+  describe 'source_line already set on the output node' do
+    let(:original_node) do
+      Coradoc::Mirror::Node::Paragraph.new(source_line: 99)
+    end
+    let(:mirror_doc) { Coradoc::Mirror::Node::Document.new(content: [original_node]) }
+
+    it 'reverse builder does not overwrite an explicit source_line', :aggregate_failures do
+      rebuilt = reverse.call(mirror_doc).children.first
+      expect(rebuilt.source_line).to eq(99)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Post-PR-#237 architecture review identified five deepening opportunities. This PR addresses all of them (one turned out to be a false positive — no fix needed).

1. **Source-line propagation moved into the Parslet Transform framework.** `Transformer#call_on_match` post-processes every rule block and injects `source_line` from the matched bindings. Removes 52 inline `SourceLineExtractor.extract(...)` calls across 7 rule files — the framework owns propagation now, so future rules can't forget to wire it.

2. **`Mirror::Node` carries `source_line` in memory.** Single touchpoints in `CoreModelToMirror#handle_element` and `MirrorToCoreModel#build_node` propagate it across the seam. Intentionally absent from every Node `key_value` block — JSON wire format stays ProseMirror-compatible; in-memory round-trips preserve the value.

3. **`AsciiDoc::Model::TextElement` owns `hard_break?`/`soft_break?` predicates.** `InlineTransformVisitor#soft_break_before?` consumes the predicate instead of comparing `line_break` against the literal `'+'`, so the hard-break marker knowledge lives in the model layer (SRP).

4. **`ReverseBuilder` converted from eager `require_relative` + load-time `registers` side effects to `autoload` + table-driven lookup.** Single source of truth for wire type → builder dispatch. 47 builder files cleaned of `registers` calls; subclasses self-register only via the third-party `register()` API. Adding a new built-in builder is now one line in `TYPE_TO_FILE` + one new file.

5. **Verified `[listing]` open-block cast is NOT a bug.** The dispatcher already handles `:listing` at `block_transformer.rb:86`. Exploration false positive; no fix needed.

## Test plan

- [x] coradoc core: 1150 examples, 0 failures
- [x] coradoc-adoc: 1123 examples, 0 failures (5 pending)
- [x] coradoc-html: 616 examples, 0 failures
- [x] coradoc-markdown: 792 examples, 0 failures (1 pending)
- [x] coradoc-mirror: 252 examples, 0 failures (includes new `source_line_propagation_spec.rb`)
- [ ] coradoc-docx: 10 pre-existing failures (unrelated — confirmed failing on main before this branch)
