### PR TITLE
fix(adoc): exclude block titles from section headers

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/block_header.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/block_header.rb
@@ -3,19 +3,29 @@
 module Coradoc
   module AsciiDoc
     module Parser
-      # Single Responsibility: parse the optional header that precedes a block.
+      # Single Responsibility: parse the optional header that precedes a
+      # structural element (block or section).
       #
-      # Encapsulates the canonical AsciiDoc block-header grammar in one place
-      # (DRY, MECE, single source of truth). Before this module existed, every
-      # block-like rule (block, table, section, paragraph, block_image) inlined
-      # its own header rule with subtly different slot orderings — and several
-      # of them captured the same Parslet key more than once in a single
-      # sequence, which triggered Parslet's "Duplicate subtrees while merging
-      # result" warning and silently discarded one of the captured values.
+      # Encapsulates the canonical AsciiDoc header grammar in one place
+      # (DRY, MECE, single source of truth). Two flavours live here because
+      # blocks and sections have different header grammars:
       #
-      # Canonical header shape, each component at most once:
+      #   block_header   = block_title? >> element_id? >> attribute_blocks?
+      #   section_header =                    element_id? >> attribute_blocks?
       #
-      #   block_title? >> element_id? >> attribute_blocks?
+      # Asciidoctor does NOT permit `.Title` to apply to a section — sections
+      # accept `[role]` attribute lists and `[[id]]` anchors but not block
+      # titles. The section's heading IS its title. Mixing the two shapes
+      # into one rule caused `section_block` to admit `.Foo` lines that
+      # collided with `section_title`'s `:title` capture, triggering
+      # Parslet's "Duplicate subtrees while merging result … (keys:
+      # [:title])" warning and silently dropping the block title.
+      #
+      # Before this module existed, every block-like rule inlined its own
+      # header rule with subtly different slot orderings — and several
+      # captured the same Parslet key more than once in a single sequence,
+      # which triggered Parslet's "Duplicate subtrees" warning and silently
+      # discarded one of the captured values.
       #
       # `attribute_blocks` accepts one or more consecutive `[...]` attribute
       # lists, captured as a Parslet sequence under the :attribute_list key.
@@ -31,12 +41,25 @@ module Coradoc
       # every attribute and lets the transformer merge them into a single
       # Coradoc::AsciiDoc::Model::AttributeList downstream.
       module BlockHeader
-        # Canonical block header rule. Single canonical order; each of title,
-        # id, and attribute_blocks is optional and matched at most once.
+        # Canonical block header rule. Includes the block title — every
+        # real block (delimited block, table, paragraph, image) accepts
+        # an optional `.Title` line before its body. Single canonical
+        # order; each of title, id, and attribute_blocks is optional and
+        # matched at most once.
         # @return [Parslet::Atoms::Base]
         def block_header
           block_title.maybe >>
             element_id.maybe >>
+            attribute_blocks.maybe
+        end
+
+        # Section header rule. Asciidoctor does not permit `.Title` on
+        # sections — the section heading itself is the title. Sections
+        # still accept the same element_id and attribute_blocks slots
+        # that blocks do (`[[anchor]]`, `[appendix]`, `[role=x]`, etc.).
+        # @return [Parslet::Atoms::Base]
+        def section_header
+          element_id.maybe >>
             attribute_blocks.maybe
         end
 

--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/section.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/section.rb
@@ -27,7 +27,7 @@ module Coradoc
         def section_block(level = 2)
           return nil if level > 8
 
