### PR TITLE
fix(adoc,mirror): parse nested inline marks (Bug 16B)

### DIFF
--- a/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/inline_transformer.rb
+++ b/coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/inline_transformer.rb
@@ -8,10 +8,49 @@ module Coradoc
           class << self
             def transform_inline(inline, format_type)
               klass = Coradoc::CoreModel::InlineElement.format_type_class(format_type)
-              klass.new(
-                content: ToCoreModel.extract_text_content(inline.content),
-                source_line: inline.source_line
-              )
+              raw_content = ToCoreModel.extract_text_content(inline.content)
+
+              # Recursively parse the mark's content to recognise nested
+              # inline marks (Bug 16B). For `**Per-repo \`file.yml\`**`,
+              # the outer Bold's content "Per-repo `file.yml`" is fed
+              # back through the inline parser so the inner constrained
+              # monospace is recognised. The parsed children are stored
+              # on the BoldElement; the Mirror handler walks them to
+              # produce ProseMirror's flat text-node-with-marks shape.
+              children = parse_nested_inline_children(raw_content)
+
+              if children.any?
+                klass.new(
+                  content: raw_content,
+                  children: children,
+                  source_line: inline.source_line
+                )
+              else
+                klass.new(
+                  content: raw_content,
+                  source_line: inline.source_line
+                )
+              end
+            end
+
+            # Re-parse a mark's raw content string through the inline
+            # parser. Returns the list of CoreModel children when the
+            # content contains nested inline marks; returns [] when
+            # the content is plain text (no nested marks to preserve).
+            # The empty return is the recursion terminator — once a
+            # mark's content has no further mark characters, the
+            # parser produces only TextContent nodes, which we drop
+            # in favour of the mark's flat content string.
+            def parse_nested_inline_children(text)
+              return [] if text.nil? || text.to_s.empty?
+
+              parsed = ToCoreModel.parse_and_transform_inline(text.to_s)
+              return [] unless parsed.is_a?(Array)
+
+              has_marks = parsed.any? do |child|
+                child.is_a?(Coradoc::CoreModel::InlineElement)
+              end
+              has_marks ? parsed : []
             end
 
             def transform_inline_text(inline, format_type)

--- a/coradoc-adoc/spec/coradoc/asciidoc/parser/nested_inline_marks_spec.rb
+++ b/coradoc-adoc/spec/coradoc/asciidoc/parser/nested_inline_marks_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'coradoc/asciidoc'
+
+# Inline marks nested inside other marks (e.g. `**bold \`code\`**`)
+# must be recognised. Before this fix, the outer mark's content was
+# captured as a flat string and the inner mark's delimiter characters
+# leaked as raw text in the output.
+#
+# Coverage below locks in:
+#   * Bold wrapping constrained code.
+#   * Italic wrapping constrained code.
+#   * Bold with text + code + text (multiple children).
+#   * Plain bold / italic (no nesting) still produce single mark.
+#   * The proper long-form `` "` ``text`` `" `` for code in curly
+#     quotes works (curly + monospace + curly).
+RSpec.describe 'Nested inline marks', :asciidoc do
+  def first_paragraph(adoc)
+    Coradoc.parse(adoc, format: :asciidoc).children.first
+  end
+
+  describe 'bold wrapping constrained code' do
+    let(:adoc) { '**Per-repo `file.yml`**' }
+    let(:para) { first_paragraph(adoc) }
+
+    it 'produces a BoldElement' do
+      expect(para.children.first).to be_a(Coradoc::CoreModel::BoldElement)
+    end
+
+    it 'BoldElement has parsed children' do
+      bold = para.children.first
+      expect(bold.children.length).to eq(2)
+    end
+
+    it 'first child is TextContent for "Per-repo "' do
+      bold = para.children.first
+      expect(bold.children[0]).to be_a(Coradoc::CoreModel::TextContent)
+      expect(bold.children[0].text).to eq('Per-repo ')
+    end
+
+    it 'second child is MonospaceElement for "file.yml"' do
+      bold = para.children.first
+      expect(bold.children[1]).to be_a(Coradoc::CoreModel::MonospaceElement)
+      expect(bold.children[1].content).to eq('file.yml')
+    end
+  end
+
+  describe 'italic wrapping constrained code' do
+    let(:adoc) { '__Per-repo `file.yml`__' }
+    let(:para) { first_paragraph(adoc) }
+
+    it 'produces an ItalicElement with children' do
+      italic = para.children.first
+      expect(italic).to be_a(Coradoc::CoreModel::ItalicElement)
+      expect(italic.children.length).to eq(2)
+    end
+
+    it 'inner child is MonospaceElement' do
+      italic = para.children.first
+      expect(italic.children[1]).to be_a(Coradoc::CoreModel::MonospaceElement)
+    end
+  end
+
+  describe 'bold with text + code + text' do
+    let(:adoc) { '**a `b` c**' }
+    let(:para) { first_paragraph(adoc) }
+
+    it 'produces a BoldElement with three children' do
+      bold = para.children.first
+      expect(bold).to be_a(Coradoc::CoreModel::BoldElement)
+      expect(bold.children.length).to eq(3)
+    end
+
+    it 'has TextContent → MonospaceElement → TextContent' do
+      bold = para.children.first
+      expect(bold.children[0]).to be_a(Coradoc::CoreModel::TextContent)
+      expect(bold.children[1]).to be_a(Coradoc::CoreModel::MonospaceElement)
+      expect(bold.children[2]).to be_a(Coradoc::CoreModel::TextContent)
+    end
+  end
+
+  describe 'plain marks (no nesting)' do
+    it 'plain bold produces a BoldElement with flat content' do
+      bold = first_paragraph('**just bold**').children.first
+      expect(bold).to be_a(Coradoc::CoreModel::BoldElement)
+      expect(bold.content).to eq('just bold')
+    end
+
+    it 'plain italic produces an ItalicElement with flat content' do
+      italic = first_paragraph('__just italic__').children.first
+      expect(italic).to be_a(Coradoc::CoreModel::ItalicElement)
+      expect(italic.content).to eq('just italic')
+    end
+  end
+
+  describe 'code inside curly quotes (proper long form)' do
+    let(:adoc) { '"` ``text`` `"' }
+    let(:para) { first_paragraph(adoc) }
+
+    it 'emits a curly open quote' do
+      texts = para.children.map do |c|
+        c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : nil
+      end
+      expect(texts).to include('“')
+    end
+
+    it 'contains a MonospaceElement for "text"', :aggregate_failures do
+      mono = para.children.find { |c| c.is_a?(Coradoc::CoreModel::MonospaceElement) }
+      expect(mono).not_to be_nil
+      expect(mono.content).to eq('text')
+    end
+
+    it 'emits a curly close quote' do
+      texts = para.children.map do |c|
+        c.is_a?(Coradoc::CoreModel::TextContent) ? c.text : nil
+      end
+      expect(texts).to include('”')
+    end
+  end
+end

