### PR TITLE
fix(adoc): recognise typographic quote patterns before monospace

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
@@ -4,6 +4,27 @@ module Coradoc
   module AsciiDoc
     module Parser
       module Inline
+        # AsciiDoc typographic quote syntax: a 2-char pattern that
+        # Asciidoctor substitutes with the corresponding Unicode curly
+        # quote. Single source of truth for the pattern → Unicode char
+        # mapping; the transformer reads this table.
+        #
+        # The patterns MUST be recognised before +monospace_constrained+
+        # in the +inline+ alternation, otherwise the lone backtick in
+        # +`"`+ or +`"``+ fires monospace and the surrounding quote
+        # collapses to straight ASCII quotes wrapped around a spurious
+        # code span.
+        TYPOGRAPHIC_QUOTE_PATTERNS = {
+          '"`' => "“",  # U+201C left double
+          '`"' => "”",  # U+201D right double
+          "'`" => "‘",  # U+2018 left single
+          "`'" => "’"   # U+2019 right single
+        }.freeze
+
+        def typographic_quote
+          (str('"`') | str('`"') | str("'`") | str("`'")).as(:typographic_quote)
+        end
+
         def attribute_reference
           str('{').present? >> str('{') >>
             match('[a-zA-Z0-9_-]').repeat(1).as(:attribute_reference) >>
@@ -170,6 +191,7 @@ module Coradoc
 
         def inline_chars?
           match('[\[*#_{<^~`]').present? |
+            typographic_quote.present? |
             str('http').present? |
             str('https').present? |
             str('link:').present? |
@@ -198,7 +220,8 @@ module Coradoc
         end
 
         def inline
-          bold_unconstrained |
+          typographic_quote |
+            bold_unconstrained |
             bold_constrained |
             span_unconstrained |
             span_constrained |

--- a/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb
@@ -67,6 +67,19 @@ module Coradoc
               )
             end
 
+            # Typographic quotes — Asciidoctor's curly-quote substitution.
+            # Each 2-char pattern collapses to a single Unicode character
+            # at parse time so downstream consumers (HTML, Markdown) see
+            # the literal typographic char without any post-processing.
+            # The mapping is the single source of truth declared on the
+            # parser side (Parser::Inline::TYPOGRAPHIC_QUOTE_PATTERNS).
+            rule(typographic_quote: simple(:pattern)) do
+              char = Coradoc::AsciiDoc::Parser::Inline::TYPOGRAPHIC_QUOTE_PATTERNS.fetch(
+                pattern.to_s, pattern.to_s
+              )
+              Model::TextElement.new(content: char)
+            end
+
             # Hard line break (` +\n` or `\\n`). Emitted as a dedicated
             # AsciiDoc model (Inline::HardLineBreak) distinct from
             # Model::LineBreak, which only represents paragraph-separator

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/typographic_quotes_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/typographic_quotes_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+
+# AsciiDoc's typographic quote syntax (`` "` `` / `` `" `` / `` '` `` /
+# `` `' ``) substitutes straight ASCII quotes with curly Unicode quotes.
+# Before this fix, the backtick in the 2-char pattern was parsed as
+# constrained monospace, leaving the surrounding quote as a straight
+# literal and wrapping the quoted text in a spurious `code` mark.
+# When the quoted text contained an inline mark (`__italic__`,
+# `**bold**`), the inner mark was never recognised and the entire
+# span — including the marker characters — was absorbed as raw
+# content of the misidentified monospace.
+#
+# Coverage below locks in:
+#   * Each of the four patterns emits the correct Unicode char.
+#   * Inner inline marks (italic, bold) are recognised inside quotes.
+#   * Plain monospace (`` `...` ``) still works when not preceded
+#     by a quote char.
+RSpec.describe 'Typographic quote substitution', :asciidoc do
+  def first_paragraph_children(adoc)
+    Coradoc.parse(adoc, format: :asciidoc).children.first.children
+  end
+
+  describe 'curly double quotes' do
+    let(:children) { first_paragraph_children('He said "`hello world`" to me.') }
+
+    it 'emits U+201C for the opener' do
+      expect(children.map { |c| c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : nil })
+        .to include('“')
+    end
+
+    it 'emits U+201D for the closer' do
+      expect(children.map { |c| c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : nil })
+        .to include('”')
+    end
+
+    it 'does not wrap the inner text in a MonospaceElement' do
+      expect(children.none?(Coradoc::CoreModel::MonospaceElement)).to be(true)
+    end
+
+    it 'preserves the inner text as plain text' do
+      texts = children.map { |c| c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : '' }
+      expect(texts.join).to include('hello world')
+    end
+  end
+
+  describe 'curly single quotes' do
+    let(:children) { first_paragraph_children("She replied '`hi there`'.") }
+
+    it 'emits U+2018 for the opener' do
+      expect(children.map { |c| c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : nil })
+        .to include('‘')
+    end
+
+    it 'emits U+2019 for the closer' do
+      expect(children.map { |c| c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : nil })
+        .to include('’')
+    end
+  end
+
+  describe 'inline marks inside curly double quotes' do
+    let(:children) { first_paragraph_children('"`__important__`" was the key word.') }
+
+    it 'recognises __italic__ as ItalicElement' do
+      italic = children.find { |c| c.is_a?(Coradoc::CoreModel::ItalicElement) }
+      expect(italic).not_to be_nil
+    end
+
+    it 'produces correct text in the italic element' do
+      italic = children.find { |c| c.is_a?(Coradoc::CoreModel::ItalicElement) }
+      expect(italic.content).to include('important')
+    end
+
+    it 'does not leave raw __ markers in the output' do
+      combined = children.flat_map do |c|
+        c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : c.content.to_s
+      end.join
+      expect(combined).not_to include('__')
+    end
+  end
+
+  describe 'inline marks inside curly double quotes (bold)' do
+    let(:children) { first_paragraph_children('"`**critical**`" was another.') }
+
+    it 'recognises **bold** as BoldElement', :aggregate_failures do
+      bold = children.find { |c| c.is_a?(Coradoc::CoreModel::BoldElement) }
+      expect(bold).not_to be_nil
+      expect(bold.content).to include('critical')
+    end
+  end
+
+  describe 'plain monospace still works' do
+    let(:children) { first_paragraph_children('Type `code` here.') }
+
+    it 'wraps plain `code` in a MonospaceElement', :aggregate_failures do
+      mono = children.find { |c| c.is_a?(Coradoc::CoreModel::MonospaceElement) }
+      expect(mono).not_to be_nil
+      expect(mono.content).to include('code')
+    end
+  end
+
+  describe 'unconstrained marks still work' do
+    it '**bold** produces BoldElement' do
+      children = first_paragraph_children('This is **bold** text.')
+      bold = children.find { |c| c.is_a?(Coradoc::CoreModel::BoldElement) }
+      expect(bold.content).to include('bold')
+    end
+
+    it '__italic__ produces ItalicElement' do
+      children = first_paragraph_children('This is __italic__ text.')
+      italic = children.find { |c| c.is_a?(Coradoc::CoreModel::ItalicElement) }
+      expect(italic.content).to include('italic')
+    end
+
+    it '``code`` produces MonospaceElement' do
+      children = first_paragraph_children('This is ``code`` text.')
+      mono = children.find { |c| c.is_a?(Coradoc::CoreModel::MonospaceElement) }
+      expect(mono.content).to include('code')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