-          block_header >>
+          section_header >>
             section_title(level).as(:title) >>
             contents.as(:contents).maybe
         end

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/section_header_no_block_title_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/section_header_no_block_title_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stringio'
+require 'coradoc/asciidoc'
+
+# Asciidoctor does not permit `.Title` block-title lines on sections — the
+# section heading IS its title. When `.Foo` precedes `== Heading`, the
+# correct parse is an orphan `.Foo` paragraph (or discarded block title)
+# followed by a clean section. Before this fix, `section_block` reused
+# `block_header` (which includes `block_title.maybe`), so both `block_title`
+# and `section_title` fired inside the same rule, both capturing the
+# Parslet key `:title`. Parslet's hash merge silently dropped one and
+# emitted its "Duplicate subtrees while merging result … (keys: [:title])"
+# warning — visible data loss with a stderr signal.
+#
+# Coverage below locks in:
+#   * The warning no longer fires for `.Foo\n== Heading` (or `...`).
+#   * The orphan block title survives as a paragraph in the document.
+#   * The section is still parsed with the correct heading.
+#   * Legitimate section headers (`[[id]]`, `[role=x]`) still work.
+#   * Block titles on actual blocks (source, example, etc.) are unaffected.
+RSpec.describe 'Block title no longer collides with section title', :asciidoc do
+  let(:captured_stderr) { StringIO.new }
+
+  # Parslet writes the "Duplicate subtrees" warning to $stderr. Capture it
+  # so the spec can assert on the absence of the warning without polluting
+  # the test run's real stderr.
+  def parse_quietly(adoc)
+    original = $stderr
+    $stderr = captured_stderr
+    Coradoc.parse(adoc, format: :asciidoc)
+  ensure
+    $stderr = original
+  end
+
+  def child_classes(doc)
+    doc.children.map(&:class)
+  end
+
+  describe 'reported bug: `.Foo` before section header' do
+    let(:adoc) { ".Foo\n\n== Section\n\nbody\n" }
+    let(:doc) { parse_quietly(adoc) }
+
+    it 'does not emit the Duplicate-subtrees warning' do
+      expect(captured_stderr.string).not_to include('Duplicate subtrees')
+    end
+
+    it 'produces two top-level children (orphan title + section)' do
+      expect(doc.children.length).to eq(2)
+    end
+
+    it 'emits the orphan `.Foo` as a paragraph block' do
+      expect(doc.children[0]).to be_a(Coradoc::CoreModel::ParagraphBlock)
+    end
+
+    it 'still parses the section with the correct title', :aggregate_failures do
+      section = doc.children[1]
+      expect(section).to be_a(Coradoc::CoreModel::SectionElement)
+      expect(section.title).to eq('Section')
+    end
+
+    it 'does not attach the block title to the section' do
+      expect(doc.children[1].title).to eq('Section')
+    end
+  end
+
+  describe '`...` triple-dot edge case' do
+    # `...` triggers the bug because `.` matches the block-title marker
+    # and `..` becomes the title text. With the fix, the parser no longer
+    # admits a block title here either.
+    it 'does not emit the Duplicate-subtrees warning' do
+      parse_quietly("...\n\n== Section\n\nbody\n")
+      expect(captured_stderr.string).not_to include('Duplicate subtrees')
+    end
+  end
+
+  describe 'legitimate section headers (regression guard)' do
+    def first_section(adoc)
+      parse_quietly(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::SectionElement) }
+    end
+
+    it 'parses a section with [[id]] anchor', :aggregate_failures do
+      section = first_section("[[my-id]]\n== Section\n\nbody\n")
+      expect(section).to be_a(Coradoc::CoreModel::SectionElement)
+      expect(section.title).to eq('Section')
+    end
+
+    it 'parses a section with [#id] shorthand anchor' do
+      section = first_section("[#my-id]\n== Section\n\nbody\n")
+      expect(section).to be_a(Coradoc::CoreModel::SectionElement)
+    end
+
+    it 'parses a section with [role=x] attribute list' do
+      section = first_section("[role=appendix]\n== Appendix\n\nbody\n")
+      expect(section.title).to eq('Appendix')
+    end
+
+    it 'parses a section with [appendix] style marker' do
+      section = first_section("[appendix]\n== Appendix\n\nbody\n")
+      expect(section.title).to eq('Appendix')
+    end
+
+    it 'parses a section with both anchor and role' do
+      section = first_section("[[sec-1]]\n[role=x]\n== Section\n\nbody\n")
+      expect(section.title).to eq('Section')
+    end
+
+    it 'does not emit warnings for any of the legitimate header forms' do
+      parse_quietly("[[id]]\n[role=x]\n== Section\n\nbody\n")
+      expect(captured_stderr.string).not_to include('Duplicate subtrees')
+    end
+  end
+
+  describe 'block titles on real blocks (regression guard)' do
+    def first_block(adoc)
+      parse_quietly(adoc).children.first
+    end
+
+    it 'still attaches `.Title` to a source block', :aggregate_failures do
+      block = first_block(".My Title\n----\ncode\n----\n")
+      expect(block).to be_a(Coradoc::CoreModel::SourceBlock)
+      expect(block.title).to eq('My Title')
+    end
+
+    it 'still attaches `.Title` to an example block', :aggregate_failures do
+      block = first_block(".Example\n====\nbody\n====\n")
+      expect(block).to be_a(Coradoc::CoreModel::ExampleBlock)
+      expect(block.title).to eq('Example')
+    end
+
+    it 'still attaches `.Title` to a quote block', :aggregate_failures do
+      block = first_block(".Quoted\n____\nbody\n____\n")
+      expect(block).to be_a(Coradoc::CoreModel::QuoteBlock)
+      expect(block.title).to eq('Quoted')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the bug where `.Foo` block-title lines preceding a section header (`== Heading`) caused Parslet to emit a "Duplicate subtrees while merging result … (keys: [:title])" warning and silently drop the block title from the parse tree.

### Root cause

`section_block` reused `block_header`, which includes `block_title.maybe`. But Asciidoctor does not permit `.Title` on sections — the section heading IS its title. When `.Foo` precedes `== Heading`, both `block_title` and `section_title` fired inside the same rule, both capturing the Parslet key `:title`. Parslet's hash merge silently dropped one.

### Fix

Split `block_header` into two flavours in the `BlockHeader` module:

```
block_header   = block_title? >> element_id? >> attribute_blocks?
section_header =                    element_id? >> attribute_blocks?
```

`section_block` now calls `section_header`. Single source of truth for header grammar stays in `BlockHeader` (DRY); the split reflects a real semantic difference between blocks (accept titles) and sections (don't) rather than an ad-hoc per-rule workaround (MECE).

The previous `block_header.rb:13` comment documented the prior instance of this bug class — collisions *within* `block_header`. This PR addresses the cross-rule variant: collisions between `block_header`'s `:title` capture and `section_title`'s `:title` capture.

### Real-world impact

The metanorma.org conversion pipeline saw 2 affected files (`learn/exercises_code/exercise-2-3-{1,2}.adoc`) where the block title silently vanished from the converted output. After this fix, the orphan `.Foo` becomes a paragraph and the section parses cleanly.

## Test plan

- [x] New `section_header_no_block_title_spec.rb` — 15 examples covering the reported bug case, the `...` triple-dot edge case, legitimate section header forms (`[[id]]`, `[#id]`, `[role=x]`, `[appendix]`), and a regression guard verifying block titles still attach to actual blocks (source, example, quote)
- [x] coradoc-adoc: 1149 examples, 0 failures (5 pending)
- [x] coradoc core: 1150 examples, 0 failures
- [x] coradoc-html: 616 examples, 0 failures
- [x] coradoc-markdown: 792 examples, 0 failures (1 pending)
- [ ] coradoc-docx: 10 pre-existing failures (unrelated — confirmed failing on main)