--- a/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
+++ b/coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb
@@ -123,10 +123,54 @@ module Coradoc
           end
 
           def build_simple_mark(element, context, mark_class)
+            # When the mark carries parsed children (Bug 16B — nested
+            # inline marks like `**bold \`code\`**`), walk the children
+            # and apply this mark to each text leaf. Inner mark elements
+            # get the outer mark added to their marks list, producing
+            # ProseMirror's flat text-node-with-marks shape.
+            if element.children&.any?
+              return flatten_marked_children(element.children, [mark_class.new], context)
+            end
+
             text = extract_inline_text(element)
             return nil if text.empty?
 
             context.text_node(text, marks: [mark_class.new])
+          end
+
+          # Walk a list of children, attaching the active set of marks
+          # to each text leaf. When a child is itself an InlineElement
+          # with its own mark (e.g. CodeElement inside BoldElement),
+          # the inner mark is added to the active set and recursion
+          # proceeds into its children. Produces the conjunction of
+          # marks for each text run that ProseMirror expects:
+          #   **a `b` c** → text("a ", [bold]), text("b", [bold, code]), text(" c", [bold])
+          def flatten_marked_children(children, active_marks, context)
+            result = []
+            children.each do |child|
+              case child
+              when CoreModel::TextContent
+                next if child.text.nil? || child.text.empty?
+
+                result << context.text_node(child.text, marks: active_marks.dup)
+              when CoreModel::InlineElement
+                inner_mark_class = SIMPLE_MARK_TYPES[child.class]
+                if inner_mark_class && child.children&.any?
+                  combined = active_marks + [inner_mark_class.new]
+                  result.concat(flatten_marked_children(child.children, combined, context))
+                elsif inner_mark_class
+                  text = extract_inline_text(child)
+                  next if text.empty?
+
+                  combined = active_marks + [inner_mark_class.new]
+                  result << context.text_node(text, marks: combined)
+                else
+                  nested = dispatch_inline(child, context)
+                  result << nested if nested
+                end
+              end
+            end
+            result
           end
 
           def build_link_mark(element, context)


### PR DESCRIPTION
## Summary

Inline marks nested inside other marks (e.g. `**bold \`code\`**`) were not recognised — the outer mark's content was captured as a flat string and the inner mark's delimiter characters leaked as raw text.

### Root cause

The AsciiDoc parser's mark rules capture their content as a flat Parslet `:text` slice. The transformer wraps this string in a Bold/Italic/Monospace model without re-parsing for nested marks.

### Fix

Two coordinated changes:

**AsciiDoc transformer** (`coradoc-adoc/lib/coradoc/asciidoc/transform/element_transformers/inline_transformer.rb`): `InlineTransformer.transform_inline` now recursively re-parses the mark's content through the inline parser. When the content contains nested inline marks, the parsed children are stored on the CoreModel InlineElement alongside the flat content string. The recursion terminates when the content has no further mark characters.

**Mirror handler** (`coradoc-mirror/lib/coradoc/mirror/handlers/inline.rb`): `build_simple_mark` now checks whether the element has parsed children. When it does, the new `flatten_marked_children` helper walks the children recursively, accumulating the active set of marks. Each text leaf emits a ProseMirror text node carrying the conjunction of all ancestor marks:

```
**a `b` c** → text("a ", [bold])
              text("b", [bold, code])
              text(" c", [bold])
```

### Bug 16A status

Bug 16A (curly-quote boundary characters silently dropped) was verified as NOT broken on main — the Unicode characters (U+201C/U+201D/U+2018/U+2019) ARE correctly emitted by the typographic_quote transformer. The bug report's claim was incorrect.

### Bug 15 edge case (code in curly quotes)

The short form `"``text```"` is genuinely ambiguous. The proper long-form `"\` \`\`text\`\` \`"` IS fully supported and produces the expected `curly + monospace + curly` output.

## Test plan

- [x] New `nested_inline_marks_spec.rb` — 13 examples
- [x] coradoc-adoc: 1202 examples, 0 failures (5 pending)
- [x] coradoc core: 1150 examples, 0 failures
- [x] coradoc-html: 616 examples, 0 failures
- [x] coradoc-markdown: 792 examples, 0 failures (1 pending)
- [x] coradoc-mirror: 252 examples, 0 failures
- [ ] coradoc-docx: 10 pre-existing failures (unrelated)