AsciiDoc's curly-quote syntax substitutes 2-char patterns with the corresponding Unicode typographic chars (`` "` ``→", `` `" ``→", `` '` ``→', `` `' ``→'). Before this fix, the lone backtick in the pattern was parsed as constrained monospace, leaving the surrounding quote as a straight literal and wrapping the quoted text in a spurious `code` span.

When the quoted text contained an inline mark (`__italic__`, `**bold**`), the inner mark was never recognised — the entire span including the marker characters was absorbed as raw content of the misidentified monospace.

### Real-world impact

The metanorma.org migration showed this on every blog post that quotes a person or document (`_posts/2018-08-24-metanorma-wins-stevie-awards.adoc` and similar). Production HTML rendered `` "`__revolutionary concept__`" `` as `"<code>__revolutionary concept__</code>"` — straight quotes, spurious monospace, raw `__` bleeding through. Worse, the parser's confusion about quote boundaries cascaded into spurious emphasis on unrelated text in the same paragraph.

### Fix

In `coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb`:

- New `TYPOGRAPHIC_QUOTE_PATTERNS` constant — single source of truth for the four pattern → Unicode char mappings.
- New `typographic_quote` parslet rule matching any of the four patterns and capturing as `:typographic_quote`.
- The `typographic_quote` rule is placed FIRST in the `inline` alternation, ahead of `monospace_constrained`.
- `inline_chars?` gains a `typographic_quote.present?` lookahead so `text_formatted` enters the inline path at the opening quote char.

In `coradoc-adoc/lib/coradoc/asciidoc/transformer/inline_rules.rb`:

- New transformer rule for `:typographic_quote` looks up the matched pattern in `TYPOGRAPHIC_QUOTE_PATTERNS` and emits a `Model::TextElement` carrying the Unicode char.

The inner content of a quoted span is regular inline content, so `__italic__` and `**bold__` inside quotes are now recognised and emitted as `ItalicElement`/`BoldElement` as expected.

## Test plan

- [x] New `typographic_quotes_spec.rb` — 14 examples covering each of the four patterns, inner italic/bold recognition, plain monospace still working, unconstrained marks still working
- [x] coradoc-adoc: 1163 examples, 0 failures (5 pending)
- [x] coradoc core: 1150 examples, 0 failures
- [x] coradoc-html: 616 examples, 0 failures
- [x] coradoc-markdown: 792 examples, 0 failures (1 pending)
- [ ] coradoc-docx: 10 pre-existing failures (unrelated — confirmed failing on main)
