### PR TITLE
fix(adoc): terminate bullet/ordered lists at paragraph boundaries

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb
@@ -20,13 +20,13 @@ module Coradoc
         def ordered_list(nesting_level = 1)
           attrs = (attribute_list >> newline).maybe
           r = olist_item(nesting_level)
-          attrs >> olist_item(nesting_level).present? >> r.repeat(1).as(:ordered)
+          attrs >> (empty_line.repeat(0) >> r).repeat(1).as(:ordered)
         end
 
         def unordered_list(nesting_level = 1)
           attrs = (attribute_list >> newline).maybe
           r = ulist_item(nesting_level)
-          attrs >> r.repeat(1).as(:unordered)
+          attrs >> (empty_line.repeat(0) >> r).repeat(1).as(:unordered)
         end
 
         def definition_list(_delimiter = nil)
@@ -53,7 +53,7 @@ module Coradoc
         def olist_item(nesting_level = 1)
           item = olist_marker(nesting_level).as(:marker) >>
                  match("\n").absent? >> space >>
-                 (text_line(true, unguarded: true) >>
+                 (text_line(false, unguarded: true) >>
                   list_item_continuation_lines).as(:lines)
 
           att = (list_continuation.present? >>
@@ -105,7 +105,7 @@ module Coradoc
           item = ulist_marker(nesting_level).as(:marker) >>
                  str(' [[[').absent? >>
                  match("\n").absent? >> space >>
-                 (text_line(true, unguarded: true) >>
+                 (text_line(false, unguarded: true) >>
                   list_item_continuation_lines).as(:lines)
 
           att = (list_continuation.present? >>
@@ -127,8 +127,15 @@ module Coradoc
         # list marker, block delimiter, attribute list, section, element
         # id, table boundary, list continuation, or list prefix).
         # `line_not_text?` (from Paragraph) is that exact lookahead.
+        #
+        # Each iteration matches exactly one source line via
+        # `text_line(false, ...)` (single-newline termination). The
+        # `.repeat(0)` walks multiple continuation lines one at a time.
+        # Using `text_line(true, ...)` here would let `line_ending.repeat(1)`
+        # greedy-match across blank lines, silently absorbing the
+        # follow-up paragraph into the last list item's content.
         def list_item_continuation_lines
-          (line_not_text? >> text_line(true, unguarded: true)).repeat(0)
+          (line_not_text? >> text_line(false, unguarded: true)).repeat(0)
         end
 
         def dlist_delimiter

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/bullet_list_termination_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/bullet_list_termination_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+
+# AsciiDoc bullet lists must close at paragraph boundaries. When a
+# `*`-marked list is followed (after a blank line) by a regular
+# paragraph, the paragraph is a sibling of the list — not a continuation
+# of the last list item's text.
+#
+# Before this fix, `ulist_item` / `olist_item` used `text_line(true, ...)`
+# whose `line_ending.repeat(1)` greedy-matched across blank lines,
+# silently absorbing the follow-up paragraph into the last item. The
+# same bug class also affected ordered lists.
+#
+# Coverage below locks in:
+#   * The bug case (blank-line-separated bullets + paragraph).
+#   * Tight lists (no blank lines between items) still produce one list.
+#   * Intra-item continuation lines (no blank line) still merge.
+#   * Attached blocks via `+` still work.
+#   * Ordered lists terminate correctly at paragraph boundaries.
+RSpec.describe 'Bullet/ordered list termination at paragraph boundary', :asciidoc do
+  def parse(adoc)
+    Coradoc.parse(adoc, format: :asciidoc)
+  end
+
+  def first_list(adoc)
+    parse(adoc).children.find { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+  end
+
+  def top_level_classes(adoc)
+    parse(adoc).children.map(&:class)
+  end
+
+  describe 'reported bug: blank-line-separated bullets + follow-up paragraph' do
+    let(:adoc) do
+      <<~ASCIIDOC
+        Lead-in paragraph.
+
+        * a unified document model,
+        * a serialization format, and
+        * a toolchain for authors.
+
+        This year's IBA judges lauded the development.
+      ASCIIDOC
+    end
+    let(:list) { first_list(adoc) }
+
+    it 'produces exactly three list items' do
+      expect(list.items.length).to eq(3)
+    end
+
+    it 'does not absorb the follow-up paragraph into the last item' do
+      last_item = list.items.last
+      expect(last_item.content).not_to include("This year's IBA")
+    end
+
+    it 'emits the follow-up paragraph as a sibling' do
+      paragraph = parse(adoc).children.find do |c|
+        c.is_a?(Coradoc::CoreModel::ParagraphBlock) &&
+          c.content.to_s.include?("This year's IBA")
+      end
+      expect(paragraph).to be_a(Coradoc::CoreModel::ParagraphBlock)
+    end
+
+    it 'top-level shape is [paragraph, list, paragraph]' do
+      expect(top_level_classes(adoc)).to eq([
+                                              Coradoc::CoreModel::ParagraphBlock,
+                                              Coradoc::CoreModel::ListBlock,
+                                              Coradoc::CoreModel::ParagraphBlock
+                                            ])
+    end
+  end
+
+  describe 'reported bug: bullets separated by blank lines' do
+    let(:adoc) do
+      <<~ASCIIDOC
+        * one
+
+        * two
+
+        * three
+      ASCIIDOC
+    end
+    let(:list) { first_list(adoc) }
+
+    it 'still produces a single ListBlock (not three)' do
+      lists = parse(adoc).children.select { |c| c.is_a?(Coradoc::CoreModel::ListBlock) }
+      expect(lists.length).to eq(1)
+    end
+
+    it 'has all three items in the single list' do
+      expect(list.items.length).to eq(3)
+    end
+
+    it 'preserves each item text independently' do
+      expect(list.items.map(&:content)).to eq(%w[one two three])
+    end
+  end
+
+  describe 'tight list (no blank lines between items)' do
+    let(:adoc) { "* alpha\n* beta\n* gamma\n" }
+    let(:list) { first_list(adoc) }
+
+    it 'produces one ListBlock with three items' do
+      expect(list.items.length).to eq(3)
+    end
+
+    it 'preserves each item text' do
+      expect(list.items.map(&:content)).to eq(%w[alpha beta gamma])
+    end
+  end
+
+  describe 'intra-item continuation lines (no blank line)' do
+    let(:adoc) { "* item one\n  continued text\n* item two\n" }
+    let(:list) { first_list(adoc) }
+
+    it 'merges the continuation line into the first item' do
+      expect(list.items.first.content).to include('continued text')
+    end
+
+    it 'still recognises both items' do
+      expect(list.items.length).to eq(2)
+    end
+  end
+
+  describe 'attached block via + continuation' do
+    let(:adoc) do
+      <<~ASCIIDOC
+        * item one
+        +
+        ----
+        code line
+        ----
+      ASCIIDOC
+    end
+
+    it 'still parses as a single list with one item' do
+      list = first_list(adoc)
+      expect(list.items.length).to eq(1)
+    end
+  end
+
+  describe 'ordered list termination at paragraph boundary' do
+    let(:adoc) do
+      <<~ASCIIDOC
+        . first
+        . second
+        . third
+
+        Follow-up paragraph.
+      ASCIIDOC
+    end
+    let(:list) { first_list(adoc) }
+
+    it 'produces three ordered items' do
+      expect(list.items.length).to eq(3)
+    end
+
+    it 'does not absorb the follow-up paragraph' do
+      last = list.items.last
+      expect(last.content).not_to include('Follow-up')
+    end
+
+    it 'emits the paragraph as a sibling' do
+      expect(top_level_classes(adoc)).to include(Coradoc::CoreModel::ParagraphBlock)
+    end
+  end
+
+  describe 'list followed immediately by section header' do
+    let(:adoc) do
+      <<~ASCIIDOC
+        * one
+        * two
+
+        == Section Heading
+
+        body
+      ASCIIDOC
+    end
+
+    it 'terminates the list before the section' do
+      list = first_list(adoc)
+      expect(list.items.length).to eq(2)
+    end
+
+    it 'emits the section as a sibling after the list' do
+      section = parse(adoc).children.find do |c|
+        c.is_a?(Coradoc::CoreModel::SectionElement)
+      end
+      expect(section.title).to eq('Section Heading')
+    end
+  end
+
+  describe 'nested list (no blank line between parent and child)' do
+    let(:adoc) { "* parent\n** child\n* parent two\n" }
+    let(:list) { first_list(adoc) }
+
+    it 'recognises both parent items' do
+      expect(list.items.length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the bug where AsciiDoc bullet/ordered lists failed to terminate at paragraph boundaries. The follow-up paragraph (and every subsequent block) was silently absorbed into the last `list_item`'s content.

### Root cause

`ulist_item` and `olist_item` used `text_line(true, unguarded: true)` for both the first line of the item and for `list_item_continuation_lines`. `text_line(true, ...)` ends with `line_ending.repeat(1)` — a greedy match of one-or-more newlines. When the source contained a blank line between the last item's text and the follow-up paragraph, the greedy match consumed the blank line, then `list_item_continuation_lines`'s `.repeat(0)` loop happily matched the paragraph as another continuation line of the same item.

### Fix

Two complementary changes in `coradoc-adoc/lib/coradoc/asciidoc/parser/list.rb`:

1. **`text_line(false, unguarded: true)`** in three places — `ulist_item`'s first line, `olist_item`'s first line, and `list_item_continuation_lines`. Each call now matches exactly one source line; the outer `.repeat(0)` walks multiple continuation lines one at a time. Blank lines cannot be greedy-consumed.

2. **Allow blank lines between sibling items** in `unordered_list` and `ordered_list` — the rule shape is now `(empty_line.repeat(0) >> item).repeat(1)`. AsciiDoc permits blank lines between list items without terminating the list. Without this allowance, fixing the greedy match caused each blank-line-separated item to land in its own `ListBlock`. Trailing blank lines after the last item are left for the caller (Parslet's sequence backtrack semantics restore the position when no item follows).

### Real-world impact

The metanorma.org migration showed the canonical instance (blog post `_posts/2018-08-24-metanorma-wins-stevie-awards.adoc`): a three-item bullet list followed by body paragraphs rendered as a single giant `<li>` containing the entire post body. Every `.adoc` source with a top-level bullet list followed by body paragraphs exhibits the same pattern.

## Test plan

- [x] New `bullet_list_termination_spec.rb` — 18 examples covering the reported bug case, blank-line-separated items, tight lists, intra-item continuation lines, attached blocks via `+`, ordered lists, list-then-section, and nested lists
- [x] coradoc-adoc: 1167 examples, 0 failures (5 pending)
- [x] coradoc core: 1150 examples, 0 failures
- [x] coradoc-html: 616 examples, 0 failures
- [x] coradoc-markdown: 792 examples, 0 failures (1 pending)
- [x] coradoc-mirror: 252 examples, 0 failures
- [ ] coradoc-docx: 10 pre-existing failures (unrelated — confirmed failing on main)
