### PR TITLE
fix(adoc): typography regression — visitor space synthesis + multi-line unconstrained marks

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/parser/inline.rb
@@ -41,7 +41,7 @@ module Coradoc
 
         def bold_unconstrained
           (str('**').present? >> str('**') >>
-            match('[^*\n]').repeat(1).as(:text).repeat(1, 1) >>
+            match('[^*]').repeat(1).as(:text).repeat(1, 1) >>
              str('**')
           ).as(:bold_unconstrained)
         end
@@ -71,7 +71,7 @@ module Coradoc
 
         def italic_unconstrained
           (str('__') >>
-            match('[^_\n]').repeat(1).as(:text).repeat(1, 1) >>
+            match('[^_]').repeat(1).as(:text).repeat(1, 1) >>
              str('__')
           ).as(:italic_unconstrained)
         end
@@ -99,7 +99,7 @@ module Coradoc
 
         def monospace_unconstrained
           (str('``') >>
-            match('[^`\n]').repeat(1).as(:text).repeat(1, 1) >>
+            match('[^\`]').repeat(1).as(:text).repeat(1, 1) >>
              str('``')
           ).as(:monospace_unconstrained)
         end

--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/inline_transform_visitor.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/inline_transform_visitor.rb
@@ -55,22 +55,25 @@ module Coradoc
             transformed = visit_content(item)
             next if transformed.empty?
 
-            result << CoreModel::TextContent.new(text: ' ') if soft_break_before?(previous, item)
+            result << CoreModel::TextContent.new(text: ' ') if line_break_between?(previous, item)
             result.concat(transformed)
             previous = item
           end
           result
         end
 
-        # Two adjacent TextElements in the content array indicate the
-        # parser split a paragraph across source lines. Join them with a
-        # space (soft break) unless the second one carries a hard-break
-        # marker — the model owns that predicate, so this method does
-        # not reach into parser-specific line_break string values.
-        def soft_break_before?(previous, current)
-          previous.is_a?(Model::TextElement) &&
-            current.is_a?(Model::TextElement) &&
-            !current.hard_break?
+        # Two adjacent TextElements only warrant a synthesised soft-break
+        # space when the parser actually split them across a source line —
+        # i.e. the previous TextElement carries a non-empty line_break.
+        # Adjacent inline elements whose source was a single line
+        # (e.g. text + typographic-quote + text) do NOT need a synthesised
+        # space: their source adjacency is exact, and adding one would
+        # introduce spurious double-spaces (TODO.bugs/15A).
+        def line_break_between?(previous, current)
+          return false unless previous.is_a?(Model::TextElement)
+          return false if current.is_a?(Model::TextElement) && current.hard_break?
+
+          !previous.line_break.to_s.empty?
         end
 
         def visit_model(model)

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/typographic_quotes_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/typographic_quotes_spec.rb
@@ -5,22 +5,31 @@ require 'coradoc/asciidoc'
 
 # AsciiDoc's typographic quote syntax (`` "` `` / `` `" `` / `` '` `` /
 # `` `' ``) substitutes straight ASCII quotes with curly Unicode quotes.
-# Before this fix, the backtick in the 2-char pattern was parsed as
-# constrained monospace, leaving the surrounding quote as a straight
-# literal and wrapping the quoted text in a spurious `code` mark.
-# When the quoted text contained an inline mark (`__italic__`,
-# `**bold**`), the inner mark was never recognised and the entire
-# span — including the marker characters — was absorbed as raw
-# content of the misidentified monospace.
+# Single-line marks (italic, bold) inside curly quotes are recognised
+# correctly. Multi-line unconstrained marks (italic __ / bold **) span
+# line breaks inside curly quotes — the parser's mark content
+# excludes newlines by default, so relaxing that exclusion makes
+# multi-line marks work the way Asciidoctor does.
 #
 # Coverage below locks in:
 #   * Each of the four patterns emits the correct Unicode char.
-#   * Inner inline marks (italic, bold) are recognised inside quotes.
-#   * Plain monospace (`` `...` ``) still works when not preceded
-#     by a quote char.
+#   * Inner text is NOT wrapped in a spurious MonospaceElement.
+#   * Single-line italic / bold inside quotes work.
+#   * Multi-line italic / bold inside quotes work (TODO.bugs/15B).
+#   * Source whitespace is preserved exactly — no synthesised
+#     double-spaces around the quote (TODO.bugs/15A).
+#   * Plain monospace (`code`) still works when not preceded by a
+#     quote char.
+#   * Unconstrained marks outside quote context still work.
 RSpec.describe 'Typographic quote substitution', :asciidoc do
   def first_paragraph_children(adoc)
     Coradoc.parse(adoc, format: :asciidoc).children.first.children
+  end
+
+  def text_only(children)
+    children.flat_map do |c|
+      c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : c.content.to_s
+    end.join
   end
 
   describe 'curly double quotes' do
@@ -39,11 +48,6 @@ RSpec.describe 'Typographic quote substitution', :asciidoc do
     it 'does not wrap the inner text in a MonospaceElement' do
       expect(children.none?(Coradoc::CoreModel::MonospaceElement)).to be(true)
     end
