### PR TITLE
fix(adoc): treat inner backticks as content in constrained monospace

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
@@ -71,7 +71,7 @@ module Coradoc
 
         def monospace_constrained
           (str('`') >>
-            match('[^`\n]').repeat(1).as(:text).repeat(1, 1) >>
+            constrained_span_content('`').as(:text).repeat(1, 1) >>
              str('`') >> str('`').absent?
           ).as(:monospace_constrained)
         end
@@ -234,6 +234,27 @@ module Coradoc
             inline.absent? >>
             match("[^\n]")
           ).repeat(1)
+        end
+
+        # Content model for a constrained inline span (`` `…` ``, `*…*`,
+        # `_…_`, `#…#`). Allows the corresponding unconstrained marker
+        # pair (`` `` ``, `**`, `__`, `##`) to appear inside the content
+        # rather than terminating the span at the first marker character.
+        #
+        # Asciidoctor treats the contents of a constrained span as an
+        # inline literal — nested constrained markers do not close the
+        # span. Without this allowance, `` `<<\`\`x\`\`>>` `` fails to
+        # match as a single monospace span: the parser sees the inner
+        # `` `` `` as a failed single-backtick close attempt, backtracks
+        # out of `monospace_constrained`, and the `<<…>>` payload then
+        # fires the `cross_reference` rule with the backticks glued
+        # onto the target.
+        #
+        # Single source of truth for every constrained rule's content
+        # model — adding a new constrained marker reuses this helper
+        # rather than re-spelling the alternation (DRY).
+        def constrained_span_content(marker)
+          (match("[^#{marker}\n]") | str(marker * 2)).repeat(1)
         end
 
         def text_formatted

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/monospace_literal_content_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/monospace_literal_content_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+
+# Asciidoctor treats the content of a constrained monospace span (`` `…` ``)
+# as an inline literal: nested markup syntax like `<<…>>` xrefs, `link:…`
+# links, or even unconstrained `` ``…`` `` monospace pairs must survive as
+# literal text rather than being re-interpreted by inline rules.
+#
+# Before this fix, `monospace_constrained` only allowed `[^`\n]+` as content,
+# so any inner backtick terminated the match attempt. The closing-backtick
+# lookahead then failed on the inner `` `` `` pair, the whole rule
+# backtracked, and the `<<…>>` payload fired `cross_reference` with the
+# backticks glued onto the xref target.
+#
+# Coverage below locks in the literal-content behaviour for the reported
+# xref case and several neighbours (links, multiple inner pairs, simple
+# monospace still parsing correctly).
+RSpec.describe 'Constrained monospace literal content', :asciidoc do
+  def first_inline(adoc)
+    Coradoc.parse(adoc, format: :asciidoc).children.first.children.first
+  end
+
+  def monospace_with(content)
+    Coradoc::CoreModel::MonospaceElement.new(content: content)
+  end
+
+  describe 'simple monospace (regression guard)' do
+    it 'parses `hello` as a single MonospaceElement' do
+      node = first_inline('`hello`')
+      expect(node).to be_a(Coradoc::CoreModel::MonospaceElement)
+    end
+
+    it 'preserves the inner text' do
+      expect(first_inline('`hello`').content).to eq('hello')
+    end
+  end
+
+  describe 'xref syntax inside backticks' do
+    it 'does not fire cross_reference for `<<target>>`' do
+      node = first_inline('`<<target>>`')
+      expect(node).to be_a(Coradoc::CoreModel::MonospaceElement)
+    end
+
+    it 'preserves the literal `<<target>>` payload as content' do
+      expect(first_inline('`<<target>>`').content).to eq('<<target>>')
+    end
+  end
+
+  describe 'the reported bug: xref with inner unconstrained monospace' do
+    let(:adoc) { '`<<``ricepotentialmilling``>>`' }
+
+    it 'produces a single MonospaceElement', :aggregate_failures do
+      node = first_inline(adoc)
+      expect(node).to be_a(Coradoc::CoreModel::MonospaceElement)
+      expect(node.content).to eq('<<``ricepotentialmilling``>>')
+    end
+
+    it 'does not emit a CrossReferenceElement anywhere in the paragraph' do
+      doc = Coradoc.parse(adoc, format: :asciidoc)
+      flat = doc.children.flat_map(&:children)
+      expect(flat.none?(Coradoc::CoreModel::CrossReferenceElement)).to be(true)
+    end
+  end
+
+  describe 'multiple inner unconstrained pairs' do
+    it 'treats each `` pair as inner content' do
+      expect(first_inline('`a``b``c`').content).to eq('a``b``c')
+    end
+
+    it 'handles three inner pairs' do
+      expect(first_inline('`a``b``c``d`').content).to eq('a``b``c``d')
+    end
+  end
+
+  describe 'other inline markup inside backticks' do
+    it 'does not fire link: inside backticks', :aggregate_failures do
+      node = first_inline('`link:https://example.com[label]`')
+      expect(node).to be_a(Coradoc::CoreModel::MonospaceElement)
+      expect(node.content).to eq('link:https://example.com[label]')
+    end
+
+    it 'does not fire footnote: inside backticks' do
+      node = first_inline('`footnote:[text]`')
+      expect(node).to be_a(Coradoc::CoreModel::MonospaceElement)
+    end
+  end
+
+  describe 'equivalent output for in-memory and serialized forms' do
+    it 'matches the explicit MonospaceElement construction' do
+      parsed = first_inline('`<<``x``>>`')
+      expected = monospace_with('<<``x``>>')
+      expect(parsed.content).to eq(expected.content)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the bug where `<<target>>` cross-reference syntax inside constrained monospace backticks (`` `<<target>>` ``) was parsed as a real xref instead of literal text.

Asciidoctor treats the content of a constrained monospace span as an inline literal — nested markup survives verbatim. The previous `monospace_constrained` rule used `[^`\n]+` for content, which terminated the match at the first inner backtick. The closing-backtick lookahead then failed on the inner ` `` ` pair, the whole rule backtracked, and the `<<...>>` payload fired `cross_reference` with the backticks glued onto the target.

### Fix

Extract a `constrained_span_content(marker)` helper that allows the corresponding unconstrained marker pair (` `` ` for monospace, `**` for bold, `__` for italic, `##` for highlight) to appear inside the content. Apply it to `monospace_constrained`.

The helper is the single source of truth for every constrained rule's content model — adding a new constrained marker reuses it rather than re-spelling the alternation (DRY). Other constrained rules (`bold_constrained`, `italic_constrained`, `highlight_constrained`) can adopt it if the same bug class surfaces for them.

### Real-world impact

The metanorma.org migration depends on coradoc. Two heavily-referenced documentation pages contained `<<...>>` syntax shown inside backticks as documentation, producing 6 broken internal links (URL-encoded as `%60%60ricepotentialmilling%60%60` and `%60%60formulaB-1%60%60`) because the xref target slugified to a path that does not exist.

## Test plan

- [x] New `monospace_literal_content_spec.rb` — 11 examples covering the reported bug case, simple xref-in-backticks, link/footnote-in-backticks, multiple inner unconstrained pairs, regression guard for plain monospace
- [x] coradoc-adoc: 1134 examples, 0 failures (5 pending)
- [x] coradoc core: 1150 examples, 0 failures
- [x] coradoc-mirror: 252 examples, 0 failures
- [x] coradoc-html: 616 examples, 0 failures
- [x] coradoc-markdown: 792 examples, 0 failures (1 pending)
- [ ] coradoc-docx: 10 pre-existing failures (unrelated — confirmed failing on main)
