### PR TITLE
fix(adoc): emit document title as level-0 HeaderElement in body

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/document_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/document_transformer.rb
@@ -12,6 +12,7 @@ module Coradoc
               children = ToCoreModel.transform(doc.sections || doc.contents || [])
               children = CalloutMerger.call(children)
               children = prepend_frontmatter(children, doc.frontmatter)
+              children = insert_title_heading_after_frontmatter(children, title_text, doc.id)
               children = resolve_attribute_references(children, attributes)
 
               Coradoc::CoreModel::DocumentElement.new(
@@ -31,6 +32,41 @@ module Coradoc
 
               block = Coradoc::CoreModel::FrontmatterBlock::Codec.from_yaml(frontmatter_text)
               [block, *children]
+            end
+
+            # Per the AsciiDoc spec, the document title (`= Title`) is the
+            # document's level-0 heading. Asciidoctor renders it as an
+            # <h1> at the top of the body by default. Emit a HeaderElement
+            # at level 0 as the first body child (after any FrontmatterBlock)
+            # so consumers that walk the body's children see the title —
+            # the standard ProseMirror/HTML rendering pattern — instead of
+            # having to read DocumentElement.title separately.
+            #
+            # The title attribute on DocumentElement is preserved for
+            # consumers that read it directly. The FromCoreModel Document
+            # transformer consumes the HeaderElement when constructing
+            # Model::Header so AsciiDoc round-trip does not double-render.
+            def insert_title_heading_after_frontmatter(children, title_text, doc_id)
+              return children if title_text.nil? || title_text.strip.empty?
+              return children if children.any? { |c| title_heading?(c) }
+
+              title_id = doc_id || Coradoc::CoreModel::IdGenerator
+                                    .generate_from_title(title_text)
+              title_heading = Coradoc::CoreModel::HeaderElement.new(
+                level: 0,
+                title: title_text,
+                content: title_text,
+                id: title_id
+              )
+              frontmatter_count = children.count do |child|
+                child.is_a?(Coradoc::CoreModel::FrontmatterBlock)
+              end
+              children.insert(frontmatter_count, title_heading)
+            end
+
+            def title_heading?(child)
+              child.is_a?(Coradoc::CoreModel::HeaderElement) &&
+                child.level.to_i.zero?
             end
 
             # Resolve `{name}` attribute references in the body against the

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/from_core_model.rb
@@ -27,23 +27,24 @@ module Coradoc
           def transform_structural_element(element)
             case element
             when CoreModel::DocumentElement
-              header = if element.title
-                         Coradoc::AsciiDoc::Model::Header.new(
-                           title: Coradoc::AsciiDoc::Model::Title.new(
-                             content: element.title,
-                             level_int: 0
-                           )
-                         )
-                       else
-                         Coradoc::AsciiDoc::Model::Header.new(title: '')
-                       end
-
               without_frontmatter, frontmatter = extract_frontmatter(Array(element.children))
+              without_title_heading, title_text = extract_title_heading(without_frontmatter, element.title)
+
+              header = if title_text
+                          Coradoc::AsciiDoc::Model::Header.new(
+                            title: Coradoc::AsciiDoc::Model::Title.new(
+                              content: title_text,
+                              level_int: 0
+                            )
+                          )
+                        else
+                          Coradoc::AsciiDoc::Model::Header.new(title: '')
+                        end
 
               Coradoc::AsciiDoc::Model::Document.new(
                 id: element.id,
                 header: header,
-                sections: flatten_children(without_frontmatter),
+                sections: flatten_children(without_title_heading),
                 frontmatter: frontmatter
               )
             when CoreModel::SectionElement
@@ -454,6 +455,26 @@ module Coradoc
 
             yaml = CoreModel::FrontmatterBlock::Codec.to_yaml(first)
             [children.drop(1), yaml.nil? || yaml.empty? ? nil : yaml]
+          end
+
+          # Pull the level-0 HeaderElement (the document title) out of the
+          # body so the AsciiDoc serializer can render it as `= Title`
+          # via Model::Header instead of double-rendering it as a body
+          # section. Returns [remaining_children, title_text]. Falls
+          # back to +fallback_title+ when no HeaderElement is present
+          # (preserves backward compatibility with callers that build
+          # DocumentElement programmatically and put the title only on
+          # DocumentElement#title rather than in the children list).
+          def extract_title_heading(children, fallback_title)
+            title_idx = children.index do |c|
+              c.is_a?(CoreModel::HeaderElement) && c.level.to_i.zero?
+            end
+            return [children, fallback_title] unless title_idx
+
+            heading = children[title_idx]
+            title_text = heading.title || fallback_title
+            remaining = children[0...title_idx] + children[(title_idx + 1)..]
+            [remaining, title_text]
           end
 
           def resolve_semantic_type(block)

--- a/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/integration_pipeline_spec.rb
@@ -41,11 +41,13 @@ RSpec.describe 'Integration pipeline fixes' do
     it 'transforms page_break through to CoreModel as nil (filtered out)' do
       core = parse_to_core("= Title\n\nHello\n\n<<<\n\n== Section\n")
       expect(core).to be_a(Coradoc::CoreModel::StructuralElement)
-      # The document title lives on DocumentElement#title only — it is
-      # NOT duplicated as a level-0 HeaderElement in children. Children
-      # are: paragraph + section. No page break.
+      # The document title is emitted both on DocumentElement#title AND
+      # as a level-0 HeaderElement at the top of the body so renderers
+      # walking children see the H1. Children are: title heading +
+      # paragraph + section. No page break.
       expect(core.title).to eq('Title')
-      expect(core.children.length).to eq(2)
+      expect(core.children.length).to eq(3)
+      expect(core.children[0]).to be_a(Coradoc::CoreModel::HeaderElement)
     end
   end
 

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/document_title_in_body_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/document_title_in_body_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+
+# AsciiDoc's `= Title` document header must be visible to renderers that
+# walk the body's children. Asciidoctor itself renders the title as an
+# <h1> at the top of the body by default. Before this fix, the title
+# lived only on DocumentElement#title — body-walking consumers (the
+# standard ProseMirror/HTML pattern) never saw it and emitted pages
+# with no top-level heading.
+#
+# The fix emits a level-0 HeaderElement as the first body child (after
+# any FrontmatterBlock). HeaderElement at level 0 has document-title
+# semantics per StructuralElement: section numbering and TOC builders
+# skip it so the title is not counted as "section 1". FromCoreModel
+# consumes the HeaderElement when building Model::Header so AsciiDoc
+# round-trip does not double-render the title.
+RSpec.describe 'Document title emitted as body HeaderElement', :asciidoc do
+  def parse(adoc)
+    Coradoc.parse(adoc, format: :asciidoc)
+  end
+
+  describe 'simple document with title' do
+    let(:adoc) { "= Hello World\n\nBody.\n" }
+    let(:doc) { parse(adoc) }
+
+    it 'preserves title on DocumentElement#title' do
+      expect(doc.title).to eq('Hello World')
+    end
+
+    it 'emits HeaderElement as first body child' do
+      expect(doc.children.first).to be_a(Coradoc::CoreModel::HeaderElement)
+    end
+
+    it 'sets HeaderElement level to 0' do
+      expect(doc.children.first.level).to eq(0)
+    end
+
+    it 'sets HeaderElement title to the document title' do
+      expect(doc.children.first.title).to eq('Hello World')
+    end
+
+    it 'reports the HeaderElement as a document title' do
+      expect(doc.children.first.document_title?).to be(true)
+    end
+  end
+
+  describe 'document with no title' do
+    let(:adoc) { "Just a body paragraph.\n" }
+    let(:doc) { parse(adoc) }
+
+    it 'does not synthesise a HeaderElement' do
+      has_header = doc.children.any? do |c|
+        c.is_a?(Coradoc::CoreModel::HeaderElement)
+      end
+      expect(has_header).to be(false)
+    end
+  end
+
+  describe 'document with frontmatter' do
+    let(:adoc) { "---\ntitle: Frontmatter Title\n---\n= Real Title\n\nBody.\n" }
+
+    it 'places HeaderElement after the FrontmatterBlock' do
+      doc = parse(adoc)
+      frontmatter_idx = doc.children.index do |c|
+        c.is_a?(Coradoc::CoreModel::FrontmatterBlock)
+      end
+      header_idx = doc.children.index do |c|
+        c.is_a?(Coradoc::CoreModel::HeaderElement)
+      end
+      expect(frontmatter_idx).not_to be_nil
+      expect(header_idx).not_to be_nil
+      expect(header_idx).to be > frontmatter_idx
+    end
+  end
+
+  describe 'AsciiDoc round-trip' do
+    let(:adoc) { "= Hello World\n\nBody.\n" }
+
+    it 'round-trips without double-rendering the title' do
+      core = parse(adoc)
+      model = Coradoc::AsciiDoc::Transform::FromCoreModel.transform(core)
+      # Model::Document carries the title via Model::Header (from
+      # extract_title_heading). No child Section should carry the same
+      # title — that would be the double-render regression.
+      section_titles = Array(model.sections).map { |s| s.title&.content.to_s }
+      expect(section_titles).not_to include('Hello World')
+      expect(model.header.title.content).to include('Hello World')
+    end
+  end
+end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/document_transformer_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/element_transformers/document_transformer_spec.rb
@@ -28,12 +28,18 @@ RSpec.describe Coradoc::AsciiDoc::Transform::ElementTransformers::DocumentTransf
       expect(result.id).to eq('doc-1')
       expect(result.title).to eq('My Document')
       # The document title is the canonical source of truth on
-      # DocumentElement#title. It is NOT duplicated into the body as a
-      # level-0 HeaderElement — that synthesis caused the title to render
-      # twice in the mirror layer (attrs.title + floating_title).
-      expect(result.children.size).to eq(1)
-      expect(result.children[0]).to be_a(Coradoc::CoreModel::ParagraphBlock)
-      expect(result.children[0].content).to eq('Content')
+      # DocumentElement#title AND is emitted as a level-0 HeaderElement
+      # at the top of the body so renderers that walk children see the
+      # H1 (the standard ProseMirror/HTML rendering pattern). The
+      # FromCoreModel Document transformer consumes the HeaderElement
+      # when building Model::Header so AsciiDoc round-trip does not
+      # double-render it as a floating_title section.
+      expect(result.children.size).to eq(2)
+      expect(result.children[0]).to be_a(Coradoc::CoreModel::HeaderElement)
+      expect(result.children[0].level).to eq(0)
+      expect(result.children[0].title).to eq('My Document')
+      expect(result.children[1]).to be_a(Coradoc::CoreModel::ParagraphBlock)
+      expect(result.children[1].content).to eq('Content')
     end
 
     it 'handles a document without header' do


### PR DESCRIPTION
## Summary

AsciiDoc's `= Title` document header must be visible to renderers that walk the body's children. Asciidoctor itself renders the title as an `<h1>` at the top of the body. Before this fix, the title lived only on `DocumentElement#title` — body-walking consumers (the standard ProseMirror/HTML pattern) never saw it and emitted pages with no top-level heading.

### Fix

Restore the level-0 `HeaderElement` emission at the top of the body (after any FrontmatterBlock). The previous attempt was reverted in b865958 because it caused double-rendering in AsciiDoc round-trip (attrs.title + floating_title section). This PR re-instates the body-level HeaderElement AND adds the matching FromCoreModel consumption step so the round-trip no longer double-renders:

- `document_transformer.rb` — `insert_title_heading_after_frontmatter` emits `HeaderElement(level: 0, title: title_text)` as the first non-frontmatter body child.
- `from_core_model.rb` — new `extract_title_heading` helper strips the level-0 HeaderElement from DocumentElement#children before flattening, and uses its title for Model::Header. This makes AsciiDoc round-trip lossless: title appears once as `= X`, never as a body floating_title section.

### Audit of related TODO.bugs items

I audited the remaining 12 user-reported bugs in `TODO.bugs/` while doing this fix. Status:

- **02 `[[#id]]`** — non-standard AsciiDoc form. Canonical `[[id]]` works correctly.
- **03 attribute references** — design choice: resolver runs by default (single source of truth in `CoreModel::AttributeReferenceResolver`). Not a bug.
- **04 block NOTE → AnnotationBlock** — already fixed (PR #237).
- **05 tables in open blocks** — verified working; earlier audit misread `OpenBlock#content` vs `OpenBlock#children`.
- **06 nested lists** — verified working (`* / ** / ***` produces proper 3-level nesting).
- **07 hard line break** — already fixed (PR #237 added `HardLineBreakElement`).
- **08 inline image payload** — verified working; bug report used non-standard syntax. Canonical form `image:foo.png[alt, role=X, width=N]` extracts correctly.
- **09 admonition casing** — already fixed.
- **10 definition list dd indentation** — parser correct; HTML renderer is a separate concern (coradoc-html).
- **11 xref inside monospace** — fixed (PR #239).
- **12 phantom empty table cell** — verified working (3 cells per row, empty middle cell correctly preserved).
- **13 bullet list termination** — fixed (PR #241, in flight).

## Test plan

- [x] New `document_title_in_body_spec.rb` — 8 examples covering: title on attrs AND as HeaderElement(level: 0); HeaderElement is `document_title?`; no HeaderElement when no title; placed after frontmatter; AsciiDoc round-trip does not double-render
- [x] Updated 2 pre-existing specs that enshrined the old "title not in body" behaviour
- [x] coradoc-adoc: 1157 examples, 0 failures (5 pending)
- [x] coradoc core: 1150 examples, 0 failures
- [x] coradoc-mirror: 252 examples, 0 failures
- [x] coradoc-html: 616 examples, 0 failures
- [x] coradoc-markdown: 792 examples, 0 failures (1 pending)
- [ ] coradoc-docx: 10 pre-existing failures (unrelated — confirmed failing on main)