-
-    it 'preserves the inner text as plain text' do
-      texts = children.map { |c| c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : '' }
-      expect(texts.join).to include('hello world')
-    end
   end
 
   describe 'curly single quotes' do
@@ -60,41 +64,90 @@ RSpec.describe 'Typographic quote substitution', :asciidoc do
     end
   end
 
-  describe 'inline marks inside curly double quotes' do
-    let(:children) { first_paragraph_children('"`__important__`" was the key word.') }
+  describe 'source whitespace preserved (TODO.bugs/15A regression guard)' do
+    # The straight `"` chars in the source are PART of the typographic
+    # pattern (the open pattern is `"` + `` ` ``, the close is `` ` `` + `"`)
+    # and get consumed/replaced by the curly chars. The expected joined
+    # text therefore contains only the curly quotes, with the source's
+    # surrounding ASCII spaces preserved exactly.
+    it 'preserves single spaces around quoted text without synthesising extras' do
+      children = first_paragraph_children('He said "`hello world`" to me.')
+      joined = text_only(children)
+      expect(joined).to eq("He said “hello world” to me.")
+    end
 
+    it 'preserves leading space after the closer' do
+      children = first_paragraph_children('He said "`hello`" to me.')
+      joined = text_only(children)
+      expect(joined).to eq("He said “hello” to me.")
+    end
+
+    it 'does not synthesise extra spaces between adjacent text and quote tokens' do
+      children = first_paragraph_children('a "`x`" b')
+      texts = children.map do |c|
+        c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : c.content.to_s
+      end
+      expect(texts).to eq(['a ', '“', 'x', '”', ' b'])
+    end
+  end
+
+  describe 'multi-line marks inside curly quotes (TODO.bugs/15B)' do
+    it 'recognises __italic__ spanning a line break' do
+      children = first_paragraph_children("\"`__Setting\nstandards__`\"")
+      italic = children.find { |c| c.is_a?(Coradoc::CoreModel::ItalicElement) }
+      expect(italic).not_to be_nil
+      expect(italic.content).to include("Setting\nstandards")
+    end
+
+    it 'recognises **bold** spanning a line break' do
+      children = first_paragraph_children("\"`**Setting\nstandards**`\"")
+      bold = children.find { |c| c.is_a?(Coradoc::CoreModel::BoldElement) }
+      expect(bold).not_to be_nil
+      expect(bold.content).to include("Setting\nstandards")
+    end
+
+    it 'does not leak raw __ markers in multi-line italic output' do
+      children = first_paragraph_children("\"`__Setting\nstandards__`\"")
+      joined = text_only(children)
+      expect(joined).not_to include('__')
+    end
+
+    it 'does not leak raw ** markers in multi-line bold output' do
+      children = first_paragraph_children("\"`**Setting\nstandards**`\"")
+      joined = text_only(children)
+      expect(joined).not_to include('**')
+    end
+  end
+
+  describe 'inline marks inside curly quotes (single-line, regression)' do
     it 'recognises __italic__ as ItalicElement' do
+      children = first_paragraph_children('"`__Setting__`"')
       italic = children.find { |c| c.is_a?(Coradoc::CoreModel::ItalicElement) }
       expect(italic).not_to be_nil
     end
 
-    it 'produces correct text in the italic element' do
-      italic = children.find { |c| c.is_a?(Coradoc::CoreModel::ItalicElement) }
-      expect(italic.content).to include('important')
-    end
-
-    it 'does not leave raw __ markers in the output' do
-      combined = children.flat_map do |c|
-        c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : c.content.to_s
-      end.join
-      expect(combined).not_to include('__')
-    end
-  end
-
-  describe 'inline marks inside curly double quotes (bold)' do
-    let(:children) { first_paragraph_children('"`**critical**`" was another.') }
-
-    it 'recognises **bold** as BoldElement', :aggregate_failures do
+    it 'recognises **bold** as BoldElement' do
+      children = first_paragraph_children('"`**critical**`"')
       bold = children.find { |c| c.is_a?(Coradoc::CoreModel::BoldElement) }
       expect(bold).not_to be_nil
-      expect(bold.content).to include('critical')
+    end
+
+    it 'recognises _constrained italic_ as ItalicElement' do
+      children = first_paragraph_children('"`_Setting_`"')
+      italic = children.find { |c| c.is_a?(Coradoc::CoreModel::ItalicElement) }
+      expect(italic).not_to be_nil
+    end
+
+    it 'recognises *constrained bold* as BoldElement' do
+      children = first_paragraph_children('"`*Setting*`"')
+      bold = children.find { |c| c.is_a?(Coradoc::CoreModel::BoldElement) }
+      expect(bold).not_to be_nil
     end
   end
 
   describe 'plain monospace still works' do
-    let(:children) { first_paragraph_children('Type `code` here.') }
-
-    it 'wraps plain `code` in a MonospaceElement', :aggregate_failures do
+    it 'wraps plain `code` in a MonospaceElement' do
+      children = first_paragraph_children('Type `code` here.')
       mono = children.find { |c| c.is_a?(Coradoc::CoreModel::MonospaceElement) }
       expect(mono).not_to be_nil
       expect(mono.content).to include('code')
@@ -118,6 +171,13 @@ RSpec.describe 'Typographic quote substitution', :asciidoc do
       children = first_paragraph_children('This is ``code`` text.')
       mono = children.find { |c| c.is_a?(Coradoc::CoreModel::MonospaceElement) }
       expect(mono.content).to include('code')
+    end
+
+    it '__multi-line italic__ outside quotes produces ItalicElement spanning newlines' do
+      children = first_paragraph_children("__Setting\nstandards__")
+      italic = children.find { |c| c.is_a?(Coradoc::CoreModel::ItalicElement) }
+      expect(italic).not_to be_nil
+      expect(italic.content).to include("Setting\nstandards")
     end
   end
 end

--- a/coradoc-adoc/spec/coradoc/asciidoc/transform/inline_transform_visitor_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/transform/inline_transform_visitor_spec.rb
@@ -101,12 +101,20 @@ RSpec.describe Coradoc::AsciiDoc::Transform::InlineTransformVisitor do
         expect(result.last).to be_a(Coradoc::CoreModel::ItalicElement)
       end
 
-      it 'inserts space between adjacent TextElements' do
-        te1 = Coradoc::AsciiDoc::Model::TextElement.new(content: 'hello')
+      it 'inserts space between adjacent TextElements when previous ended with a line break' do
+        te1 = Coradoc::AsciiDoc::Model::TextElement.new(content: 'hello', line_break: "\n")
         te2 = Coradoc::AsciiDoc::Model::TextElement.new(content: 'world')
         result = visitor.transform([te1, te2])
         texts = result.map { |r| r.is_a?(Coradoc::CoreModel::TextContent) ? r.text : r.content.to_s }
         expect(texts).to eq(['hello', ' ', 'world'])
+      end
+
+      it 'does not insert space between adjacent TextElements on the same line' do
+        te1 = Coradoc::AsciiDoc::Model::TextElement.new(content: 'hello')
+        te2 = Coradoc::AsciiDoc::Model::TextElement.new(content: 'world')
+        result = visitor.transform([te1, te2])
+        texts = result.map { |r| r.is_a?(Coradoc::CoreModel::TextContent) ? r.text : r.content.to_s }
+        expect(texts).to eq(['hello', 'world'])
       end
 
       it 'does not insert space before first item' do


### PR DESCRIPTION
## Summary

Follow-up to PR #243 (curly-quote recognition, bug 14). That fix introduced two visible regressions on edge cases in the canonical test case `_posts/2018-08-24-metanorma-wins-stevie-awards.adoc`.

### Bug 15A — Spurious whitespace around plain-text curly quotes

The visitor's `soft_break_before?` synthesised a space between ANY two adjacent `TextElement` nodes. For `` "`hello world`" ``, the curly-quote tokens became individual `TextElement` nodes, and the visitor fired between them and the surrounding text — producing double-spaces in the rendered output.

**Fix:** the visitor now synthesises a space ONLY when the previous `TextElement` carried a non-empty `line_break` (i.e. the parser actually split them across a source line). Source whitespace is preserved exactly; line-broken paragraphs continue to work.

### Bug 15B — Multi-line marks inside curly quotes

The unconstrained mark rules (`__`, `**`, ` `` ``) used `match('[^_\n]')` etc., excluding newlines. A mark that wrapped across a line break inside a curly quote was never matched — the markers leaked through as raw text and no mark was applied.

**Fix:** relax the content match in each unconstrained rule to `match('[^_]')` (and analogous for the other two). Unconstrained marks now span newlines, matching Asciidoctor's behaviour. The real-world Stevie Awards example now renders correctly:

  `` "`__Setting\nstandards for standardization__`" `` → `<em>Setting\nstandards for standardization</em>`

Constrained marks (single `*`/`_`/`` ` ``) remain single-line per the Asciidoctor spec — only unconstrained marks span lines.

### Known edge case (not fixed in this pass)

`"``text``"` (unconstrained code in curly quotes) is a corner case where the typographic open pattern (`` "` ``) eats one of the two backticks, leaving the unconstrained code pattern unable to match. Real-world impact is small since the more common patterns (`__…__` and `**…**`) are now fully working.

## Test plan

- [x] `typographic_quotes_spec.rb` extended with 7 new cases:
  - Whitespace preservation (Bug 15A regression guards)
  - Multi-line italic / bold inside curly quotes
  - No raw `__` / `**` markers leak in multi-line output
- [x] `inline_transform_visitor_spec.rb` updated to exercise the line-break synthesis case (previous test relied on always-synthesise behaviour, no longer correct)
- [x] coradoc-adoc: 1197 examples, 0 failures (5 pending)
- [x] coradoc core: 1150 examples, 0 failures
- [x] coradoc-html: 616 examples, 0 failures
- [x] coradoc-markdown: 792 examples, 0 failures (1 pending)
- [x] coradoc-mirror: 252 examples, 0 failures
- [ ] coradoc-docx: 10 pre-existing failures (unrelated — confirmed failing on main)
